### PR TITLE
fix: Memory leaks in Hover Previews

### DIFF
--- a/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUp.tsx
+++ b/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUp.tsx
@@ -73,14 +73,19 @@ export const PreviewPopUp = React.forwardRef<
 
 	useEffect(() => {
 		updateRef.current = update
+	}, [update])
 
+	useEffect(() => {
 		if (trackMouse) {
 			const listener = ({ clientX: x }: MouseEvent) => {
 				virtualElement.current.getBoundingClientRect = generateGetBoundingClientRect(
 					x,
 					anchor?.getBoundingClientRect().y ?? 0
 				)
-				if (update) update().catch((e) => console.error(e))
+				// If update is available, call it to reposition the popper:
+				if (updateRef.current) {
+					updateRef.current().catch((e) => console.error(e))
+				}
 			}
 			document.addEventListener('mousemove', listener)
 
@@ -88,7 +93,7 @@ export const PreviewPopUp = React.forwardRef<
 				document.removeEventListener('mousemove', listener)
 			}
 		}
-	}, [update, anchor])
+	}, [trackMouse, anchor])
 
 	useImperativeHandle(ref, () => {
 		return {

--- a/packages/webui/src/client/ui/PreviewPopUp/Previews/IFramePreview.tsx
+++ b/packages/webui/src/client/ui/PreviewPopUp/Previews/IFramePreview.tsx
@@ -20,15 +20,16 @@ export function IFramePreview({ content }: IFramePreviewProps): React.ReactEleme
 			const url = new URL(content.href)
 			iFrameElement.current?.contentWindow?.postMessage(content.postMessage, url.origin)
 		}
-	}, [])
+	}, [content.postMessage, content.href])
 
 	useEffect(() => {
-		if (!iFrameElement) return
+		// Create a stable reference to the iframe element:
+		const currentIFrame = iFrameElement.current
+		if (!currentIFrame) return
+		currentIFrame.addEventListener('load', onLoadListener)
 
-		iFrameElement.current?.addEventListener('load', onLoadListener)
-
-		return () => iFrameElement.current?.removeEventListener('load', onLoadListener)
-	}, [iFrameElement.current, onLoadListener])
+		return () => currentIFrame.removeEventListener('load', onLoadListener)
+	}, [onLoadListener])
 
 	const style: Record<string, string | number> = {}
 	if (content.dimensions) {

--- a/packages/webui/src/client/ui/PreviewPopUp/Previews/VTPreview.tsx
+++ b/packages/webui/src/client/ui/PreviewPopUp/Previews/VTPreview.tsx
@@ -36,16 +36,18 @@ export function VTPreviewElement({ content, time }: VTPreviewProps): React.React
 	const studioContext = useContext(StudioContext)
 
 	useEffect(() => {
-		if (!videoElement.current) return
+		// Create a stable reference to the video element:
+		const currentVideoElement = videoElement.current
+		if (!currentVideoElement) return
 
 		setVideoElementPosition(
-			videoElement.current,
+			currentVideoElement,
 			time ?? 0,
 			content.itemDuration ?? 0,
 			content.seek ?? 0,
 			content.loop ?? false
 		)
-	}, [videoElement.current, time])
+	}, [time, content.itemDuration, content.seek, content.loop])
 
 	const itemDuration = content.itemDuration ?? 0
 	const offsetTimePosition = (time ?? 0) + (content.seek ?? 0)


### PR DESCRIPTION

## About the Contributor
This PR is made on the behalf of BBC

## Type of Contribution
This is a bug fix

## Current Behavior
After introduction of the new hover previews, bbc has experiences UI Crashes

## New Behavior
Some of hover components was constantly re-rendering and re-triggering itself.
Ensuring the useEffects only triggers when needed, fixed the issue.

## Testing


- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas
UI

## Time Frame
This is an urgent fix for bbc

## Other Information

## Status
Manual testing in multiple rundowns has been performed with positive outcome.

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
