### PR TITLE
Fix: Account for Part when calculating piece times (SOFIE-3922)

### DIFF
--- a/packages/corelib/src/playout/processAndPrune.ts
+++ b/packages/corelib/src/playout/processAndPrune.ts
@@ -15,15 +15,7 @@ function getPieceStartTimeAsReference(newPieceStart: number | 'now'): number | R
 }
 
 function getPieceStartTimeWithinPart(p: ReadonlyDeep<PieceInstance>): 'now' | number {
-	// If the piece is dynamically inserted, then its preroll should be factored into its start time, but not for any infinite continuations
-	const isStartOfAdlib =
-		!!p.dynamicallyInserted && !(p.infinite?.fromPreviousPart || p.infinite?.fromPreviousPlayhead)
-
-	if (isStartOfAdlib && p.piece.enable.start !== 'now') {
-		return p.piece.enable.start + (p.piece.prerollDuration ?? 0)
-	} else {
-		return p.piece.enable.start
-	}
+	return p.piece.enable.start
 }
 
 function isClear(piece?: ReadonlyDeep<PieceInstance>): boolean {

--- a/packages/job-worker/src/playout/__tests__/timeline.test.ts
+++ b/packages/job-worker/src/playout/__tests__/timeline.test.ts
@@ -1285,8 +1285,9 @@ describe('Timeline', () => {
 					})
 
 					const pieceOffset = 12560
+
 					// Simulate the piece timing confirmation from playout-gateway
-					await doSimulatePiecePlaybackTimings(playlistId, pieceOffset, 2)
+					await doSimulatePiecePlaybackTimings(playlistId, pieceOffset, 2) // This pieceOffset includes the partPreroll
 
 					// Now we have a concrete time
 					await checkTimings({
@@ -1456,8 +1457,6 @@ describe('Timeline', () => {
 					// Simulate the piece timing confirmation from playout-gateway
 					await doSimulatePiecePlaybackTimings(playlistId, pieceOffset, 2)
 
-					const pieceOffsetWithPreroll = pieceOffset + 340
-
 					// Now we have a concrete time
 					await checkTimings({
 						previousPart: null,
@@ -1465,7 +1464,7 @@ describe('Timeline', () => {
 							piece000: {
 								controlObj: {
 									start: 500, // This one gave the preroll
-									end: pieceOffsetWithPreroll,
+									end: pieceOffset,
 								},
 								childGroup: {
 									preroll: 500,
@@ -1484,7 +1483,7 @@ describe('Timeline', () => {
 							[adlibbedPieceId]: {
 								// Our adlibbed piece
 								controlObj: {
-									start: pieceOffsetWithPreroll,
+									start: pieceOffset,
 								},
 								childGroup: {
 									preroll: 340,

--- a/packages/job-worker/src/playout/timeline/__tests__/pieceGroup.test.ts
+++ b/packages/job-worker/src/playout/timeline/__tests__/pieceGroup.test.ts
@@ -539,7 +539,7 @@ describe('Pieces', () => {
 				classes: [],
 				enable: {
 					...enable,
-					end: 400,
+					end: 600,
 				},
 			})
 		})

--- a/packages/job-worker/src/playout/timeline/multi-gateway.ts
+++ b/packages/job-worker/src/playout/timeline/multi-gateway.ts
@@ -225,6 +225,7 @@ function deNowifyCurrentPieces(
 	const objectsNotDeNowified: TimelineObjRundown[] = []
 	// The relative time for 'now' to be resolved to, inside of the part group
 	const nowInPart = targetNowTime - currentPartGroupStartTime
+	const nowInPartWithoutPreroll = nowInPart - (currentPartInstance.partInstance.partPlayoutTimings?.toPartDelay ?? 0)
 
 	// Ensure any pieces in the currentPartInstance have their now replaced
 	for (const pieceInstance of currentPartInstance.pieceInstances) {
@@ -232,7 +233,7 @@ function deNowifyCurrentPieces(
 			pieceInstance.updatePieceProps({
 				enable: {
 					...pieceInstance.pieceInstance.piece.enable,
-					start: nowInPart,
+					start: nowInPartWithoutPreroll,
 				},
 			})
 		}

--- a/packages/job-worker/src/playout/timeline/part.ts
+++ b/packages/job-worker/src/playout/timeline/part.ts
@@ -66,7 +66,7 @@ export function transformPartIntoTimeline(
 				nowInParentGroup,
 				pieceInstance,
 				pieceEnable,
-				0,
+				pieceInstance.dynamicallyInserted ? 0 : partTimings.toPartDelay,
 				pieceGroupFirstObjClasses,
 				isInHold,
 				false

--- a/packages/job-worker/src/playout/timeline/piece.ts
+++ b/packages/job-worker/src/playout/timeline/piece.ts
@@ -95,13 +95,8 @@ export function getPieceEnableInsidePart(
 ): TSR.Timeline.TimelineEnable {
 	const pieceEnable: TSR.Timeline.TimelineEnable = { ...pieceInstance.piece.enable }
 	if (typeof pieceEnable.start === 'number') {
-		if (pieceInstance.dynamicallyInserted) {
-			// timed adlibbed pieces needs to factor in their preroll
-			pieceEnable.start += pieceInstance.piece.prerollDuration || 0
-		} else {
-			// timed planned pieces should be offset based on the preroll of the part
-			pieceEnable.start += partTimings.toPartDelay
-		}
+		// pieces should be offset based on the preroll of the part
+		pieceEnable.start += partTimings.toPartDelay
 	}
 
 	// If the part has an end time, we can consider post-roll

--- a/packages/job-worker/src/playout/timeline/pieceGroup.ts
+++ b/packages/job-worker/src/playout/timeline/pieceGroup.ts
@@ -136,7 +136,7 @@ export function createPieceGroupAndCap(
 	let resolvedEndCap: number | string | undefined
 	// If the start has been adjusted, the end needs to be updated to compensate
 	if (typeof pieceInstance.resolvedEndCap === 'number') {
-		resolvedEndCap = pieceInstance.resolvedEndCap - (pieceStartOffset ?? 0)
+		resolvedEndCap = pieceInstance.resolvedEndCap + (pieceStartOffset ?? 0)
 	} else if (pieceInstance.resolvedEndCap) {
 		// TODO - there could already be a piece with a cap of 'now' that we could use as our end time
 		// As the cap is for 'now', rather than try to get tsr to understand `end: 'now'`, we can create a 'now' object to tranlate it


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the NRK

## Type of Contribution

This is a:
<!-- (pick one) -->
Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

We've seen an issue where Pieces that are planned to play back-to-back have a gap in between their timeline objects.

The issue only shows up when the Part has a prerollDuration set.


## New Behavior
<!--
What is the new behavior?
-->

Take Part preroll into account when stopping a Piece with another Piece.

Previously Piece control objects end caps caused Pieces to end prematurely.
This changes how start times of adlibbed Pieces gets stored, to keep everything in a pre-preroll-adjusted timespace.


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [x] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas & Testing

This PR affects the playout logic, so regression testing with focus on playout is warranted.

Set prerollDuration to something higher than usual to exaggerate any bad effects during tests.

## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
