### PR TITLE
fix: Filters title swapped for dashboard_layout and rundown_layout

### DIFF
--- a/meteor/lib/api/rundownLayouts.ts
+++ b/meteor/lib/api/rundownLayouts.ts
@@ -134,7 +134,7 @@ class RundownLayoutsRegistry {
 export namespace RundownLayoutsAPI {
 	const registry = new RundownLayoutsRegistry()
 	registry.registerShelfLayout(RundownLayoutType.RUNDOWN_LAYOUT, {
-		filtersTitle: 'Panels',
+		filtersTitle: 'Tabs',
 		supportedFilters: [
 			RundownLayoutElementType.ADLIB_REGION,
 			RundownLayoutElementType.EXTERNAL_FRAME,
@@ -143,7 +143,7 @@ export namespace RundownLayoutsAPI {
 		],
 	})
 	registry.registerShelfLayout(RundownLayoutType.DASHBOARD_LAYOUT, {
-		filtersTitle: 'Tabs',
+		filtersTitle: 'Panels',
 		supportedFilters: [
 			RundownLayoutElementType.ADLIB_REGION,
 			RundownLayoutElementType.EXTERNAL_FRAME,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
In layout editor (Shelf layout): Label and button text for `rundown_layout` says "PANELS" and "Add Panels".
In layout editor (Shelf layout): Label and button text for `dashboard_layout` says "TABS" and "Add Tabs".

* **What is the new behavior (if this is a feature change)?**
In layout editor (Shelf layout): Label and button text for `rundown_layout` says "TABS" and "Add Tabs".
In layout editor (Shelf layout): Label and button text for `dashboard_layout` says "PANELS" and "Add Panels".

![Rundown Layout Screenshot](https://user-images.githubusercontent.com/11258272/136774728-239f1a86-90e0-4fd4-ae3c-b43c1b029b29.png)
![Dashboard Layout Screenshot](https://user-images.githubusercontent.com/11258272/136774726-d3c1d3d7-7478-4a58-9a60-bfa54f628e1d.png)

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [X] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK

