### PR TITLE
fix: StudioId should be undefined

### DIFF
--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -144,7 +144,6 @@ export namespace ServerPeripheralDeviceAPI {
 				status: {
 					statusCode: StatusCode.UNKNOWN,
 				},
-				studioId: protectString(''),
 				settings: {},
 				connected: true,
 				connectionId: options.connectionId,


### PR DESCRIPTION
The PR has been opened by SuperFly.tv on behalf of EVS Broadcast Equipment.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

**What is the current behavior?** (You can also link to an open issue here)

When peripheral devices first connect they are assigned an empty string in the `studioId` property, this is inconsistent with the typings which allow `studioId` to be undefined and causes some trouble for users of the HTTP API.

**What is the new behavior (if this is a feature change)?**

`studioId` is `undefined` when the device first connects, until assigned to a studio.

**Other information**:

**Status**
<!--
Check the checkboxes below as the PR progresses.
The author is encouraged to do a functional test before submitting
-->
- [ ] Code documentation for the relevant parts in the code have been added/updated by the PR author
- [ ] The functionality has been tested by the PR author
- [ ] The functionality has been tested by NRK
