### PR TITLE
feat: mos rundown metadata updates should trigger a light regeneratio…

### DIFF
--- a/meteor/server/api/ingest/ingestCache.ts
+++ b/meteor/server/api/ingest/ingestCache.ts
@@ -19,6 +19,7 @@ import { saveIntoCache } from '../../cache/lib'
 import { profiler } from '../profiler'
 import { getSegmentId, getPartId } from './lib'
 import { Changes } from '../../lib/database'
+import { SetOptional } from 'type-fest'
 
 interface LocalIngestBase {
 	modified: number
@@ -33,10 +34,10 @@ export interface LocalIngestPart extends IngestPart, LocalIngestBase {}
 export function isLocalIngestRundown(o: IngestRundown | LocalIngestRundown): o is LocalIngestRundown {
 	return !!o['modified']
 }
-export function makeNewIngestRundown(ingestRundown: IngestRundown): LocalIngestRundown {
+export function makeNewIngestRundown(ingestRundown: SetOptional<IngestRundown, 'segments'>): LocalIngestRundown {
 	return {
 		...ingestRundown,
-		segments: _.map(ingestRundown.segments, makeNewIngestSegment),
+		segments: ingestRundown.segments ? _.map(ingestRundown.segments, makeNewIngestSegment) : [],
 		modified: getCurrentTime(),
 	}
 }

--- a/meteor/server/api/ingest/mosDevice/ingest.ts
+++ b/meteor/server/api/ingest/mosDevice/ingest.ts
@@ -12,7 +12,7 @@ import {
 } from './lib'
 import { literal, protectString, getCurrentTime, normalizeArray } from '../../../../lib/lib'
 import { IngestPart } from '@sofie-automation/blueprints-integration'
-import { handleUpdatedRundownInner } from '../rundownInput'
+import { handleUpdatedRundownInner, handleUpdatedRundownMetaDataInner } from '../rundownInput'
 import { LocalIngestRundown, LocalIngestSegment, LocalIngestPart } from '../ingestCache'
 import { RundownId } from '../../../../lib/collections/Rundowns'
 import { logger } from '../../../../lib/logging'
@@ -194,7 +194,48 @@ export async function handleMosRundownMetadata(
 		async (cache, ingestRundown) => {
 			if (!ingestRundown) throw new Meteor.Error(`handleMosRundownMetadata lost the IngestRundown...`)
 
-			return handleUpdatedRundownInner(cache, ingestRundown, false, peripheralDevice)
+			return handleUpdatedRundownMetaDataInner(cache, ingestRundown, peripheralDevice)
+		}
+	)
+}
+
+export async function handleMosReadyToAir(
+	peripheralDevice: PeripheralDevice,
+	action: MOS.IMOSROReadyToAir
+): Promise<void> {
+	const studio = getStudioFromDevice(peripheralDevice)
+
+	const rundownExternalId = parseMosString(action.ID)
+
+	return runIngestOperationWithCache(
+		'handleMosRundownMetadata',
+		studio._id,
+		rundownExternalId,
+		(ingestRundown) => {
+			if (ingestRundown) {
+				// No changes
+				return ingestRundown
+			} else {
+				throw new Meteor.Error(404, `Rundown "${rundownExternalId}" not found`)
+			}
+		},
+		async (cache, ingestRundown) => {
+			if (!ingestRundown) throw new Meteor.Error(`handleMosReadyToAir lost the IngestRundown...`)
+			if (!cache.Rundown.doc) throw new Meteor.Error(`handleMosReadyToAir expects an existing Rundown...`)
+
+			if (!canRundownBeUpdated(cache.Rundown.doc, false)) return null
+
+			// Set the ready to air status of a Rundown
+			if (cache.Rundown.doc.airStatus !== action.Status) {
+				cache.Rundown.update((doc) => {
+					doc.airStatus = action.Status
+					return doc
+				})
+
+				return handleUpdatedRundownMetaDataInner(cache, ingestRundown, peripheralDevice)
+			} else {
+				return null
+			}
 		}
 	)
 }

--- a/meteor/server/api/ingest/rundownInput.ts
+++ b/meteor/server/api/ingest/rundownInput.ts
@@ -430,10 +430,10 @@ export async function handleUpdatedRundownMetaData(
 		rundownExternalId,
 		(ingestRundown) => {
 			if (ingestRundown) {
-				return makeNewIngestRundown({
-					...newIngestRundown,
+				return {
+					...makeNewIngestRundown(newIngestRundown),
 					segments: ingestRundown.segments,
-				})
+				}
 			} else {
 				throw new Meteor.Error(404, `Rundown "${rundownExternalId}" not found`)
 			}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature. continuation of #591

* **What is the current behavior?** (You can also link to an open issue here)

When receiving a `mosRoMetadata` or `mosRoReadyToAir` we would regenerate every segment in the rundown, even though it is very unlikely that the mos operations will have caused anything in the segments to have changed.

* **What is the new behavior (if this is a feature change)?**

Using the metadata update flow implemented for the non-mos ingest api, the blueprints `getRundown` is called. The properties which are available to `getSegment` are then checked for changes, and only if they changed are the calls to `getSegment` made.

In the case of simple/common operations, this should greatly reduce the amount of work sofie does when properties are changed in enps. Properties such as changing the start time or duration of the rundown will not cause a full regeneration (unless the start date is changed, but that is caused by the nrk blueprints storing that in the metaData)

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
