### PR TITLE
fix: nora hoverscrub not showing content on first load SOFIE-2819

### DIFF
--- a/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
+++ b/meteor/client/ui/FloatingInspectors/NoraFloatingInspector.tsx
@@ -187,16 +187,19 @@ export class NoraPreviewRenderer extends React.Component<{}, IStateHeader> {
 	}
 
 	private _onNoraMessage = (msg: MessageEvent): void => {
+		if (!this.state.noraContent) return
+
+		const rendererUrl = new URL(this.state.noraContent.previewRenderer)
+		if (rendererUrl.origin !== msg.origin) return
+
 		if (msg.source !== this.iframeElement?.contentWindow) return
 		if (msg.data.event === 'nora-render') {
-			console.log('nora-render', msg)
-
 			if (msg.data.data.loaded) {
 				// Nora has loaded, dispatch the initial content
 
 				// Future: this may want to be done via `onload` on the iframe in the future to allow for non-nora renderers to work
 
-				if (this.state.noraContent && this.iframeElement?.contentWindow) {
+				if (this.iframeElement?.contentWindow) {
 					this.postNoraEvent(this.iframeElement.contentWindow, this.state.noraContent)
 				}
 			}


### PR DESCRIPTION

## About the Contributor
This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a: Bug fix 

## Current Behavior
When hovering over a nora piece, the preview doesn't show once the renderer loads. It will load for the second piece you hover over.
This gets worse if there are multiple renderers used on the page, as it is the first piece each time the renderer url changes that doesnt display.


## Testing Instructions
<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->

A version has been made for r50, as some refactoring has been done which makes this merge non-trivial https://github.com/nrkno/sofie-core/commit/9338aca6429cce50a7c0e7aeec8763bb184a4590

## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
