### PR TITLE
Fix: avoid zebra stripes on PieceInstance infinite continuations by falling back to previous PieceInstance Package statuses

### DIFF
--- a/meteor/server/publications/pieceContentStatusUI/checkPieceContentStatus.ts
+++ b/meteor/server/publications/pieceContentStatusUI/checkPieceContentStatus.ts
@@ -198,6 +198,10 @@ export type PieceContentStatusPiece = Pick<
 	'_id' | 'content' | 'expectedPackages' | 'name'
 > & {
 	pieceInstanceId?: PieceInstanceId
+	/**
+	 * If this is an infinite continuation, check the previous PieceInstance to fill the gap when package-manager has not processed an adlibbed part
+	 */
+	previousPieceInstanceId?: PieceInstanceId
 }
 export interface PieceContentStatusStudio
 	extends Pick<DBStudio, '_id' | 'previewContainerIds' | 'thumbnailContainerIds'> {
@@ -656,6 +660,13 @@ async function checkPieceContentExpectedPackageStatus(
 				if (piece.pieceInstanceId) {
 					// If this is a PieceInstance, try looking up the PieceInstance first
 					expectedPackageIds.unshift(getExpectedPackageId(piece.pieceInstanceId, expectedPackage._id))
+
+					if (piece.previousPieceInstanceId) {
+						// Also try the previous PieceInstance, when this is an infinite continuation in case package-manager needs to catchup
+						expectedPackageIds.unshift(
+							getExpectedPackageId(piece.previousPieceInstanceId, expectedPackage._id)
+						)
+					}
 				}
 
 				let warningMessage: ContentMessageLight | null = null

--- a/meteor/server/publications/pieceContentStatusUI/rundown/reactiveContentCache.ts
+++ b/meteor/server/publications/pieceContentStatusUI/rundown/reactiveContentCache.ts
@@ -64,7 +64,7 @@ export const partInstanceFieldSpecifier = literal<
 	part: 1, // This could be stricter, but this is unlikely to be changed once the PartInstance is created
 })
 
-export type PieceInstanceFields = '_id' | 'rundownId' | 'partInstanceId' | 'piece'
+export type PieceInstanceFields = '_id' | 'rundownId' | 'partInstanceId' | 'piece' | 'infinite'
 export const pieceInstanceFieldSpecifier = literal<
 	MongoFieldSpecifierOnesStrict<Pick<PieceInstance, PieceInstanceFields>>
 >({
@@ -72,6 +72,7 @@ export const pieceInstanceFieldSpecifier = literal<
 	rundownId: 1,
 	partInstanceId: 1,
 	piece: 1, // This could be stricter, but this is unlikely to be changed once the PieceInstance is created
+	infinite: 1, // This could be stricter, but this is temporary and should never change once set
 })
 
 export type AdLibPieceFields =

--- a/meteor/server/publications/pieceContentStatusUI/rundown/regenerateItems.ts
+++ b/meteor/server/publications/pieceContentStatusUI/rundown/regenerateItems.ts
@@ -166,6 +166,18 @@ export async function regenerateForPieceInstanceIds(
 			const sourceLayer =
 				pieceDoc.piece.sourceLayerId && sourceLayersForRundown?.sourceLayers?.[pieceDoc.piece.sourceLayerId]
 
+			let previousPieceInstanceId: PieceInstanceId | undefined
+			if (pieceDoc.infinite) {
+				// Note: this is a temporary solution, until single packages can be owned by multiple PieceInstances
+				// This shouldn't need to be reactive upon this PieceInstance, as this is filling a brief gap until package-manager catches up.
+				// That assumption could be wrong, but trying to track this dependency will be messy so would be nice to avoid.
+				const previousPieceInstance = contentCache.PieceInstances.findOne({
+					'infinite.infiniteInstanceId': pieceDoc.infinite.infiniteInstanceId,
+					'infinite.infiniteInstanceIndex': pieceDoc.infinite.infiniteInstanceIndex - 1,
+				})
+				previousPieceInstanceId = previousPieceInstance?._id
+			}
+
 			if (partInstance && segment && sourceLayer) {
 				const [status, dependencies] = await checkPieceContentStatusAndDependencies(
 					uiStudio,
@@ -173,6 +185,7 @@ export async function regenerateForPieceInstanceIds(
 					{
 						...pieceDoc.piece,
 						pieceInstanceId: pieceDoc._id,
+						previousPieceInstanceId,
 					},
 					sourceLayer
 				)


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core//docs/for-developers/contribution-guidelines
-->

## About the Contributor
This PR is made on behalf of bbc
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

## Type of Contribution
This is a bug fix

## New Behavior
 If an infinite pieceinstance has no package statuses available, try using them from the previous pieceinstance instead

This is similar to how we try using them from the piece, if the pieceinstance has none available. But to handle the case of an adlibbed pieceinstance when adlibbing a new part.

This is a not very nice and is a temporary fix

## Testing
Unknown - but is in production at bbc

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
