### PR TITLE
feat: add getUpcomingParts method to OnSetAsNextContext

### DIFF
--- a/packages/blueprints-integration/src/context/onSetAsNextContext.ts
+++ b/packages/blueprints-integration/src/context/onSetAsNextContext.ts
@@ -11,6 +11,7 @@ import {
 	IShowStyleUserContext,
 } from '../index.js'
 import { BlueprintQuickLookInfo } from './quickLoopInfo.js'
+import { ReadonlyDeep } from 'type-fest'
 
 /**
  * Context in which 'current' is the part currently on air, and 'next' is the partInstance being set as Next
@@ -55,6 +56,13 @@ export interface IOnSetAsNextContext extends IShowStyleUserContext, IEventContex
 	getPartForPreviousPiece(piece: IBlueprintPieceDB): Promise<IBlueprintPart | undefined>
 	/** Gets the Segment. This primarily allows for accessing metadata */
 	getSegment(segment: 'current' | 'next'): Promise<IBlueprintSegment | undefined>
+
+	/** Get a list of the upcoming Parts in the Rundown, in the order that they will be Taken
+	 *
+	 * @param limit The max number of parts returned. Default is 5.
+	 * @returns An array of Parts. If there is no next part, the array will be empty.
+	 */
+	getUpcomingParts(limit?: number): Promise<ReadonlyDeep<IBlueprintPart[]>>
 
 	/**
 	 * Creative actions

--- a/packages/job-worker/src/blueprints/context/OnSetAsNextContext.ts
+++ b/packages/job-worker/src/blueprints/context/OnSetAsNextContext.ts
@@ -26,6 +26,8 @@ import { protectString } from '@sofie-automation/corelib/dist/protectedString'
 import { BlueprintQuickLookInfo } from '@sofie-automation/blueprints-integration/dist/context/quickLoopInfo'
 import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { selectNewPartWithOffsets } from '../../playout/moveNextPart.js'
+import { getOrderedPartsAfterPlayhead } from '../../playout/lookahead/util.js'
+import { convertPartToBlueprints } from './lib.js'
 
 export class OnSetAsNextContext
 	extends ShowStyleUserContext
@@ -55,6 +57,10 @@ export class OnSetAsNextContext
 
 	public get currentPartState(): ActionPartChange {
 		return this.partAndPieceInstanceService.nextPartState
+	}
+
+	async getUpcomingParts(limit: number = 5): Promise<ReadonlyDeep<IBlueprintPart[]>> {
+		return getOrderedPartsAfterPlayhead(this.jobContext, this.playoutModel, limit).map(convertPartToBlueprints)
 	}
 
 	async getPartInstance(part: 'current' | 'next'): Promise<IBlueprintPartInstance<unknown> | undefined> {


### PR DESCRIPTION
## About the Contributor

This pull request is posted on behalf of the BBC.

## Type of Contribution

This is a Feature

## Current Behavior

This pull request extends the work done in https://github.com/Sofie-Automation/sofie-core/pull/1524

The `getUpcomingParts` method was available in `onTake` and action execution contexts, but was missing from the `onSetAsNext` context. This limited blueprints' ability to access information about upcoming parts when a part is being set as next.

## New Behavior

The `getUpcomingParts` method is now available in the `onSetAsNext` context, providing blueprints with the ability to query upcoming parts in the rundown during the `onSetAsNext` callback. This matches the functionality already available in `onTake` and action contexts.

**API Addition:**

```typescript
async getUpcomingParts(limit?: number): Promise<ReadonlyDeep<IBlueprintPart[]>>
```

This method returns a list of the upcoming Parts in the Rundown, in the order they will be Taken, with a default limit of 5 parts.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [x] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

This PR affects:
* The `IOnSetAsNextContext` interface in the blueprints-integration package
* The `OnSetAsNextContext` implementation in the job-worker package
* Blueprint API surface - blueprints can now use `context.getUpcomingParts()` inside `onSetAsNext` callbacks

## Time Frame

* Not urgent, but we would like to get this merged into the in-development release.

## Other Information

Implementation details:

- Uses the existing `getOrderedPartsAfterPlayhead` utility function (same as OnTakeContext)
- Returns up to 5 parts by default (configurable via optional limit parameter)
- Properly typed with `ReadonlyDeep` to prevent accidental mutations
- Follows the same pattern as the existing implementation in OnTakeContext

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
