### PR TITLE
fix: improve error messaging in evalBlueprint()

### DIFF
--- a/meteor/server/api/blueprints/cache.ts
+++ b/meteor/server/api/blueprints/cache.ts
@@ -6,7 +6,7 @@ import { stringifyError } from '@sofie-automation/shared-lib/dist/lib/stringifyE
 
 export function evalBlueprint(blueprint: Pick<Blueprint, '_id' | 'name' | 'code'>): SomeBlueprintManifest {
 	const blueprintPath = `db:///blueprint/${blueprint.name || blueprint._id}-bundle.js`
-	const context = vm.createContext({}, {})
+	const context = vm.createContext({ process: process }, {})
 	const script = new vm.Script(
 		`__run_result = ${blueprint.code}
 __run_result || blueprint`,
@@ -14,7 +14,13 @@ __run_result || blueprint`,
 			filename: blueprintPath,
 		}
 	)
-	const entry = script.runInContext(context)
+
+	let entry: any
+	try {
+		entry = script.runInContext(context)
+	} catch (e) {
+		console.error(`Error evaluating Blueprint .runInContext "${blueprint._id}": "${stringifyError(e)}"`)
+	}
 
 	const manifest: SomeBlueprintManifest = entry.default
 

--- a/meteor/server/api/blueprints/cache.ts
+++ b/meteor/server/api/blueprints/cache.ts
@@ -19,7 +19,7 @@ __run_result || blueprint`,
 	try {
 		entry = script.runInContext(context)
 	} catch (e) {
-		console.error(`Error evaluating Blueprint .runInContext "${blueprint._id}": "${stringifyError(e)}"`)
+		logger.error(`Error evaluating Blueprint .runInContext "${blueprint._id}": "${stringifyError(e)}"`)
 	}
 
 	const manifest: SomeBlueprintManifest = entry.default

--- a/meteor/server/api/blueprints/cache.ts
+++ b/meteor/server/api/blueprints/cache.ts
@@ -6,7 +6,7 @@ import { stringifyError } from '@sofie-automation/shared-lib/dist/lib/stringifyE
 
 export function evalBlueprint(blueprint: Pick<Blueprint, '_id' | 'name' | 'code'>): SomeBlueprintManifest {
 	const blueprintPath = `db:///blueprint/${blueprint.name || blueprint._id}-bundle.js`
-	const context = vm.createContext({ process: process }, {})
+	const context = vm.createContext({}, {})
 	const script = new vm.Script(
 		`__run_result = ${blueprint.code}
 __run_result || blueprint`,


### PR DESCRIPTION
## About the Contributor
This PR is made on behalf of BBC

## Type of Contribution

This is a code improvement

## Current Behavior
Currently blueprints that are uploaded but fails to run  (e.g. if it reference to node process) will show this error-message in core:
`[error] Blueprint restore failed: Error: Blueprint main-showstyle failed to parse [400] `

## New Behavior
Adding a try-catch around the .runInContext() ensures a detailed error message, informing about the issue in the blueprint

## Testing
- [x] No unit test changes are needed for this PR

### Affected areas
This PR affects errorhandling in upload of Blueprints

## Time Frame

## Other Information

## Status

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
