### PR TITLE
fix: missing fetch for blueprints, and minor logging changes

### DIFF
--- a/meteor/server/api/ingest/mosDevice/mosIntegration.ts
+++ b/meteor/server/api/ingest/mosDevice/mosIntegration.ts
@@ -163,7 +163,7 @@ export namespace MosIntegration {
 
 		const rundownExternalId = parseMosString(Action.RunningOrderID)
 
-		logger.info(`mosRoStoryInsert after "${Action.StoryID}" Stories: ${Stories.map((s) => s.ID)}`)
+		logger.info(`mosRoStoryInsert before "${Action.StoryID}" Stories: ${Stories.map((s) => s.ID)}`)
 		logger.debug(Action, Stories)
 
 		await runIngestOperation(studioId, IngestJobs.MosInsertStory, {

--- a/packages/job-worker/src/blueprints/cache.ts
+++ b/packages/job-worker/src/blueprints/cache.ts
@@ -54,7 +54,12 @@ export async function parseBlueprintDocument(
 		let manifest: SomeBlueprintManifest
 		try {
 			const blueprintPath = `db:///blueprint/${blueprint.name || blueprint._id}-bundle.js`
-			const context = vm.createContext({}, {})
+			const context = vm.createContext(
+				{
+					fetch,
+				},
+				{}
+			)
 			const script = new vm.Script(
 				`__run_result = ${blueprint.code}
 __run_result || blueprint`,

--- a/packages/job-worker/src/playout/timeline/multi-gateway.ts
+++ b/packages/job-worker/src/playout/timeline/multi-gateway.ts
@@ -59,6 +59,12 @@ export function deNowifyMultiGatewayTimeline(
 
 	// Because updatePlannedTimingsForPieceInstances changes start times of infinites, we can now run deNowifyInfinites()
 	deNowifyInfinites(targetNowTime, objectsNotDeNowified, timelineObjsMap)
+
+	for (const obj of timelineObjs) {
+		if (!Array.isArray(obj.enable) && obj.enable.start === 'now') {
+			logger.error(`deNowifyMultiGatewayTimeline: "${obj.id}" still set to 'now'`)
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core//docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of NRK.

## Type of Contribution

This is a: Bug fix

## Current Behavior

In release51, `node-fetch` was exposed to blueprints. That was removed as builtin `fetch` was expected to be available, but it is blocked by the sandbox and has to be explicitly provided.

A line of logging in the mos handling is incorrect

Adds some logging to the timeline generation to make sure that any objects that failed to be de-nowified are logged as an error.


## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
