### PR TITLE
Fix: Underscore on all links after conversion to Bootstrap

### DIFF
--- a/packages/webui/src/client/styles/main.scss
+++ b/packages/webui/src/client/styles/main.scss
@@ -125,6 +125,12 @@ body {
 	letter-spacing: 0.5px;
 }
 
+// By default an a-tag has underlined text - and Link components are rendered as a-tags
+// So the default behaviour set to none, and then we can override it in the components that need it:
+a {
+	text-decoration: none;
+}
+
 :fullscreen ::-webkit-scrollbar {
 	background: #252627;
 }


### PR DESCRIPTION

## About the Contributor
This is made on behalf of BBC

## Type of Contribution

This is a bug fix

## Current Behavior
After conversion to Bootstrap labels on all links are underlined

## New Behavior
The reason for this is that the React Link component uses the "a"-tag, and that has a default underline decorator.
A global text-decorator: none has been added for "a"-tags, as the default style.

## Testing
Have been checking links in Rundown view and in System status

### Affected areas
Links in the UI.


- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
