### PR TITLE
fix: In-Out words was placed and styled wrong

### DIFF
--- a/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUp.scss
+++ b/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUp.scss
@@ -174,24 +174,30 @@
 	}
 
 	.preview-popUp__in-out-words {
-		font-size: 0.8em;
 		letter-spacing: 0em;
 
 		width: 100%;
 		overflow: hidden;
-		text-overflow: ellipsis;
+		text-overflow: clip;
 		white-space: nowrap;
 
-		display: flex;
-		justify-content: space-between;
-
+		margin-top: -25px; //Pull up the in/out words a bit
 		padding: 7px;
+
+		.separation-line {
+			width: 100%;
+			height: 1px;
+			background-color: #5b5b5b;
+			margin-bottom: 5px;
+		}
 
 		.in-words,
 		.out-words {
+			color: white;
+			font-weight: 500;
 			white-space: nowrap;
 			overflow: hidden;
-			text-overflow: ellipsis;
+			text-overflow: clip;
 		}
 
 		.out-words {

--- a/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUpContent.tsx
+++ b/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUpContent.tsx
@@ -38,6 +38,7 @@ export function PreviewPopUpContent({ content, time }: PreviewPopUpContentProps)
 		case 'inOutWords':
 			return (
 				<div className="preview-popUp__in-out-words">
+					<hr className="separation-line" />
 					<div className="in-words">{content.in}</div>
 					<div className="out-words">{content.out}</div>
 				</div>

--- a/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUpContext.tsx
+++ b/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUpContext.tsx
@@ -98,6 +98,13 @@ export function convertSourceLayerItemToPreview(
 					}
 					break
 				case PreviewType.VT:
+					if (popupPreview.preview.outWords) {
+						contents.push({
+							type: 'inOutWords',
+							in: popupPreview.preview.inWords,
+							out: popupPreview.preview.outWords,
+						})
+					}
 					if (contentStatus?.previewUrl) {
 						contents.push({
 							type: 'video',
@@ -107,13 +114,6 @@ export function convertSourceLayerItemToPreview(
 						contents.push({
 							type: 'image',
 							src: contentStatus.thumbnailUrl,
-						})
-					}
-					if (popupPreview.preview.outWords) {
-						contents.push({
-							type: 'inOutWords',
-							in: popupPreview.preview.inWords,
-							out: popupPreview.preview.outWords,
 						})
 					}
 					break
@@ -139,6 +139,13 @@ export function convertSourceLayerItemToPreview(
 					type: 'title',
 					content: content.fileName,
 				},
+				content.lastWords
+					? {
+							type: 'inOutWords',
+							in: content.firstWords,
+							out: content.lastWords,
+						}
+					: undefined,
 				contentStatus?.previewUrl
 					? {
 							type: 'video',
@@ -150,13 +157,6 @@ export function convertSourceLayerItemToPreview(
 								src: contentStatus.thumbnailUrl,
 							}
 						: undefined,
-				content.lastWords
-					? {
-							type: 'inOutWords',
-							in: content.firstWords,
-							out: content.lastWords,
-						}
-					: undefined,
 				...(contentStatus?.messages?.map<PreviewContent>((m) => ({
 					type: 'warning',
 					content: m as any,
@@ -261,6 +261,7 @@ export function convertSourceLayerItemToPreview(
 				{
 					type: 'script',
 					script: content.fullScript,
+					firstWords: content.firstWords,
 					lastWords: content.lastWords,
 					comment: content.comment,
 					lastModified: content.lastModified ?? undefined,
@@ -301,6 +302,7 @@ export type PreviewContent =
 	| {
 			type: 'script'
 			script?: string
+			firstWords?: string
 			lastWords?: string
 			comment?: string
 			lastModified?: number


### PR DESCRIPTION
## About the Contributor
This PR is made on behalf of BBC

## Type of Contribution

This is a bug fix.

## Current Behavior
After implementation of the new hover previews, styling on the In-Out words in VT preview was missing.

## New Behavior
Styling on the VT hover previews

## Testing

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas
UI hover previews.

## Time Frame

## Status


- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
