### PR TITLE
fix: hover iframePreview was not updating when hovering directly from one pvw to the next

### DIFF
--- a/packages/webui/src/client/ui/PreviewPopUp/Previews/IFramePreview.tsx
+++ b/packages/webui/src/client/ui/PreviewPopUp/Previews/IFramePreview.tsx
@@ -17,8 +17,8 @@ export function IFramePreview({ content }: IFramePreviewProps): React.ReactEleme
 
 	const onLoadListener = useCallback(() => {
 		if (content.postMessage) {
-			const url = new URL(content.href)
-			iFrameElement.current?.contentWindow?.postMessage(content.postMessage, url.origin)
+			// use * as URL reference to avoid cors when posting message with new reference:
+			iFrameElement.current?.contentWindow?.postMessage(content.postMessage, '*')
 		}
 	}, [content.postMessage, content.href])
 
@@ -30,6 +30,14 @@ export function IFramePreview({ content }: IFramePreviewProps): React.ReactEleme
 
 		return () => currentIFrame.removeEventListener('load', onLoadListener)
 	}, [onLoadListener])
+
+	// Handle postMessage updates when iframe is already loaded
+	useEffect(() => {
+		if (content.postMessage && iFrameElement.current?.contentWindow) {
+			// use * as URL reference to avoid cors when posting message with new reference:
+			iFrameElement.current.contentWindow.postMessage(content.postMessage, '*')
+		}
+	}, [content.postMessage, content.href])
 
 	const style: Record<string, string | number> = {}
 	if (content.dimensions) {


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core//docs/for-developers/contribution-guidelines
-->

## About the Contributor
This PR is made on behalf of BBC

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

## Type of Contribution

This is a bug fix

## Current Behavior
Currently the preview is not always updating when hovering directly between 2 iFrames 

## New Behavior
Retriggering when postMessage or href is changing, has been added. 
Prior to this, the postMessage was only updated on load.

## Testing
Hover between 2 adjacent iFrames

### Affected areas
This is a small bug fix, and only affects iFrame Previews.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
