### PR TITLE
fix: remove over-eager debug logging filtering from connectionManager

### DIFF
--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -262,6 +262,12 @@ export class TSRHandler {
 			const device = this._coreTsrHandlers[id]?._device
 			const name = `Device "${device?.deviceName ?? id}" (${device?.instanceId ?? 'instance unknown'})`
 
+			if (!e || !('message' in e)) {
+				return {
+					message: name + ': ' + 'Unknown error: ' + JSON.stringify(e),
+				}
+			}
+
 			return {
 				message: e.message && name + ': ' + e.message,
 				name: e.name && name + ': ' + e.name,
@@ -368,7 +374,7 @@ export class TSRHandler {
 		this.tsr.connectionManager.on('connectionEvent:debug', (id, ...args) => {
 			const device = this._coreTsrHandlers[id]?._device
 
-			if (!device?.debugLogging && !this._coreHandler.logDebug) {
+			if (!this._coreHandler.logDebug) {
 				return
 			}
 			if (args.length === 0) {


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a:

<!-- (pick one) -->

Bug fix

## Current Behavior

The event handler for `connectionEvent:debug` inside playout gateway's `tsrHandler.ts` is a bit too nosy, checking the device config, before forwarding the logging to the logger. If for whatever reason, the config states between the two sides gets mismatched, the logging will not be forwarded.

## New Behavior

Since device-level logging filtering is already handled by TSR, there's no point in checking this twice. Checking if top-level debug logging is enabled at this point should be enough.

Additionally, handle a case if a non-Error value is emitted (such as undefined) in `fixError`.

<!--
What is the new behavior?
-->

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->
This PR fixes a potential issue in the logging output of Playout Gateway.

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->
Not urgent, but we would like to get this merged into the in-development release.

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR removes redundant device-level debug logging filtering from the Playout Gateway's `tsrHandler.ts` file, and improves error handling for non-Error values.

### Changes

**Debug Logging Gate Simplification (lines 374-387)**
- The `connectionEvent:debug` handler now gates debug output solely by the global `logDebug` flag, removing a device-level `debugLogging` check that was previously applied
- This allows debug messages to be emitted whenever global debug logging is enabled, regardless of individual device configuration states
- Rationale: Eliminates duplicate filtering that could suppress logs when device-config state mismatched between different parts of the system; TSR now handles device-level filtering directly

**Error Handling Robustness (lines 261-276)**
- The `fixError` helper function now explicitly handles non-Error values (e.g., `undefined`, plain objects)
- When an error object lacks a `message` property, the function returns a simplified error object with only a generated message (including device name and stringified error representation)
- Previously, such values would be processed without explicit type checking

### Impact
- Logging behavior: Debug messages from device connections may now be emitted more freely when global debug logging is enabled
- Error handling: More resilient handling of unexpected error types emitted to the connection event handler
- No public API changes; affects internal logging of Playout Gateway operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->