### PR TITLE
fix: leaking `debounce-fn`s when queuing `EventsJobs.PartInstanceTimings` jobs SOFIE-2307

### DIFF
--- a/packages/job-worker/package.json
+++ b/packages/job-worker/package.json
@@ -45,7 +45,6 @@
 		"@sofie-automation/corelib": "link:../corelib",
 		"@sofie-automation/shared-lib": "link:../shared-lib",
 		"amqplib": "^0.10.3",
-		"debounce-fn": "^4.0.0",
 		"deepmerge": "^4.2.2",
 		"elastic-apm-node": "^3.38.0",
 		"eventemitter3": "^4.0.7",

--- a/packages/job-worker/src/blueprints/events.ts
+++ b/packages/job-worker/src/blueprints/events.ts
@@ -6,13 +6,12 @@ import { PieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceIns
 import { JobContext } from '../jobs'
 import { PartInstanceId, RundownPlaylistId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { logger } from '../logging'
-import * as debounceFn from 'debounce-fn'
 import { EventsJobs } from '@sofie-automation/corelib/dist/worker/events'
 import { stringifyError } from '@sofie-automation/corelib/dist/lib'
 
 const EVENT_WAIT_TIME = 500
 
-const partInstanceTimingDebounceFunctions = new Map<string, debounceFn.DebouncedFunction<[], void>>()
+const partInstanceTimingDebounceFunctions = new Map<string, NodeJS.Timer>()
 
 function handlePartInstanceTimingEvent(
 	context: JobContext,
@@ -24,32 +23,24 @@ function handlePartInstanceTimingEvent(
 	// wait EVENT_WAIT_TIME, because blueprint.onAsRunEvent() it is likely for there to be a bunch of started and stopped events coming in at the same time
 	// These blueprint methods are not time critical (meaning they do raw db operations), and can be easily delayed
 	const funcId = `${playlistId}_${partInstanceId}`
-	const cachedFunc = partInstanceTimingDebounceFunctions.get(funcId)
-	if (cachedFunc) {
-		cachedFunc()
-	} else {
-		const newFunc = debounceFn(
-			() => {
-				context
-					.queueEventJob(EventsJobs.PartInstanceTimings, {
-						playlistId,
-						partInstanceId,
-					})
-					.catch((e) => {
-						logger.error(
-							`Failed to queue job in handlePartInstanceTimingEvent "${funcId}": "${stringifyError(e)}"`
-						)
-					})
-			},
-			{
-				before: false,
-				after: true,
-				wait: EVENT_WAIT_TIME,
-			}
-		)
-		partInstanceTimingDebounceFunctions.set(funcId, newFunc)
-		newFunc()
-	}
+	const pendingTimer = partInstanceTimingDebounceFunctions.get(funcId)
+	if (pendingTimer) clearTimeout(pendingTimer)
+
+	// Future: using context inside a timer like this is not supposed to be done...
+	const newTimer = setTimeout(() => {
+		partInstanceTimingDebounceFunctions.delete(funcId)
+
+		context
+			.queueEventJob(EventsJobs.PartInstanceTimings, {
+				playlistId,
+				partInstanceId,
+			})
+			.catch((e) => {
+				logger.error(`Failed to queue job in handlePartInstanceTimingEvent "${funcId}": "${stringifyError(e)}"`)
+			})
+	}, EVENT_WAIT_TIME)
+
+	partInstanceTimingDebounceFunctions.set(funcId, newTimer)
 }
 
 export function reportPartInstanceHasStarted(

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -3092,7 +3092,7 @@
     webpack-sources "^3.2.2"
 
 "@sofie-automation/blueprints-integration@link:blueprints-integration":
-  version "1.47.0"
+  version "1.47.1-1"
   dependencies:
     "@sofie-automation/shared-lib" "link:shared-lib"
     timeline-state-resolver-types "7.5.0"
@@ -3120,7 +3120,7 @@
     shelljs "^0.8.5"
 
 "@sofie-automation/corelib@link:corelib":
-  version "1.47.0"
+  version "1.47.1-1"
   dependencies:
     "@sofie-automation/blueprints-integration" "link:blueprints-integration"
     "@sofie-automation/shared-lib" "link:shared-lib"
@@ -3136,7 +3136,7 @@
     underscore "^1.13.4"
 
 "@sofie-automation/shared-lib@link:shared-lib":
-  version "1.47.0"
+  version "1.47.1-1"
   dependencies:
     tslib "^2.4.0"
     type-fest "^2.19.0"
@@ -6026,13 +6026,6 @@ dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
-
-debounce-fn@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/debounce-fn/-/debounce-fn-4.0.0.tgz#ed76d206d8a50e60de0dd66d494d82835ffe61c7"
-  integrity sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==
-  dependencies:
-    mimic-fn "^3.0.0"
 
 debug@2.6.9, debug@^2.6.0:
   version "2.6.9"
@@ -10204,11 +10197,6 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
-
-mimic-fn@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.1.0.tgz#65755145bbf3e36954b949c16450427451d5ca74"
-  integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
 
 mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The studio-worker in Sofie is slowly leaking memory.

It looks to be the caching of these debounce-fns, one for every PartInstance taken, is leaking the `context` object for the job, which in turn is causing the `CacheForPlayout` for that job to be leaked.

By using a simpler method of for the debounce, where it can clean up after itself we can avoid this leak

* **Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [x] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
