### PR TITLE
Fix determining TSR version when running in certain configurations

### DIFF
--- a/packages/shared-lib/src/tsr.ts
+++ b/packages/shared-lib/src/tsr.ts
@@ -1,5 +1,10 @@
 import * as TSR from 'timeline-state-resolver-types'
 export { TSR }
 
-import * as tsrPkgInfo from 'timeline-state-resolver-types/package.json'
-export const TSR_VERSION: string = tsrPkgInfo.version
+// Dynamically import package.json to avoid import attributes error
+const TSR_VERSION = require('timeline-state-resolver-types/package.json').version
+
+// Below line should work in Node.js 18+ and with bundlers that support import attributes, and replace the above
+// import { version as TSR_VERSION } from 'timeline-state-resolver-types/package.json' with { type: 'json' }
+
+export { TSR_VERSION }


### PR DESCRIPTION
## About the Contributor



## Type of Contribution

This is a Bug fix / Code improvement for compatibility with later node versions

## Current Behavior

Using `import` with a json file is banned in node 20 unless you use `with { type: 'json' }`, which is not supported in node 16, our current build target.

Question: Does using import freeze the value at sofie-core build time, not reflect the version that yarn has chosen to install? If so, is that the right thing to do?

## New Behavior

Use require to import the `package.json` file.

## Testing

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

This PR affects building blueprints.

## Time Frame

* Not urgent, but we would like to get this merged into the in-development release.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core//)) has been added / updated.
