### PR TITLE
fix: Race condition in device change handling

### DIFF
--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -283,6 +283,7 @@ export class TSRHandler {
 
 			coreTsrHandler.statusChanged(status)
 
+			if (!coreTsrHandler._device) return
 			// When the status has changed, the deviceName might have changed:
 			coreTsrHandler._device.reloadProps().catch((err) => {
 				this.logger.error(`Error in reloadProps: ${stringifyError(err)}`)


### PR DESCRIPTION
## About the Contributor

This PR has been opened by SuperFly.tv on behalf of EVS Broadcast Equipment (henceforth EVS).

## Type of Contribution

This is a:

Bug fix

## Current Behaviour

Under some circumstances, particularly seen during device initialisation, a connectionChanged message leads to dereference of an undefined variable leading to an unhandled promise rejection.

## New Behaviour

The potentially undefined variable is tested before dereferencing.

## Testing

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

* This PR affects status updates from TSR devices.

## Time Frame

We would like to get this merged into the in-development release.

## Status

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
