### PR TITLE
chore: fix docker compose example permissions to sofie-store

### DIFF
--- a/packages/documentation/docs/user-guide/installation/installing-sofie-server-core.md
+++ b/packages/documentation/docs/user-guide/installation/installing-sofie-server-core.md
@@ -37,6 +37,16 @@ services:
     networks:
       - sofie
 
+  # Fix Ownership Snapshots mount
+  # Because docker volumes are owned by root by default
+  # And our images follow best-practise and don't run as root
+  change-vol-ownerships:
+    image: node:22-alpine
+    user: 'root'
+    volumes:
+      - sofie-store:/mnt/sofie-store
+    entrypoint: ['sh', '-c', 'chown -R node:node /mnt/sofie-store']
+
   core:
     hostname: core
     image: sofietv/tv-automation-server-core:release51
@@ -54,7 +64,10 @@ services:
     volumes:
       - sofie-store:/mnt/sofie-store
     depends_on:
-      - db
+      change-vol-ownerships:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
 
   playout-gateway:
     image: sofietv/tv-automation-playout-gateway:release51


### PR DESCRIPTION

## About the Contributor

This pull request is posted on behalf of Superfly

## Type of Contribution

This is a: Documentation improvement

## Current Behavior

Since #1417, the docker compose example file does not operate cleanly. Generating a snapshot or attempting to upload blueprints assets fails with permissions issues.

This is because docker volumes are by default owned by root, and the user we run sofie as does not have permissions to write to the folder.  
To resolve this, we can add another step to the compose script which runs the chmod of the store folder to the correct ownership, and make the core container depend on this being successful.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
