### PR TITLE
fix: Prevents "stuck" joycon when going from single to paired or vice…

### DIFF
--- a/meteor/client/ui/Prompter/controller/joycon-device.ts
+++ b/meteor/client/ui/Prompter/controller/joycon-device.ts
@@ -24,6 +24,7 @@ export class JoyConController extends ControllerAbstract {
 	private reverseSpeedSpline: Spline
 
 	private updateSpeedHandle: number | null = null
+	private timestampOfLastUsedJoyconInput: number = 0
 	private currentPosition = 0
 	private lastInputValue = ''
 	private lastButtonInputs: { [index: number]: { mode: JoyconMode; buttons: number[] } } = {}
@@ -225,11 +226,10 @@ export class JoyConController extends ControllerAbstract {
 
 	private getActiveInputsOfJoycons(joycons: JoyconWithData[]): number {
 		let lastSeenSpeed = 0
-		let lastSeenSpeedTimestamp = 0
 
 		for (const joycon of joycons) {
 			// sort/filter by gamepad timestamp to use the most up-to-date input, in order to prevent the "stuck" dead joycon when going from pairs to singles
-			if (joycon.timestamp > lastSeenSpeedTimestamp) {
+			if (joycon.timestamp >= this.timestampOfLastUsedJoyconInput) {
 				// handle buttons at the same time as evaluating stick input
 				this.handleButtons(joycon)
 
@@ -243,7 +243,7 @@ export class JoyConController extends ControllerAbstract {
 							lastSeenSpeed = joycon.axes[0] * 1.4 // in this mode, R is "positive"
 							// factor increased by 1.4 to account for the R joystick being less sensitive than L
 						}
-						lastSeenSpeedTimestamp = joycon.timestamp
+						this.timestampOfLastUsedJoyconInput = joycon.timestamp
 					}
 				} else if (joycon.mode === 'LR') {
 					// L + R mode
@@ -254,7 +254,7 @@ export class JoyConController extends ControllerAbstract {
 						lastSeenSpeed = joycon.axes[3] * -1.4 // in this mode, we are "negative" on both sticks....
 						// factor increased by 1.4 to account for the R joystick being less sensitive than L
 					}
-					lastSeenSpeedTimestamp = joycon.timestamp
+					this.timestampOfLastUsedJoyconInput = joycon.timestamp
 				}
 			}
 		}


### PR DESCRIPTION
… versa AND have active joystick input when doing so.

Known bug on MacOS where a "stuck" active joystick won't recover before re-pairing (going to L+R-mode) again.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix: Solves an edge case where a joycon can get "stuck" and continue to scroll when going from a L+R pair to a single controller, without any way of stopping it. It is not stop-able.


* **What is the current behavior?** (You can also link to an open issue here)
When having a "stuck" joycon input, nothing can be done to stop it before a L+R pair is connected again.


* **What is the new behavior (if this is a feature change)?**
When having a "stuck" controller, any movement/input on any other joycon unit will take over the control


* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
