### PR TITLE
Fix: eventlisteners should clean up

### DIFF
--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -38,7 +38,7 @@
 		"@fortawesome/fontawesome-svg-core": "^6.7.2",
 		"@fortawesome/free-solid-svg-icons": "^6.7.2",
 		"@fortawesome/react-fontawesome": "^0.2.2",
-		"@jstarpl/react-contextmenu": "^2.15.0",
+		"@jstarpl/react-contextmenu": "^2.15.1",
 		"@nrk/core-icons": "^9.6.0",
 		"@popperjs/core": "^2.11.8",
 		"@sofie-automation/blueprints-integration": "1.53.0-in-development",

--- a/packages/webui/src/client/ui/SegmentTimeline/SegmentTimeline.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/SegmentTimeline.tsx
@@ -290,6 +290,9 @@ export class SegmentTimelineClass extends React.Component<Translated<WithTiming<
 	componentWillUnmount(): void {
 		super.componentWillUnmount?.()
 		clearTimeout(this.highlightTimeout)
+		if (this.segmentBlock) {
+			this.segmentBlock.removeEventListener('wheel', this.onTimelineWheel, { capture: true })
+		}
 
 		RundownViewEventBus.off(RundownViewEvents.HIGHLIGHT, this.onHighlight)
 		RundownViewEventBus.off(RundownViewEvents.SEGMENT_ZOOM_ON, this.onRundownEventSegmentZoomOn)


### PR DESCRIPTION

## About the Contributor
This PR is made on behalf of BBC

## Type of Contribution
This is a bug fix

## Current Behavior
Currently there's a memory leak in UI, because of detached nodes 

## New Behavior
Two places have been found where the was non removed eventlisteners.
1 - in SegmentTimeline (fix in code)
2 - in @jstarpl/react-contextmenu (fixed in module, in v.2.15.1)

## Testing
UI has been tested throughly, with Chrome inspector memory logging, running through 3 days.

### Affected areas
Memory Leak in UI

## Time Frame
This is an urgent bug for BBC

## Status

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
