### PR TITLE
Fix: Add plannedStartedPlayback to BP interface

### DIFF
--- a/packages/blueprints-integration/src/documents/partInstance.ts
+++ b/packages/blueprints-integration/src/documents/partInstance.ts
@@ -31,4 +31,16 @@ export interface IBlueprintPartInstanceTimings {
 	reportedStartedPlayback?: Time
 	/** Point in time the Part stopped playing (ie the time of the playout) */
 	reportedStoppedPlayback?: Time
+
+	/**
+	 * Point in time where the Part is planned to start playing.
+	 * This gets set when the part is taken
+	 * It may get set to a point in the past, if an offset is chosen when starting to play the part
+	 */
+	plannedStartedPlayback?: Time
+	/**
+	 * Point in time where the Part is planned to stop playing
+	 * This gets set when the plannedStartedPlayback of the following part is set
+	 */
+	plannedStoppedPlayback?: Time
 }


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core//docs/for-developers/contribution-guidelines
-->

## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: Code improvement

## Current Behavior

<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

Currently, only `reportedStartedPlayback` and `reportedStoppedPlayback` are exposed to blueprints in the types.
This is unfortunate, since they might not be set at all when running in multiGatewayMode, and `plannedStartedPlayback` & `plannedStoppedPlayback` are actually already exposed, value-wise.

## New Behavior

<!--
What is the new behavior?
-->

`plannedStartedPlayback` & `plannedStoppedPlayback` are added to the blueprint types (they are already in the values).

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
