### PR TITLE
fix!: docker images using CMD instead of ENTRYPOINT

### DIFF
--- a/meteor/Dockerfile
+++ b/meteor/Dockerfile
@@ -62,4 +62,4 @@ COPY meteor/docker-entrypoint.sh /opt
 WORKDIR /opt/core/
 RUN chown -R 1000:1000 /opt/core
 USER 1000
-CMD ["/opt/docker-entrypoint.sh"]
+ENTRYPOINT ["/opt/docker-entrypoint.sh"]

--- a/meteor/Dockerfile.circle
+++ b/meteor/Dockerfile.circle
@@ -8,4 +8,4 @@ COPY meteor/docker-entrypoint.sh /opt
 WORKDIR /opt/core
 RUN chown -R 1000:1000 /opt/core
 USER 1000
-CMD ["/opt/docker-entrypoint.sh"]
+ENTRYPOINT ["/opt/docker-entrypoint.sh"]

--- a/packages/.yarnrc.yml
+++ b/packages/.yarnrc.yml
@@ -1,1 +1,5 @@
+compressionLevel: mixed
+
+enableGlobalCache: false
+
 nodeLinker: node-modules

--- a/packages/documentation/docs/user-guide/installation/installing-sofie-server-core.md
+++ b/packages/documentation/docs/user-guide/installation/installing-sofie-server-core.md
@@ -75,7 +75,10 @@ services:
   spreadsheet-gateway:
     image: superflytv/sofie-spreadsheet-gateway:latest
     restart: always
-    command: yarn start -host core -port 3000 -id spreadsheetGateway0
+    environment:
+      DEVICE_ID: spreadsheetGateway0
+      CORE_HOST: core
+      CORE_PORT: '3000'
     networks:
       - sofie
     depends_on:
@@ -86,10 +89,13 @@ services:
     image: sofietv/tv-automation-mos-gateway:release51
     restart: always
     ports:
-      - "10540:10540" # MOS Lower port
-      - "10541:10541" # MOS Upper port
+      - '10540:10540' # MOS Lower port
+      - '10541:10541' # MOS Upper port
       # - "10542:10542" # MOS query port - not used
-    command: yarn start -host core -port 3000 -id mosGateway0
+    environment:
+      DEVICE_ID: mosGateway0
+      CORE_HOST: core
+      CORE_PORT: '3000'
     networks:
       - sofie
     depends_on:

--- a/packages/live-status-gateway/Dockerfile
+++ b/packages/live-status-gateway/Dockerfile
@@ -31,4 +31,4 @@ COPY --from=0 /opt/corelib /opt/corelib
 WORKDIR /opt/live-status-gateway
 RUN chown -R 1000:1000 /opt/live-status-gateway
 USER 1000
-CMD ["node", "dist/index.js"]
+ENTRYPOINT ["node", "dist/index.js"]

--- a/packages/live-status-gateway/Dockerfile.circle
+++ b/packages/live-status-gateway/Dockerfile.circle
@@ -13,4 +13,4 @@ COPY corelib /opt/corelib
 WORKDIR /opt/live-status-gateway
 RUN chown -R 1000:1000 /opt/live-status-gateway
 USER 1000
-CMD ["node", "dist/index.js"]
+ENTRYPOINT ["node", "dist/index.js"]

--- a/packages/mos-gateway/Dockerfile
+++ b/packages/mos-gateway/Dockerfile
@@ -9,7 +9,6 @@ RUN corepack enable
 RUN yarn install --immutable
 RUN yarn run pinst --disable
 RUN yarn lerna run --scope \*\*/mos-gateway --include-dependencies --stream build
-RUN yarn plugin import workspace-tools
 RUN yarn workspaces focus mos-gateway --production # purge dev-dependencies
 
 # DEPLOY IMAGE
@@ -25,4 +24,4 @@ COPY --from=0 /opt/shared-lib /opt/shared-lib
 WORKDIR /opt/mos-gateway
 RUN chown -R 1000:1000 /opt/mos-gateway
 USER 1000
-CMD ["node", "dist/index.js"]
+ENTRYPOINT ["node", "dist/index.js"]

--- a/packages/mos-gateway/Dockerfile.circle
+++ b/packages/mos-gateway/Dockerfile.circle
@@ -10,4 +10,4 @@ COPY shared-lib /opt/shared-lib
 WORKDIR /opt/mos-gateway
 RUN chown -R 1000:1000 /opt/mos-gateway
 USER 1000
-CMD ["node", "dist/index.js"]
+ENTRYPOINT ["node", "dist/index.js"]

--- a/packages/playout-gateway/Dockerfile
+++ b/packages/playout-gateway/Dockerfile
@@ -9,7 +9,6 @@ RUN corepack enable
 RUN yarn install --immutable
 RUN yarn run pinst --disable
 RUN yarn lerna run --scope \*\*/playout-gateway --include-dependencies --stream build
-RUN yarn plugin import workspace-tools
 RUN yarn workspaces focus playout-gateway --production # purge dev-dependencies
 
 # DEPLOY IMAGE
@@ -25,4 +24,4 @@ COPY --from=0 /opt/shared-lib /opt/shared-lib
 WORKDIR /opt/playout-gateway
 RUN chown -R 1000:1000 /opt/playout-gateway
 USER 1000
-CMD ["node", "dist/index.js"]
+ENTRYPOINT ["node", "dist/index.js"]

--- a/packages/playout-gateway/Dockerfile.circle
+++ b/packages/playout-gateway/Dockerfile.circle
@@ -10,4 +10,4 @@ COPY shared-lib /opt/shared-lib
 WORKDIR /opt/playout-gateway
 RUN chown -R 1000:1000 /opt/playout-gateway
 USER 1000
-CMD ["node", "dist/index.js"]
+ENTRYPOINT ["node", "dist/index.js"]


### PR DESCRIPTION

## About the Contributor

This pull request is posted on behalf of Superfly

## Type of Contribution

This is a: Bug fix 

## Current Behavior

When launching the docker images with extra arguments, the syntax is clunky. Because of the way the images are built, you have to do a `docker run playout-gateway node dist/index.js -host core -port 3000`. In other words, it requires the user of the image to know how to launch the application inside of the docker image. 
This is hard enough, that [until recently](https://github.com/Sofie-Automation/sofie-core/pull/1444) the Sofie documentation was wrong and would say to do `docker run playout-gateway yarn start -host core -port 3000` which would actually fail with a corepack error. 
This command changed a while back, I suspect when we updated to yarn 3.

So this is not friendly to those deploying sofie.

## New Behavior

The documentation has already been 'fixed' (by specifying the arguments through environment variables) in the above PR (and backported to main). 

But at times, it is useful to be able to supply arguments. So the images have been corrected to use an `ENTRPOINT` line. This means that they can now be used like `docker run playout-gateway -host core -port 3000`. In other words, the how to launch the application is now enforced by the images, leaving the user free to specify just the arguments.

Side note: If someone really wants to run a truely custom command, they can still do so with something like `docker run --entrypoint bash playout-gateway`

This is a potentially breaking change for anyone using the docker images, so I am targetting this at the development branch instead of stable/testing. If anyone is running with a command containing the `node dist/index.js`, they will need to change their commands to remove that.

Additionally there were a couple of errors in some of the docker images causing them to not build. (The ones that do a self-contained build, not the ones built here in github actions)

## Testing

I have tested this locally with freshly built images and am satisfied it is working. I did not test every gateway, but the changes were the same for them all.


- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

This affects the docker images and deployment scripts of sofie users.

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
