### PR TITLE
fix: "waitForPromise can't be used client-side" is periodically printed in the Browser Console

### DIFF
--- a/meteor/lib/lib.ts
+++ b/meteor/lib/lib.ts
@@ -199,7 +199,13 @@ export function lazyIgnore(name: string, f1: () => Promise<void> | void, t: numb
 	}
 	lazyIgnoreCache[name] = Meteor.setTimeout(() => {
 		delete lazyIgnoreCache[name]
-		waitForPromise(f1())
+		if (Meteor.isClient) {
+			f1()?.catch((e) => {
+				throw new Error(e)
+			})
+		} else {
+			waitForPromise(f1())
+		}
 	}, t)
 }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

A log line for an error "waitForPromise can't be used client-side" is logged on an interval.

* **What is the new behavior (if this is a feature change)?**

`waitForPromise` should not be run when running Client-side.

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [x] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
