### PR TITLE
fix: parent device settings confusing use of config id

### DIFF
--- a/packages/webui/src/client/ui/Settings/SettingsMenu.tsx
+++ b/packages/webui/src/client/ui/Settings/SettingsMenu.tsx
@@ -530,8 +530,8 @@ function SettingsMenuPeripheralDevice({ device }: Readonly<SettingsMenuPeriphera
 				<p>
 					{device.connected ? t('Connected') : t('Disconnected')}, {t('Status')}:{' '}
 					{statusCodeString(t, device.status.statusCode)}
-					{configIdString(t, device.studioAndConfigId?.configId)}
 				</p>
+				<p className="text-s">{configIdString(t, device.studioAndConfigId?.configId)}</p>
 			</NavLink>
 			<hr className="vsubtle" />
 		</>
@@ -561,6 +561,6 @@ function statusCodeString(t: TFunction, statusCode: StatusCode): string {
 }
 
 function configIdString(t: TFunction, configId: string | undefined): string {
-	if (configId) return t(', Config ID: ') + configId
-	else return t(', Unconfigured')
+	if (configId) return t('Config ID: ') + configId
+	else return t('Unconfigured')
 }

--- a/packages/webui/src/client/ui/Settings/Studio/Devices/ParentDevices.tsx
+++ b/packages/webui/src/client/ui/Settings/Studio/Devices/ParentDevices.tsx
@@ -221,7 +221,7 @@ function GenericParentDevicesTable({
 		for (const device of allParentDevices) {
 			options.push({
 				value: device._id,
-				name: device.studioAndConfigId?.configId || unprotectString(device._id),
+				name: device.name || unprotectString(device._id),
 				i: options.length,
 			})
 		}
@@ -239,8 +239,8 @@ function GenericParentDevicesTable({
 			<thead>
 				<tr className="hl">
 					<th key="Name">{t('Name')}</th>
+					<th key="ConfigID">{t('ID')}</th>
 					<th key="GatewayID">{t('Gateway')}</th>
-					<th key="ConfigID">{t('Config ID')}</th>
 					<th key="LastSeen">{t('Last Seen')}</th>
 					<th key="action">&nbsp;</th>
 				</tr>
@@ -318,9 +318,9 @@ function SummaryRow({
 		>
 			<th className="settings-studio-device__name c2">{item.computed.name}</th>
 
-			<th className="settings-studio-device__parent c2">{peripheralDevice?.deviceType || '-'}</th>
+			<th className="settings-studio-device__configID c2">{item.id}</th>
 
-			<th className="settings-studio-device__configID c2">{peripheralDevice?.configId || '-'}</th>
+			<th className="settings-studio-device__parent c2">{peripheralDevice?.deviceType || '-'}</th>
 
 			<th className="settings-studio-device__type c2">
 				{peripheralDevice ? <MomentFromNow date={peripheralDevice.lastSeen} /> : '-'}
@@ -349,9 +349,9 @@ function DeletedSummaryRow({ item, undeleteItemWithId }: Readonly<DeletedSummary
 		<tr>
 			<th className="settings-studio-device__name c2 deleted">{item.defaults.name}</th>
 
-			<th className="settings-studio-device__gateway c2 deleted">-</th>
+			<th className="settings-studio-device__configID c2 deleted">{item.id}</th>
 
-			<th className="settings-studio-device__configID c2 deleted">-</th>
+			<th className="settings-studio-device__gateway c2 deleted">-</th>
 
 			<th className="settings-studio-device__last_seen c2 deleted">-</th>
 
@@ -376,9 +376,9 @@ function OrphanedSummaryRow({ configId, device, createItemWithId }: Readonly<Orp
 		<tr>
 			<th className="settings-studio-device__name c2 deleted">-</th>
 
-			<th className="settings-studio-device__gateway c2 deleted">{device.deviceName || unprotectString(device._id)}</th>
+			<th className="settings-studio-device__configID c2 deleted">{configId}</th>
 
-			<th className="settings-studio-device__configID c2 deleted">{device.studioAndConfigId?.configId || '-'}</th>
+			<th className="settings-studio-device__gateway c2 deleted">{device.deviceName || unprotectString(device._id)}</th>
 
 			<th className="settings-studio-device__last_seen c2 deleted">{<MomentFromNow date={device.lastSeen} />}</th>
 
@@ -415,6 +415,11 @@ function ParentDeviceEditRow({
 		<tr className="expando-details hl" key={item.id + '-details'}>
 			<td colSpan={99}>
 				<div className="properties-grid">
+					<label className="field">
+						<LabelActual label={t('ID')} />
+						{item.id}
+					</label>
+
 					<LabelAndOverrides label={t('Name')} item={item} overrideHelper={overrideHelper} itemKey={'name'}>
 						{(value, handleUpdate) => <TextInputControl value={value} handleUpdate={handleUpdate} />}
 					</LabelAndOverrides>
@@ -466,7 +471,7 @@ function AssignPeripheralDeviceConfigId({
 
 	return (
 		<label className="field">
-			<LabelActual label={'Config ID'} />
+			<LabelActual label={'Peripheral Device'} />
 			<div className="field-content">
 				<DropdownInputControl<PeripheralDeviceId | undefined>
 					options={peripheralDeviceOptions}


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
This pull request is posted on behalf of Superfly

## Type of Contribution

This is a: Bug fix

## Current Behavior

In the Parent devices section of peripheral device, the 'config id' field is confusing and the options change 'randomly'

This appears to be caused by #1539, which seems to have mixed up the peripheral devices and configs. (It would have looked a lot more sane if the configs I was using had been defined by the bluerpints and not added in the ui

This appears to allow for picking a 'config id', but this table is the configs, so it suggests it is picking another row from within the same table, which is not what it is doing.

https://github.com/user-attachments/assets/4054ab3a-6501-408d-a8a3-d42867581bb1



## New Behavior

The 'Config ID' field has been renamed back to 'Peripheral Device' as that is what it is picking, with the option names corrected back to the name of the device, not the configId.

<img width="903" height="317" alt="image" src="https://github.com/user-attachments/assets/1e166755-6e78-460f-9d3d-49ea4cabe97f" />

Additionally, the devices on the left have been tidied a bit, so that the configId is shown on its own line, to avoid the lines growing overly wide and wrapping weirdly
<img width="355" height="137" alt="image" src="https://github.com/user-attachments/assets/fdfd099b-62c4-40a7-9932-c5b70b903f1d" />




## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
