### PR TITLE
fix: disable some null subscriptions

### DIFF
--- a/meteor/server/publications/partsUI/publication.ts
+++ b/meteor/server/publications/partsUI/publication.ts
@@ -189,7 +189,7 @@ meteorCustomPublish(
 	MeteorPubSub.uiParts,
 	CustomCollectionName.UIParts,
 	async function (pub, playlistId: RundownPlaylistId | null) {
-		check(playlistId, Match.Optional(String))
+		check(playlistId, Match.Maybe(String))
 
 		triggerWriteAccessBecauseNoCheckNecessary()
 

--- a/packages/webui/src/client/ui/ClockView/CameraScreen/index.tsx
+++ b/packages/webui/src/client/ui/ClockView/CameraScreen/index.tsx
@@ -14,7 +14,7 @@ import { UIStudio } from '@sofie-automation/meteor-lib/dist/api/studios'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { PieceExtended } from '../../../lib/RundownResolver'
 import { Rundowns } from '../../../collections'
-import { useSubscription, useTracker } from '../../../lib/ReactMeteorData/ReactMeteorData'
+import { useSubscription, useSubscriptionIfEnabled, useTracker } from '../../../lib/ReactMeteorData/ReactMeteorData'
 import { UIPartInstances, UIStudios } from '../../Collections'
 import { Rundown as RundownComponent } from './Rundown'
 import { useLocation } from 'react-router-dom'
@@ -102,17 +102,17 @@ export function CameraScreen({ playlist, studioId }: Readonly<IProps>): JSX.Elem
 	const rundownIds = useMemo(() => rundowns.map((rundown) => rundown._id), [rundowns])
 	const showStyleBaseIds = useMemo(() => rundowns.map((rundown) => rundown.showStyleBaseId), [rundowns])
 
-	const rundownsReady = useSubscription(CorelibPubSub.rundownsInPlaylists, playlistIds)
-	useSubscription(CorelibPubSub.segments, rundownIds, {})
+	const rundownsReady = useSubscriptionIfEnabled(CorelibPubSub.rundownsInPlaylists, playlistIds.length > 0, playlistIds)
+	useSubscriptionIfEnabled(CorelibPubSub.segments, rundownIds.length > 0, rundownIds, {})
 
 	const studioReady = useSubscription(MeteorPubSub.uiStudio, studioId)
-	useSubscription(MeteorPubSub.uiPartInstances, playlist?.activationId ?? null)
+	useSubscriptionIfEnabled(MeteorPubSub.uiPartInstances, !!playlist?.activationId, playlist?.activationId ?? null)
 
-	useSubscription(CorelibPubSub.parts, rundownIds, null)
+	useSubscriptionIfEnabled(CorelibPubSub.parts, rundownIds.length > 0, rundownIds, null)
 
-	useSubscription(CorelibPubSub.pieceInstancesSimple, rundownIds, null)
+	useSubscriptionIfEnabled(CorelibPubSub.pieceInstancesSimple, rundownIds.length > 0, rundownIds, null)
 
-	const piecesReady = useSubscription(CorelibPubSub.pieces, rundownIds, null)
+	const piecesReady = useSubscriptionIfEnabled(CorelibPubSub.pieces, rundownIds.length > 0, rundownIds, null)
 
 	const [piecesReadyOnce, setPiecesReadyOnce] = useState(false)
 	useEffect(() => {

--- a/packages/webui/src/client/ui/ClockView/PresenterScreen.tsx
+++ b/packages/webui/src/client/ui/ClockView/PresenterScreen.tsx
@@ -4,7 +4,13 @@ import { PartUi } from '../SegmentTimeline/SegmentTimelineContainer'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { Rundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
 import { withTiming, WithTiming } from '../RundownView/RundownTiming/withTiming'
-import { useSubscription, useSubscriptions, useTracker, withTracker } from '../../lib/ReactMeteorData/ReactMeteorData'
+import {
+	useSubscription,
+	useSubscriptionIfEnabled,
+	useSubscriptions,
+	useTracker,
+	withTracker,
+} from '../../lib/ReactMeteorData/ReactMeteorData'
 import { protectString, unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 import { getCurrentTime } from '../../lib/systemTime'
 import { PartInstance } from '@sofie-automation/meteor-lib/dist/collections/PartInstances'
@@ -335,21 +341,21 @@ export function usePresenterScreenSubscriptions(props: PresenterScreenProps): vo
 		[props.playlistId]
 	)
 
-	useSubscription(CorelibPubSub.rundownsInPlaylists, playlist ? [playlist._id] : [])
+	useSubscriptionIfEnabled(CorelibPubSub.rundownsInPlaylists, !!playlist, playlist ? [playlist._id] : [])
 
 	const { rundownIds, showStyleBaseIds, showStyleVariantIds } = useRundownAndShowStyleIdsForPlaylist(playlist?._id)
 
-	useSubscription(CorelibPubSub.segments, rundownIds, {})
-	useSubscription(CorelibPubSub.parts, rundownIds, null)
-	useSubscription(MeteorPubSub.uiParts, playlist?._id ?? null)
-	useSubscription(MeteorPubSub.uiPartInstances, playlist?.activationId ?? null)
-	useSubscription(CorelibPubSub.pieces, rundownIds, null)
+	useSubscriptionIfEnabled(CorelibPubSub.segments, rundownIds.length > 0, rundownIds, {})
+	useSubscriptionIfEnabled(CorelibPubSub.parts, rundownIds.length > 0, rundownIds, null)
+	useSubscriptionIfEnabled(MeteorPubSub.uiParts, !!playlist, playlist?._id ?? null)
+	useSubscriptionIfEnabled(MeteorPubSub.uiPartInstances, !!playlist?.activationId, playlist?.activationId ?? null)
+	useSubscriptionIfEnabled(CorelibPubSub.pieces, rundownIds.length > 0, rundownIds, null)
 	useSubscriptions(
 		MeteorPubSub.uiShowStyleBase,
 		showStyleBaseIds.map((id) => [id])
 	)
-	useSubscription(CorelibPubSub.showStyleVariants, null, showStyleVariantIds)
-	useSubscription(MeteorPubSub.rundownLayouts, showStyleBaseIds)
+	useSubscriptionIfEnabled(CorelibPubSub.showStyleVariants, showStyleVariantIds.length > 0, null, showStyleVariantIds)
+	useSubscriptionIfEnabled(MeteorPubSub.rundownLayouts, showStyleBaseIds.length > 0, showStyleBaseIds)
 
 	const { currentPartInstance, nextPartInstance } = useTracker(
 		() => {

--- a/packages/webui/src/client/ui/Prompter/PrompterView.tsx
+++ b/packages/webui/src/client/ui/Prompter/PrompterView.tsx
@@ -10,6 +10,7 @@ import {
 	Translated,
 	useGlobalDelayedTrackerUpdateState,
 	useSubscription,
+	useSubscriptionIfEnabled,
 	useSubscriptions,
 	useTracker,
 } from '../../lib/ReactMeteorData/ReactMeteorData'
@@ -653,11 +654,11 @@ function Prompter(props: Readonly<PropsWithChildren<IPrompterProps>>): JSX.Eleme
 		[props.rundownPlaylistId]
 	)
 	const rundownIDs = playlist ? RundownPlaylistCollectionUtil.getRundownUnorderedIDs(playlist) : []
-	useSubscription(CorelibPubSub.segments, rundownIDs, {})
+	useSubscriptionIfEnabled(CorelibPubSub.segments, rundownIDs.length > 0, rundownIDs, {})
 	useSubscription(MeteorPubSub.uiParts, props.rundownPlaylistId)
-	useSubscription(MeteorPubSub.uiPartInstances, playlist?.activationId ?? null)
-	useSubscription(CorelibPubSub.pieces, rundownIDs, null)
-	useSubscription(CorelibPubSub.pieceInstancesSimple, rundownIDs, null)
+	useSubscriptionIfEnabled(MeteorPubSub.uiPartInstances, !!playlist?.activationId, playlist?.activationId ?? null)
+	useSubscriptionIfEnabled(CorelibPubSub.pieces, rundownIDs.length > 0, rundownIDs, null)
+	useSubscriptionIfEnabled(CorelibPubSub.pieceInstancesSimple, rundownIDs.length > 0, rundownIDs, null)
 
 	const rundowns = useTracker(
 		() =>
@@ -1011,7 +1012,11 @@ const PrompterContent = withTranslation()(
 			}
 
 			if (hasInsertedScript) {
-				lines.push(<div className="prompter-break end">—{t('End of script')}—</div>)
+				lines.push(
+					<div key="end-of-script" className="prompter-break end">
+						—{t('End of script')}—
+					</div>
+				)
 			}
 
 			return lines

--- a/packages/webui/src/client/ui/Status/package-status/index.tsx
+++ b/packages/webui/src/client/ui/Status/package-status/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { useSubscription, useTracker } from '../../../lib/ReactMeteorData/react-meteor-data'
+import { useSubscriptionIfEnabled, useTracker } from '../../../lib/ReactMeteorData/react-meteor-data'
 import { ExpectedPackageWorkStatus } from '@sofie-automation/corelib/dist/dataModel/ExpectedPackageWorkStatuses'
 import { normalizeArrayToMap, unprotectString } from '../../../lib/tempLib'
 import { ExpectedPackageDB } from '@sofie-automation/corelib/dist/dataModel/ExpectedPackages'
@@ -29,15 +29,16 @@ export const ExpectedPackagesStatus: React.FC<{}> = function ExpectedPackagesSta
 			UIStudios.find()
 				.fetch()
 				.map((studio) => studio._id),
+		[],
 		[]
 	)
 
 	const allSubsReady: boolean =
 		[
-			useSubscription(CorelibPubSub.expectedPackageWorkStatuses, studioIds ?? []),
-			useSubscription(CorelibPubSub.expectedPackages, studioIds ?? []),
-			useSubscription(CorelibPubSub.packageContainerStatuses, studioIds ?? []),
-			studioIds && studioIds.length > 0,
+			useSubscriptionIfEnabled(CorelibPubSub.expectedPackageWorkStatuses, studioIds.length > 0, studioIds),
+			useSubscriptionIfEnabled(CorelibPubSub.expectedPackages, studioIds.length > 0, studioIds),
+			useSubscriptionIfEnabled(CorelibPubSub.packageContainerStatuses, studioIds.length > 0, studioIds),
+			studioIds.length > 0,
 		].reduce((memo, value) => memo && value, true) || false
 
 	const expectedPackageWorkStatuses = useTracker(() => ExpectedPackageWorkStatuses.find({}).fetch(), [], [])
@@ -50,7 +51,11 @@ export const ExpectedPackagesStatus: React.FC<{}> = function ExpectedPackagesSta
 		expectedPackageWorkStatuses.forEach((epws) => devices.add(epws.deviceId))
 		return Array.from(devices)
 	}, [packageContainerStatuses, expectedPackageWorkStatuses])
-	const peripheralDeviceSubReady = useSubscription(CorelibPubSub.peripheralDevices, deviceIds)
+	const peripheralDeviceSubReady = useSubscriptionIfEnabled(
+		CorelibPubSub.peripheralDevices,
+		deviceIds.length > 0,
+		deviceIds
+	)
 	const peripheralDevices = useTracker(() => PeripheralDevices.find().fetch(), [], [])
 	const peripheralDevicesMap = normalizeArrayToMap(peripheralDevices, '_id')
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

Upstream of https://github.com/nrkno/sofie-nrk-core/pull/15

## About the Contributor

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a: Bug fix 

## Current Behavior

The `MeteorPubSub.uiParts` publication was erroring when the client tried to subscribe with a `null` parameter. According to the types this is valid (and has been fixed), but it would return null and do nothing.

We have a helper `useSubscriptionIfEnabled` in the ui, which can optimise away these pointless subscriptions, so the usage and various others have been updated to use that when the publciation would return null.


## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
