### PR TITLE
feat(Action Triggers): Select AdLib Action Trigger Modes

### DIFF
--- a/meteor/client/ui/Settings/components/triggeredActions/actionEditors/actionSelector/ActionSelector.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/actionEditors/actionSelector/ActionSelector.tsx
@@ -9,6 +9,7 @@ import classNames from 'classnames'
 import { EditAttribute } from '../../../../../../lib/EditAttribute'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faAngleRight, faTrash } from '@fortawesome/free-solid-svg-icons'
+import { AdLibActionEditor } from './actionEditors/AdLibActionEditor'
 
 interface IProps {
 	action: SomeAction
@@ -32,6 +33,9 @@ function getArguments(t: TFunction, action: SomeAction): string[] {
 			}
 			break
 		case PlayoutActions.adlib:
+			if (action.arguments) {
+				result.push(t('Mode: {{triggerMode}}', { triggerMode: action.arguments.triggerMode }))
+			}
 			break
 		case PlayoutActions.createSnapshotForDebug:
 			break
@@ -100,7 +104,7 @@ function hasArguments(action: SomeAction): boolean {
 		case PlayoutActions.activateRundownPlaylist:
 			return action.force || action.rehearsal
 		case PlayoutActions.adlib:
-			return false
+			return !!action.arguments
 		case PlayoutActions.createSnapshotForDebug:
 			return false
 		case PlayoutActions.deactivateRundownPlaylist:
@@ -229,7 +233,7 @@ function getActionParametersEditor(
 				</div>
 			)
 		case PlayoutActions.adlib:
-			return null
+			return <AdLibActionEditor action={action} onChange={onChange} />
 		case PlayoutActions.createSnapshotForDebug:
 			return null
 		case PlayoutActions.deactivateRundownPlaylist:

--- a/meteor/client/ui/Settings/components/triggeredActions/actionEditors/actionSelector/actionEditors/AdLibActionEditor.tsx
+++ b/meteor/client/ui/Settings/components/triggeredActions/actionEditors/actionSelector/actionEditors/AdLibActionEditor.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react'
+import _ from 'underscore'
+import { useTranslation } from 'react-i18next'
+import { PlayoutActions, SomeAction } from '@sofie-automation/blueprints-integration'
+import { EditAttribute } from '../../../../../../../lib/EditAttribute'
+import { useTracker } from '../../../../../../../lib/ReactMeteorData/ReactMeteorData'
+import { RundownBaselineAdLibActions } from '../../../../../../../../lib/collections/RundownBaselineAdLibActions'
+import { AdLibActions } from '../../../../../../../../lib/collections/AdLibActions'
+
+export function AdLibActionEditor({
+	action,
+	onChange,
+}: {
+	action: SomeAction
+	onChange: (newVal: Partial<typeof action>) => void
+}) {
+	const { t } = useTranslation()
+	const allTriggerModes = useTracker(
+		() => {
+			return _.chain([
+				...RundownBaselineAdLibActions.find().map((action) =>
+					action.triggerModes?.map((triggerMode) => triggerMode.data)
+				),
+				...AdLibActions.find().map((action) => action.triggerModes?.map((triggerMode) => triggerMode.data)),
+			])
+				.flatten()
+				.compact()
+				.uniq()
+				.value() as string[]
+		},
+		[],
+		[]
+	)
+
+	// this Editor only renders for AdLib
+	if (action.action !== PlayoutActions.adlib) return null
+
+	return (
+		<>
+			<div className="mts">
+				<EditAttribute
+					className="form-control"
+					modifiedClassName="bghl"
+					type={'toggle'}
+					label={t('Use Trigger Mode')}
+					overrideDisplayValue={!!action.arguments}
+					attribute={''}
+					updateFunction={(_e, newVal) => {
+						onChange({
+							...action,
+							arguments: newVal ? { triggerMode: '' } : null,
+						})
+					}}
+				/>
+			</div>
+			{action.arguments && (
+				<>
+					<div className="mts">
+						<label className="block">{t('Trigger Mode')}</label>
+						<EditAttribute
+							className="form-control input text-input input-m"
+							type="dropdowntext"
+							options={allTriggerModes}
+							overrideDisplayValue={action.arguments.triggerMode}
+							attribute={''}
+							updateFunction={(_e, newVal) => {
+								onChange({
+									...action,
+									arguments: {
+										...action.arguments,
+										triggerMode: newVal,
+									},
+								})
+							}}
+						/>
+					</div>
+				</>
+			)}
+		</>
+	)
+}

--- a/meteor/lib/api/triggers/actionFactory.ts
+++ b/meteor/lib/api/triggers/actionFactory.ts
@@ -1,5 +1,6 @@
 import {
 	ClientActions,
+	IAdlibPlayoutActionArguments,
 	IBaseFilterLink,
 	IGUIContextFilterLink,
 	IRundownPlaylistFilterLink,
@@ -193,7 +194,11 @@ function createRundownPlaylistContext(
  * @param {ShowStyleBase} showStyleBase
  * @return {*}  {ExecutableAdLibAction}
  */
-function createAdLibAction(filterChain: AdLibFilterChainLink[], showStyleBase: ShowStyleBase): ExecutableAdLibAction {
+function createAdLibAction(
+	filterChain: AdLibFilterChainLink[],
+	showStyleBase: ShowStyleBase,
+	actionArguments: IAdlibPlayoutActionArguments | undefined
+): ExecutableAdLibAction {
 	const compiledAdLibFilter = compileAdLibFilter(filterChain, showStyleBase)
 
 	return {
@@ -261,7 +266,7 @@ function createAdLibAction(filterChain: AdLibFilterChainLink[], showStyleBase: S
 								wrappedAdLib._id,
 								wrappedAdLib.item.actionId,
 								wrappedAdLib.item.userData,
-								undefined
+								(actionArguments && actionArguments.triggerMode) || undefined
 							)
 						)
 						break
@@ -274,7 +279,7 @@ function createAdLibAction(filterChain: AdLibFilterChainLink[], showStyleBase: S
 								wrappedAdLib._id,
 								wrappedAdLib.item.actionId,
 								wrappedAdLib.item.userData,
-								undefined
+								(actionArguments && actionArguments.triggerMode) || undefined
 							)
 						)
 						break
@@ -455,7 +460,7 @@ export function createAction(action: SomeAction, showStyleBase: ShowStyleBase): 
 		case ClientActions.rewindSegments:
 			return createRewindSegmentsAction(action.filterChain)
 		case PlayoutActions.adlib:
-			return createAdLibAction(action.filterChain, showStyleBase)
+			return createAdLibAction(action.filterChain, showStyleBase, action.arguments || undefined)
 		case PlayoutActions.activateRundownPlaylist:
 			if (action.force) {
 				return createUserActionWithCtx(

--- a/meteor/lib/api/triggers/actionFilterChainCompilers.ts
+++ b/meteor/lib/api/triggers/actionFilterChainCompilers.ts
@@ -35,6 +35,9 @@ type CompiledFilter<T> = {
 	global: boolean | undefined
 	segment: 'current' | 'next' | undefined
 	part: 'current' | 'next' | undefined
+	arguments?: {
+		triggerMode: string
+	}
 	/**
 	 * The query compiler has determined that this filter will always return an empty set,
 	 * it's safe to skip it entirely.

--- a/packages/blueprints-integration/src/triggers.ts
+++ b/packages/blueprints-integration/src/triggers.ts
@@ -156,9 +156,14 @@ export type IAdLibFilterLink =
 			value: 'adLib' | 'adLibAction' | 'clear' | 'sticky'
 	  }
 
+export interface IAdlibPlayoutActionArguments {
+	triggerMode: string
+}
+
 export interface IAdlibPlayoutAction extends ITriggeredActionBase {
 	action: PlayoutActions.adlib
 	filterChain: (IRundownPlaylistFilterLink | IGUIContextFilterLink | IAdLibFilterLink)[]
+	arguments?: IAdlibPlayoutActionArguments | null
 }
 
 export interface IRundownPlaylistActivateAction extends ITriggeredActionBase {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

It is not possible to use discreet AdLib Actions trigger modes through Action Triggers.

* **What is the new behavior (if this is a feature change)?**

The option to specify an AdLib Action Trigger Mode is now available in the "Ad-Lib" Action in Action Triggers. The dropdown for selecting/providing the mode to be used is a text field with autocomplete based on the existing content, similarly to how the Tags filter works.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
