### PR TITLE
Show lint errors as diff if they are fixable

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -474,7 +474,7 @@ jobs:
         run: |
           cd packages/${{ matrix.package-name }}
           yarn lint --fix
-          git diff --exit-code || (echo "Lint errors found in package ${{ matrix.package-name }}" && exit 1)
+          git diff --exit-code . || (echo "Lint errors found in package ${{ matrix.package-name }}" && exit 1)
         env:
           CI: true
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

## Type of Contribution

This is a CI improvement

## Current Behavior

<img width="921" height="243" alt="image" src="https://github.com/user-attachments/assets/8957f93f-43d4-466a-986f-93daf361bf3d" />

## New Behavior

<img width="1181" height="592" alt="image" src="https://github.com/user-attachments/assets/01a84ef4-c838-407e-93a7-667aa57c293f" />

This would have saved me loads of time if it existed before as the exact error was very unclear to me from the initial message, especially as I had confusion over the line numbers and locally the error didn't reproduce straight away.

## Testing

CI only. I've tested it by branching this PR from a broken point.

### Affected areas

This affects CI.

## Time Frame

* Not urgent, but we would like to get this merged into the in-development release.


## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request modifies the GitHub Actions workflow to improve lint error handling in the package matrix job. The changes introduce automatic lint error fixing with visual diff output.

## Changes Made

**File: `.github/workflows/node.yaml`**

The lint-packages job's linting step has been updated to:

1. Run `yarn lint --fix` to automatically apply fixable lint corrections
2. Use `git diff --exit-code .` to display any remaining changes as a diff
3. Fail the CI job with an explicit error message if lint errors persist after auto-fixing

The diff is scoped to the current package directory (`.`) rather than the entire repository, preventing false failures caused by unrelated changes to files like `packages/.yarnrc.yml` that may be modified during CI setup.

## Impact

This change enables developers to see exactly which lint errors were detected and which fixes were applied, improving the debugging experience when lint checks fail. The auto-fix capability reduces friction by handling simple style corrections automatically, while still catching unfixable or semantic issues that require manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->