### PR TITLE
Set sub-device peripheralDeviceId from deviceOptions parentDeviceName

### DIFF
--- a/packages/job-worker/src/playout/upgrade.ts
+++ b/packages/job-worker/src/playout/upgrade.ts
@@ -18,7 +18,7 @@ import {
 	StudioRouteSetExclusivityGroup,
 } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { Complete, clone, literal } from '@sofie-automation/corelib/dist/lib'
-import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import { protectString, unprotectString } from '@sofie-automation/corelib/dist/protectedString'
 import { applyAndValidateOverrides } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
 import { wrapTranslatableMessageFromBlueprints } from '@sofie-automation/corelib/dist/TranslatableMessage'
 import {
@@ -30,6 +30,7 @@ import { CommonContext } from '../blueprints/context/index.js'
 import { JobContext } from '../jobs/index.js'
 import { FixUpBlueprintConfigContext } from '@sofie-automation/corelib/dist/fixUpBlueprintConfig/context'
 import { DEFAULT_MINIMUM_TAKE_SPAN } from '@sofie-automation/shared-lib/dist/core/constants'
+import { PERIPHERAL_SUBTYPE_PROCESS, PeripheralDevice } from '@sofie-automation/corelib/dist/dataModel/PeripheralDevice'
 
 /**
  * Run the Blueprint applyConfig for the studio
@@ -58,37 +59,61 @@ export async function handleBlueprintUpgradeForStudio(context: JobContext, _data
 			dev[0],
 			literal<Complete<StudioDeviceSettings>>({
 				name: dev[1].name ?? '',
-				options: dev[1],
+				options: dev[1].options ?? {},
 			}),
 		])
 	)
+
+	const peripheralDevices = (await context.directCollections.PeripheralDevices.findFetch(
+		{ subType: PERIPHERAL_SUBTYPE_PROCESS, 'studioAndConfigId.studioId': context.studioId },
+		{ projection: { _id: 1 } }
+	)) as Array<Pick<PeripheralDevice, '_id'>>
+
 	const playoutDevices = Object.fromEntries(
-		Object.entries<TSR.DeviceOptionsAny>(result.playoutDevices ?? {}).map((dev) => [
-			dev[0],
-			literal<Complete<StudioPlayoutDevice>>({
-				peripheralDeviceId: undefined,
-				options: dev[1],
-			}),
-		])
+		Object.entries<TSR.DeviceOptionsAny>(result.playoutDevices ?? {}).map((dev) => {
+			const { parentDeviceName, ...payload } = dev[1] as any
+			return [
+				dev[0],
+				literal<Complete<StudioPlayoutDevice>>({
+					peripheralDeviceId: peripheralDevices.find(
+						(p) => unprotectString(p._id).substring(0, parentDeviceName?.length) === parentDeviceName
+					)?._id,
+					options: payload,
+				}),
+			]
+		})
 	)
+
 	const ingestDevices = Object.fromEntries(
-		Object.entries<unknown>(result.ingestDevices ?? {}).map((dev) => [
-			dev[0],
-			literal<Complete<StudioIngestDevice>>({
-				peripheralDeviceId: undefined,
-				options: dev[1],
-			}),
-		])
+		Object.entries<unknown>(result.ingestDevices ?? {}).map((dev) => {
+			const { parentDeviceName, ...payload } = dev[1] as any
+			return [
+				dev[0],
+				literal<Complete<StudioIngestDevice>>({
+					peripheralDeviceId: peripheralDevices.find(
+						(p) => unprotectString(p._id).substring(0, parentDeviceName?.length) === parentDeviceName
+					)?._id,
+					options: payload,
+				}),
+			]
+		})
 	)
+
 	const inputDevices = Object.fromEntries(
-		Object.entries<unknown>(result.inputDevices ?? {}).map((dev) => [
-			dev[0],
-			literal<Complete<StudioInputDevice>>({
-				peripheralDeviceId: undefined,
-				options: dev[1],
-			}),
-		])
+		Object.entries<unknown>(result.inputDevices ?? {}).map((dev) => {
+			const { parentDeviceName, ...payload } = dev[1] as any
+			return [
+				dev[0],
+				literal<Complete<StudioInputDevice>>({
+					peripheralDeviceId: peripheralDevices.find(
+						(p) => unprotectString(p._id).substring(0, parentDeviceName?.length) === parentDeviceName
+					)?._id,
+					options: payload,
+				}),
+			]
+		})
 	)
+
 	const routeSets = Object.fromEntries(
 		Object.entries<Partial<StudioRouteSet>>(result.routeSets ?? {}).map((dev) => [
 			dev[0],


### PR DESCRIPTION
## About the Contributor

This PR has been opened by SuperFly.tv on behalf of EVS Broadcast Equipment (henceforth EVS).

## Type of Contribution

This is a:

Feature

## Current Behaviour

When configuring a new peripheral sub-device in a Studio upgrade the peripheralDeviceId would be left undefined.

## New Behaviour

The updated code allows the device options of the new sub-device to specify a parentDeviceName property that is then used to find a peripheralDeviceId with a matching name.
Parent devices append an extra string to the configured name so the search for a match uses only the first characters of the parent device _id property.

## Testing

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

This PR affects peripheral sub-devices configured through a studio upgrade operation triggered by the API.

## Time Frame

We would like to get this merged into the in-development release.

## Status

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
