### PR TITLE
feat: Add space bar as "Take" shortcut

### DIFF
--- a/meteor/server/migration/upgrades/defaultSystemActionTriggers.ts
+++ b/meteor/server/migration/upgrades/defaultSystemActionTriggers.ts
@@ -127,6 +127,11 @@ export const DEFAULT_CORE_TRIGGERS: IBlueprintDefaultCoreSystemTriggers = {
 				keys: 'F12',
 				up: true,
 			},
+			'2': {
+				type: TriggerType.hotkey,
+				keys: 'Space',
+				up: true,
+			},
 		},
 		_rank: ++j * 1000,
 		name: t('Take'),


### PR DESCRIPTION

<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of myself

## Type of Contribution

This is a Feature

## Current Behavior

The defaults for "Take" are "F12" and "Numpad Enter", both fairly obscure keys. Many laptop keyboards don't feature either of them, at least not without use of the Fn modifier key. If the show goes straight to plan, it's literally the only key that you need, so it should be more obvious.

## New Behavior

Pressing space Takes the next item.

F12 and Numpad Enter still work. You can still remove space in settings if you need to.

## Testing

* Setup Sofie so that all settings are default
* Start a rundown
* Press space

It should take the next part.

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [X] No unit test changes are needed for this PR

### Affected areas

This PR affects a default setting.

## Time Frame

* Not urgent, but we would like to get this merged into the in-development release.

## Other Information

This has annoyed me for ages.

## Status

- [X] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
