### PR TITLE
feat: wrap text on mini shelf buttons

### DIFF
--- a/packages/webui/src/client/styles/shelf/dashboard.scss
+++ b/packages/webui/src/client/styles/shelf/dashboard.scss
@@ -437,6 +437,7 @@ $dashboard-button-height: 3.625em;
 						1px -1px 0px rgba(0, 0, 0, 0.5),
 						0.5px 0.5px 2px rgba(0, 0, 0, 1);
 					z-index: 2;
+					text-wrap: balance;
 
 					&.dashboard-panel__panel__button__label--editable {
 						text-shadow: none;


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the BBC

## Type of Contribution

This is a Feature

## Current Behavior

Long labels on the Mini shelf are truncated, the user is not able to see the full name of the button.

## New Behavior

Add wrapping to the label

## Testing

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [X] No unit test changes are needed for this PR

### Affected areas

Styling of the Mini shelf buttons.

## Time Frame

Not urgent, but we would like to get this merged into the in-development release.

## Status

- [X] PR is ready to be reviewed.
- [X] The functionality has been tested by the author.
- [X] Relevant unit tests has been added / updated.
- [X] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
