### PR TITLE
fix: bug in onTimelineGenerate: Use same time for "now" everywhere

### DIFF
--- a/packages/job-worker/src/playout/timeline/multi-gateway.ts
+++ b/packages/job-worker/src/playout/timeline/multi-gateway.ts
@@ -7,7 +7,6 @@ import { PieceTimelineMetadata } from './pieceGroup'
 import { StudioPlayoutModelBase } from '../../studio/model/StudioPlayoutModel'
 import { logger } from '../../logging'
 import { JobContext } from '../../jobs'
-import { getCurrentTime } from '../../lib'
 import { PlayoutModel } from '../model/PlayoutModel'
 import { RundownTimelineTimingContext, getInfinitePartGroupId } from './rundown'
 import { getExpectedLatency } from '@sofie-automation/corelib/dist/studio/playout'
@@ -23,17 +22,16 @@ import { PlayoutPieceInstanceModel } from '../model/PlayoutPieceInstanceModel'
  * This does introduce a risk of error when changes are made to how we generate the timeline, but that risk should be small.
  */
 export function deNowifyMultiGatewayTimeline(
-	context: JobContext,
 	playoutModel: PlayoutModel,
 	timelineObjs: TimelineObjRundown[],
-	timingContext: RundownTimelineTimingContext | undefined
+	timingContext: RundownTimelineTimingContext | undefined,
+	targetNowTime: number
 ): void {
 	if (!timingContext) return
 
 	const timelineObjsMap = normalizeArray(timelineObjs, 'id')
 
-	const nowOffsetLatency = calculateNowOffsetLatency(context, playoutModel)
-	const targetNowTime = getCurrentTime() + (nowOffsetLatency ?? 0)
+	logger.info(`deNowifyMultiGatewayTimeline: ${targetNowTime}`)
 
 	// Replace `start: 'now'` in currentPartInstance on timeline
 	const currentPartInstance = playoutModel.currentPartInstance


### PR DESCRIPTION
## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: Bug fix

## Current Behavior

<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

We have found a issue where the timings of pieces are not monotonic.
This only affects infinite pieces, and probably only when `multiGatewayMode` is enabled.

How to reproduce:

In a blueprints adlibAction:
```typescript
// Stop the previous (infinite) piece
await context.stopPiecesOnLayers(['myLayer'])

await insertPiecesTyped(context, 'current', {
	[...],
	sourceLayerId: 'myLayer',
	enable: { start: 'now' },
	lifespan: PieceLifespan.OutOnShowStyleEnd,
})
```
This results in a virtual piece being inserted to stop the previous infinite `OutOnShowStyleEnd` piece, [at time ](https://github.com/Sofie-Automation/sofie-core/blob/f222545db5a68de63ce45ecff3c839b1b8a86311/packages/job-worker/src/playout/adlibUtils.ts#L282) `getCurrentTime()+calculateNowOffsetLatency` (this is correct).
Then a pieceInstance is inserted at time `"now"`, which is later resolved using `getCurrentTime()`.
In our case, this ends up in that the virtual piece ends up _after_ the inserted Piece, thus instantly ending it.


## New Behavior

<!--
What is the new behavior?
-->

The same `getCurrentTime()+calculateNowOffsetLatency` time is used in both `deNowifyMultiGatewayTimeline` and in `getTimelineRundown`.


## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

This PR affects the playout logic in general.

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

* This is a critical bug for us, but not urgent to merge into upstream.


## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

Disclaimer: I have not gone through the other places where `getCurrentTime()` is used, so there _might_ be other places `calculateNowOffsetLatency` should be used.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
