### PR TITLE
Fix/pr segment live lime out of sync

### DIFF
--- a/packages/webui/src/client/lib/rundown.ts
+++ b/packages/webui/src/client/lib/rundown.ts
@@ -105,7 +105,8 @@ export namespace RundownUtils {
 		useSmartHours?: boolean,
 		minusPrefix?: string,
 		floorTime?: boolean,
-		hardFloor?: boolean
+		hardFloor?: boolean,
+		invertedSignIndicator?: boolean
 	): string {
 		let isNegative = milliseconds < 0
 		if (isNegative) {
@@ -175,6 +176,11 @@ export namespace RundownUtils {
 			if (hours === 0 && minutes === 0 && secondsRest === 0) {
 				isNegative = true
 			}
+		}
+
+		// Reverse the + indicator to show overtime:
+		if (invertedSignIndicator && !(hours === 0 && minutes === 0 && secondsRest === 0)) {
+			isNegative = !isNegative
 		}
 
 		return (

--- a/packages/webui/src/client/ui/RundownView/RundownTiming/CurrentPartRemaining.tsx
+++ b/packages/webui/src/client/ui/RundownView/RundownTiming/CurrentPartRemaining.tsx
@@ -38,11 +38,11 @@ export const CurrentPartRemaining = withTiming<IPartRemainingProps, {}>({
 				<span
 					className={ClassNames(
 						this.props.className,
-						Math.floor(displayTimecode / 1000) <= 0 ? this.props.heavyClassName : undefined
+						Math.floor(displayTimecode / 1000) < 0 ? this.props.heavyClassName : undefined
 					)}
 					role="timer"
 				>
-					{RundownUtils.formatDiffToTimecode(displayTimecode || 0, true, false, true, false, true, '+', false, true)}
+					{RundownUtils.formatDiffToTimecode(displayTimecode, true, false, true, false, true, '', false, true, true)}
 				</span>
 			)
 		}

--- a/packages/webui/src/client/ui/RundownView/RundownTiming/CurrentPartRemaining.tsx
+++ b/packages/webui/src/client/ui/RundownView/RundownTiming/CurrentPartRemaining.tsx
@@ -32,18 +32,17 @@ export const CurrentPartRemaining = withTiming<IPartRemainingProps, {}>({
 		render(): JSX.Element | null {
 			if (!this.props.timingDurations || !this.props.timingDurations.currentTime) return null
 			if (this.props.timingDurations.currentPartInstanceId !== this.props.currentPartInstanceId) return null
-			let displayTimecode = this.props.timingDurations.remainingTimeOnCurrentPart
+			const displayTimecode = this.props.timingDurations.remainingTimeOnCurrentPart
 			if (displayTimecode === undefined) return null
-			displayTimecode *= -1
 			return (
 				<span
 					className={ClassNames(
 						this.props.className,
-						Math.floor(displayTimecode / 1000) > 0 ? this.props.heavyClassName : undefined
+						Math.floor(displayTimecode / 1000) <= 0 ? this.props.heavyClassName : undefined
 					)}
 					role="timer"
 				>
-					{RundownUtils.formatDiffToTimecode(displayTimecode || 0, true, false, true, false, true, '', false, true)}
+					{RundownUtils.formatDiffToTimecode(displayTimecode || 0, true, false, true, false, true, '+', false, true)}
 				</span>
 			)
 		}

--- a/packages/webui/src/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
+++ b/packages/webui/src/client/ui/RundownView/RundownTiming/SegmentDuration.tsx
@@ -75,7 +75,7 @@ export const SegmentDuration = withTiming<ISegmentDurationProps, {}>()(function 
 					})}
 					role="timer"
 				>
-					{RundownUtils.formatDiffToTimecode(value, false, false, true, false, true, '+')}
+					{RundownUtils.formatDiffToTimecode(value, false, false, true, false, true, '+', false, true)}
 				</span>
 			</>
 		)


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This PR is made on behalf of BBC
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->


## Type of Contribution
This is a bug fix


## Current Behavior
Currently time is reverted using `displayTimecode *= -1` in `CurrentPartRemaining`
This gives a +1 second offset in countdown, so when starting a part it will show the same timecode for 2 seconds.

Reason: (example of the issue)
A part with onAirPartDuration = 8000ms
When take in to that part:
#### 1 sec: liveline will show the time based on the onAirPartDuration  (not the calculated)
* As this is exactly -8000ms the `*= -1` value becomes 8000ms which will display: "00:00:08 as expected. If it had used the calculated time it would have shown "00:00:09" as the calculated value is -8001ms at this time.

#### 2 sec: value is now the calculated value -7001 ms 
* As this is a little under -7 sec the `*= -1` value becomes 7001ms (a little over 7 sec) and that will display  "00:00:08"

## New Behavior
Instead of reverting the time, `invertedSignIndicator?: boolean` has been added as an option in `formatDiffToTimecode()`
and the reversion has been removed in `CurrentPartRemaining`



## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas
This could affect other visual/audio related places, but probably only the audio count down.
<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
