### PR TITLE
fix: ingest parts not being updated when rank changes

### DIFF
--- a/packages/job-worker/src/blueprints/ingest/MutableIngestRundownImpl.ts
+++ b/packages/job-worker/src/blueprints/ingest/MutableIngestRundownImpl.ts
@@ -347,11 +347,7 @@ export class MutableIngestRundownImpl<TRundownPayload = unknown, TSegmentPayload
 			}
 
 			// Regenerate the segment if there are substantial changes
-			if (
-				segmentInfo.segmentHasChanges ||
-				segmentInfo.partOrderHasChanged ||
-				segmentInfo.partIdsWithChanges.length > 0
-			) {
+			if (segmentInfo.segmentHasChanges || segmentInfo.partIdsWithChanges.length > 0) {
 				segmentsToRegenerate.push(ingestSegment)
 			}
 		})

--- a/packages/job-worker/src/ingest/runOperation.ts
+++ b/packages/job-worker/src/ingest/runOperation.ts
@@ -202,7 +202,7 @@ export async function runIngestUpdateOperationBase(
 			}
 		} finally {
 			// Ensure we save the nrcs ingest data
-			// await pSaveNrcsIngestChanges
+			await pSaveNrcsIngestChanges
 
 			span?.end()
 		}

--- a/packages/job-worker/src/playout/model/PlayoutModel.ts
+++ b/packages/job-worker/src/playout/model/PlayoutModel.ts
@@ -226,6 +226,12 @@ export interface PlayoutModel extends PlayoutModelReadonly, StudioPlayoutModelBa
 	clearSelectedPartInstances(): void
 
 	/**
+	 * Clear the currently selected previousPartInstance.
+	 * This can be useful if it references a Rundown that has been removed from the Playlist
+	 */
+	clearPreviousPartInstance(): void
+
+	/**
 	 * Insert an adlibbed PartInstance into the RundownPlaylist
 	 * @param part Part to insert
 	 * @param pieces Planned Pieces to insert into Part

--- a/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
@@ -346,6 +346,15 @@ export class PlayoutModelImpl extends PlayoutModelReadonlyImpl implements Playou
 		this.#playlistHasChanged = true
 	}
 
+	clearPreviousPartInstance(): void {
+		this.playlistImpl.previousPartInfo = null
+
+		// Make sure that a hold isn't running. We can't block it here, so abort it immediately instead
+		this.playlistImpl.holdState = RundownHoldState.NONE
+
+		this.#playlistHasChanged = true
+	}
+
 	calculatePartTimings(
 		fromPartInstance: PlayoutPartInstanceModel | null,
 		toPartInstance: PlayoutPartInstanceModel,

--- a/packages/job-worker/src/rundownPlaylists.ts
+++ b/packages/job-worker/src/rundownPlaylists.ts
@@ -490,7 +490,13 @@ export async function handleMoveRundownIntoPlaylist(
 					}
 
 					// If the playlist is active this could have changed lookahead
-					await updatePlayoutAfterChangingRundownInPlaylist(context, newPlaylist, intoPlaylistLock, rundown)
+					await updatePlayoutAfterChangingRundownInPlaylist(
+						context,
+						newPlaylist,
+						intoPlaylistLock,
+						rundown,
+						null
+					)
 				}
 			)
 		} else {
@@ -540,7 +546,7 @@ export async function handleRestoreRundownsInPlaylistToDefaultOrder(
 
 			if (updatedPlaylist) {
 				// If the playlist is active this could have changed lookahead
-				await updatePlayoutAfterChangingRundownInPlaylist(context, updatedPlaylist, playlistLock, null)
+				await updatePlayoutAfterChangingRundownInPlaylist(context, updatedPlaylist, playlistLock, null, null)
 			}
 		}
 	})


### PR DESCRIPTION
## About the Contributor

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: Bug fix



## New Behavior

This includes a few bug fixes targetting ingest.
* `fix: ingest parts not being updated when rank changes` - sometimes the NrcsIngestDataCacheObj for parts would not be saved when their rank changed, causing the rank change to be lost
* `fix: missing await of promise` - a missing await of a promise, which could lead to a new ingest job beginning before the previous one had finished being written to the db
* `fix: ignore invalid partInstances during syncChangesToPartInstances` - If `syncChangesToPartInstances` failed to load a partInstance, it would throw an error and cause the whole updating playout following ingest process to fail. Instead simply ignore the bad partinstance
* `fix: ensure the previousPartInstnace is cleaned up when belonging to a Rundown being removed from the playlist` - when removing a Rundown from a RundownPlaylist, if the previousPartInstance belongs to the removed rundown then clear the reference to it.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [x] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
