### PR TITLE
feat: Status message customisation

### DIFF
--- a/meteor/__mocks__/helpers/database.ts
+++ b/meteor/__mocks__/helpers/database.ts
@@ -127,6 +127,7 @@ export async function setupMockPeripheralDevice(
 		created: 1234,
 		status: {
 			statusCode: StatusCode.GOOD,
+			statusDetails: [],
 		},
 		lastSeen: 1234,
 		lastConnected: 1234,

--- a/meteor/server/__tests__/cronjobs.test.ts
+++ b/meteor/server/__tests__/cronjobs.test.ts
@@ -510,6 +510,7 @@ describe('cronjobs', () => {
 				name: props.deviceName,
 				status: {
 					statusCode: StatusCode.GOOD,
+					statusDetails: [],
 				},
 				token: '',
 				...props,

--- a/meteor/server/api/__tests__/peripheralDevice.test.ts
+++ b/meteor/server/api/__tests__/peripheralDevice.test.ts
@@ -203,7 +203,7 @@ describe('test peripheralDevice general API methods', () => {
 		})
 		await MeteorCall.peripheralDevice.setStatus(device._id, device.token, {
 			statusCode: StatusCode.WARNING_MINOR,
-			messages: ["Something's not right"],
+			statusDetails: [{ message: "Something's not right" }],
 		})
 		expect(((await PeripheralDevices.findOneAsync(device._id)) as PeripheralDevice).status).toMatchObject({
 			statusCode: StatusCode.WARNING_MINOR,
@@ -650,6 +650,7 @@ describe('test peripheralDevice general API methods', () => {
 				lastSeen: 0,
 				status: {
 					statusCode: StatusCode.GOOD,
+					statusDetails: [],
 				},
 				subType: '_process',
 				token: 'MockToken',

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -2,7 +2,14 @@ import { Meteor } from 'meteor/meteor'
 import { check, Match } from '../lib/check'
 import _ from 'underscore'
 import { PeripheralDeviceType, PeripheralDevice } from '@sofie-automation/corelib/dist/dataModel/PeripheralDevice'
-import { PeripheralDeviceCommands, PeripheralDevices, Rundowns, Studios, UserActionsLog } from '../collections'
+import {
+	PeripheralDeviceCommands,
+	PeripheralDevices,
+	Rundowns,
+	Studios,
+	UserActionsLog,
+	Blueprints,
+} from '../collections'
 import { stringifyObjects, literal } from '@sofie-automation/corelib/dist/lib'
 import { protectString, unprotectString } from '@sofie-automation/corelib/dist/protectedString'
 import { getCurrentTime } from '../lib/lib'
@@ -37,6 +44,7 @@ import {
 	PeripheralDeviceInitOptions,
 	PeripheralDeviceStatusObject,
 	TimelineTriggerTimeResult,
+	DeviceStatusError,
 } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
 import { checkStudioExists } from '../optimizations'
 import {
@@ -65,8 +73,89 @@ import bodyParser from 'koa-bodyparser'
 import { assertConnectionHasOneOfPermissions } from '../security/auth'
 import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { getRootSubpath } from '../lib'
+import { evalBlueprint } from './blueprints/cache'
+import { StudioBlueprintManifest } from '@sofie-automation/blueprints-integration'
+import { ErrorMessageResolver } from '@sofie-automation/corelib'
+import { interpollateTranslation } from '@sofie-automation/corelib/dist/TranslatableMessage'
+import { Blueprint } from '@sofie-automation/corelib/dist/dataModel/Blueprint'
+import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 
 const apmNamespace = 'peripheralDevice'
+
+/**
+ * Resolve device error messages using the Studio blueprint's deviceErrorMessages.
+ * This allows blueprints to customize error messages shown to operators.
+ */
+async function resolveDeviceErrorMessages(
+	studioId: StudioId,
+	deviceName: string,
+	deviceId: PeripheralDeviceId,
+	errors: DeviceStatusError[]
+): Promise<string[]> {
+	try {
+		// Get the studio and its blueprint
+		const studio = (await Studios.findOneAsync(studioId, {
+			projection: { blueprintId: 1 },
+		})) as Pick<DBStudio, 'blueprintId'> | undefined
+
+		if (!studio?.blueprintId) {
+			// No blueprint, return empty (caller will use original messages)
+			return []
+		}
+
+		// Get the blueprint code
+		const blueprint = (await Blueprints.findOneAsync(studio.blueprintId, {
+			projection: { _id: 1, name: 1, code: 1 },
+		})) as Pick<Blueprint, '_id' | 'name' | 'code'> | undefined
+
+		if (!blueprint) {
+			return []
+		}
+
+		// Evaluate the blueprint to get the manifest with deviceErrorMessages
+		const blueprintManifest = evalBlueprint(blueprint) as StudioBlueprintManifest
+
+		if (!blueprintManifest.deviceErrorMessages) {
+			// Blueprint doesn't define any custom error messages
+			return []
+		}
+
+		// Create resolver with the blueprint's error messages
+		const resolver = new ErrorMessageResolver(
+			blueprint._id,
+			blueprintManifest.deviceErrorMessages,
+			undefined // No system error messages
+		)
+
+		// Resolve each error
+		const resolvedMessages: string[] = []
+		for (const error of errors) {
+			const message = resolver.getDeviceErrorMessage(
+				error.code,
+				{
+					deviceName,
+					deviceId: unprotectString(deviceId),
+					...error.context,
+				},
+				error.message // Default message from TSR
+			)
+
+			if (message) {
+				// Interpolate the message template with context values
+				const interpolated = interpollateTranslation(message.key, message.args)
+				resolvedMessages.push(interpolated)
+			}
+			// If message is null, it was suppressed by the blueprint
+		}
+
+		return resolvedMessages
+	} catch (e) {
+		// Log error but don't fail - fall back to original messages
+		logger.error(`Error resolving device error messages: ${e}`)
+		return []
+	}
+}
+
 export namespace ServerPeripheralDeviceAPI {
 	export async function initialize(
 		context: MethodContext,
@@ -201,6 +290,20 @@ export namespace ServerPeripheralDeviceAPI {
 		check(status.statusCode, Number)
 		if (status.statusCode < StatusCode.UNKNOWN || status.statusCode > StatusCode.FATAL) {
 			throw new Meteor.Error(400, 'device status code is not known')
+		}
+
+		// Resolve error messages using Studio blueprint if structured errors are present
+		if (status.errors && status.errors.length > 0 && peripheralDevice.studioAndConfigId) {
+			const resolvedMessages = await resolveDeviceErrorMessages(
+				peripheralDevice.studioAndConfigId.studioId,
+				peripheralDevice.name,
+				peripheralDevice._id,
+				status.errors
+			)
+			if (resolvedMessages.length > 0) {
+				// Replace the pre-formatted messages with blueprint-customized ones
+				status.messages = resolvedMessages
+			}
 		}
 
 		// check if we have to update something:

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -44,7 +44,7 @@ import {
 	PeripheralDeviceInitOptions,
 	PeripheralDeviceStatusObject,
 	TimelineTriggerTimeResult,
-	DeviceStatusError,
+	DeviceStatusDetail,
 } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
 import { checkStudioExists } from '../optimizations'
 import {
@@ -83,20 +83,20 @@ import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 const apmNamespace = 'peripheralDevice'
 
 /**
- * Resolve device error messages using the Studio blueprint's deviceErrorMessages.
+ * Resolve device status details using the Studio blueprint's deviceErrorMessages.
  * This allows blueprints to customize error messages shown to operators.
  *
  * @param studioId - The studio ID to look up the blueprint
  * @param deviceName - The peripheral device name (shorter than TSR's internal name)
  * @param deviceId - The peripheral device ID
- * @param errors - Structured errors from TSR
+ * @param statusDetails - Structured status details from TSR
  * @param defaultMessages - The original messages from TSR (used as fallback)
  */
-async function resolveDeviceErrorMessages(
+async function resolveDeviceStatusDetails(
 	studioId: StudioId,
 	deviceName: string,
 	deviceId: PeripheralDeviceId,
-	errors: DeviceStatusError[],
+	statusDetails: DeviceStatusDetail[],
 	defaultMessages: string[]
 ): Promise<string[]> {
 	try {
@@ -139,18 +139,18 @@ async function resolveDeviceErrorMessages(
 			undefined // No system error messages
 		)
 
-		// Resolve each error
+		// Resolve each status detail
 		const resolvedMessages: string[] = []
-		for (let i = 0; i < errors.length; i++) {
-			const error = errors[i]
+		for (let i = 0; i < statusDetails.length; i++) {
+			const statusDetail = statusDetails[i]
 			// Use the original TSR message as fallback, or error code if not available
-			const defaultMessage = defaultMessages[i] ?? error.code
+			const defaultMessage = defaultMessages[i] ?? statusDetail.code
 
-			logger.debug(`Resolving error code: ${error.code}, context: ${JSON.stringify(error.context)}`)
+			logger.debug(`Resolving error code: ${statusDetail.code}, context: ${JSON.stringify(statusDetail.context)}`)
 			const message = resolver.getDeviceErrorMessage(
-				error.code,
+				statusDetail.code,
 				{
-					...error.context,
+					...statusDetail.context,
 					// Override with peripheral device info (TSR might have longer names)
 					deviceName,
 					deviceId: unprotectString(deviceId),
@@ -161,10 +161,10 @@ async function resolveDeviceErrorMessages(
 			if (message) {
 				// Interpolate the message template with context values
 				const interpolated = interpollateTranslation(message.key, message.args)
-				logger.debug(`Resolved message for ${error.code}: ${interpolated}`)
+				logger.debug(`Resolved message for ${statusDetail.code}: ${interpolated}`)
 				resolvedMessages.push(interpolated)
 			} else {
-				logger.debug(`Message suppressed for ${error.code}`)
+				logger.debug(`Message suppressed for ${statusDetail.code}`)
 			}
 		}
 
@@ -323,14 +323,14 @@ export namespace ServerPeripheralDeviceAPI {
 		}
 
 		logger.info(
-			`Device ${deviceId} setStatus: errors=${status.errors?.length ?? 'undefined'}, messages=${status.messages?.length ?? 'undefined'}, studioId=${studioId ?? 'none'}`
+			`Device ${deviceId} setStatus: statusDetails=${status.statusDetails?.length ?? 'undefined'}, messages=${status.messages?.length ?? 'undefined'}, studioId=${studioId ?? 'none'}`
 		)
-		if (status.errors && status.errors.length > 0 && studioId) {
-			const resolvedMessages = await resolveDeviceErrorMessages(
+		if (status.statusDetails && status.statusDetails.length > 0 && studioId) {
+			const resolvedMessages = await resolveDeviceStatusDetails(
 				studioId,
 				peripheralDevice.name,
 				peripheralDevice._id,
-				status.errors,
+				status.statusDetails,
 				status.messages ?? []
 			)
 			if (resolvedMessages.length > 0) {

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -143,9 +143,14 @@ async function resolveDeviceStatusDetails(
 		const resolvedMessages: string[] = []
 		for (let i = 0; i < statusDetails.length; i++) {
 			const statusDetail = statusDetails[i]
-			// Use the original TSR message as fallback (statusDetail.message is the pre-rendered TSR string,
-			// more useful than the raw error code string)
-			const defaultMessage = defaultMessages[i] ?? statusDetail.message ?? statusDetail.code
+			// statusDetail.message is always pre-rendered by TSR; use it as fallback if no defaultMessages entry
+			const defaultMessage = defaultMessages[i] ?? statusDetail.message
+
+			if (!statusDetail.code) {
+				// No structured code - use the pre-rendered TSR message directly
+				resolvedMessages.push(defaultMessage)
+				continue
+			}
 
 			logger.debug(
 				`Resolving status code: ${statusDetail.code}, context: ${JSON.stringify(statusDetail.context)}`
@@ -257,6 +262,7 @@ export namespace ServerPeripheralDeviceAPI {
 				created: getCurrentTime(),
 				status: {
 					statusCode: StatusCode.UNKNOWN,
+					statusDetails: [],
 				},
 				connected: true,
 				connectionId: options.connectionId,
@@ -330,19 +336,23 @@ export namespace ServerPeripheralDeviceAPI {
 		}
 
 		logger.info(
-			`Device ${deviceId} setStatus: statusDetails=${status.statusDetails?.length ?? 'undefined'}, messages=${status.messages?.length ?? 'undefined'}, studioId=${studioId ?? 'none'}`
+			`Device ${deviceId} setStatus: statusDetails=${status.statusDetails.length}, messages=${status.messages?.length ?? 'undefined'}, studioId=${studioId ?? 'none'}`
 		)
-		if (status.statusDetails && status.statusDetails.length > 0 && studioId) {
-			const resolvedMessages = await resolveDeviceStatusDetails(
-				studioId,
-				peripheralDevice.name,
-				peripheralDevice._id,
-				status.statusDetails,
-				status.messages ?? []
-			)
-			if (resolvedMessages.length > 0) {
-				// Replace the pre-formatted messages with blueprint-customized ones
-				status.messages = resolvedMessages
+		if (status.statusDetails.length > 0) {
+			if (studioId) {
+				const resolvedMessages = await resolveDeviceStatusDetails(
+					studioId,
+					peripheralDevice.name,
+					peripheralDevice._id,
+					status.statusDetails,
+					status.messages ?? []
+				)
+				// Use blueprint-resolved messages if available, otherwise fall back to statusDetails messages
+				status.messages =
+					resolvedMessages.length > 0 ? resolvedMessages : status.statusDetails.map((d) => d.message)
+			} else {
+				// No studio context, derive messages directly from statusDetails
+				status.messages = status.statusDetails.map((d) => d.message)
 			}
 		}
 

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -75,7 +75,7 @@ import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { getRootSubpath } from '../lib'
 import { evalBlueprint } from './blueprints/cache'
 import { StudioBlueprintManifest } from '@sofie-automation/blueprints-integration'
-import { ErrorMessageResolver } from '@sofie-automation/corelib'
+import { StatusMessageResolver } from '@sofie-automation/corelib'
 import { interpollateTranslation } from '@sofie-automation/corelib/dist/TranslatableMessage'
 import { Blueprint } from '@sofie-automation/corelib/dist/dataModel/Blueprint'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
@@ -83,8 +83,8 @@ import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 const apmNamespace = 'peripheralDevice'
 
 /**
- * Resolve device status details using the Studio blueprint's deviceErrorMessages.
- * This allows blueprints to customize error messages shown to operators.
+ * Resolve device status details using the Studio blueprint's deviceStatusMessages.
+ * This allows blueprints to customize status messages shown to operators.
  *
  * @param studioId - The studio ID to look up the blueprint
  * @param deviceName - The peripheral device name (shorter than TSR's internal name)
@@ -119,23 +119,23 @@ async function resolveDeviceStatusDetails(
 			return []
 		}
 
-		// Evaluate the blueprint to get the manifest with deviceErrorMessages
+		// Evaluate the blueprint to get the manifest with deviceStatusMessages
 		const blueprintManifest = evalBlueprint(blueprint) as StudioBlueprintManifest
 
 		logger.debug(
-			`Blueprint ${blueprint._id} deviceErrorMessages keys: ${Object.keys(blueprintManifest.deviceErrorMessages ?? {}).join(', ')}`
+			`Blueprint ${blueprint._id} deviceStatusMessages keys: ${Object.keys(blueprintManifest.deviceStatusMessages ?? {}).join(', ')}`
 		)
 
-		if (!blueprintManifest.deviceErrorMessages) {
-			// Blueprint doesn't define any custom error messages
-			logger.debug(`Blueprint ${blueprint._id} has no deviceErrorMessages`)
+		if (!blueprintManifest.deviceStatusMessages) {
+			// Blueprint doesn't define any custom status messages
+			logger.debug(`Blueprint ${blueprint._id} has no deviceStatusMessages`)
 			return []
 		}
 
-		// Create resolver with the blueprint's error messages
-		const resolver = new ErrorMessageResolver(
+		// Create resolver with the blueprint's status messages
+		const resolver = new StatusMessageResolver(
 			blueprint._id,
-			blueprintManifest.deviceErrorMessages,
+			blueprintManifest.deviceStatusMessages,
 			undefined // No system error messages
 		)
 
@@ -143,11 +143,14 @@ async function resolveDeviceStatusDetails(
 		const resolvedMessages: string[] = []
 		for (let i = 0; i < statusDetails.length; i++) {
 			const statusDetail = statusDetails[i]
-			// Use the original TSR message as fallback, or error code if not available
-			const defaultMessage = defaultMessages[i] ?? statusDetail.code
+			// Use the original TSR message as fallback (statusDetail.message is the pre-rendered TSR string,
+			// more useful than the raw error code string)
+			const defaultMessage = defaultMessages[i] ?? statusDetail.message ?? statusDetail.code
 
-			logger.debug(`Resolving error code: ${statusDetail.code}, context: ${JSON.stringify(statusDetail.context)}`)
-			const message = resolver.getDeviceErrorMessage(
+			logger.debug(
+				`Resolving status code: ${statusDetail.code}, context: ${JSON.stringify(statusDetail.context)}`
+			)
+			const message = resolver.getDeviceStatusMessage(
 				statusDetail.code,
 				{
 					...statusDetail.context,
@@ -163,7 +166,11 @@ async function resolveDeviceStatusDetails(
 				const interpolated = interpollateTranslation(message.key, message.args)
 				logger.debug(`Resolved message for ${statusDetail.code}: ${interpolated}`)
 				resolvedMessages.push(interpolated)
+				// Also mutate statusDetail.message so the UI can read from statusDetails[].message directly
+				statusDetail.message = interpolated
 			} else {
+				// Message suppressed by blueprint - clear the message so the UI doesn't show the raw TSR message
+				statusDetail.message = ''
 				logger.debug(`Message suppressed for ${statusDetail.code}`)
 			}
 		}
@@ -171,7 +178,7 @@ async function resolveDeviceStatusDetails(
 		return resolvedMessages
 	} catch (e) {
 		// Log error but don't fail - fall back to original messages
-		logger.error(`Error resolving device error messages: ${e}`)
+		logger.error(`Error resolving device status messages: ${e}`)
 		return []
 	}
 }
@@ -312,7 +319,7 @@ export namespace ServerPeripheralDeviceAPI {
 			throw new Meteor.Error(400, 'device status code is not known')
 		}
 
-		// Resolve error messages using Studio blueprint if structured errors are present
+		// Resolve status messages using Studio blueprint if structured status details are present
 		// Child devices (like casparcg0) don't have studioAndConfigId directly - get it from parent
 		let studioId = peripheralDevice.studioAndConfigId?.studioId
 		if (!studioId && peripheralDevice.parentDeviceId) {

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -336,9 +336,9 @@ export namespace ServerPeripheralDeviceAPI {
 		}
 
 		logger.info(
-			`Device ${deviceId} setStatus: statusDetails=${status.statusDetails.length}, messages=${status.messages?.length ?? 'undefined'}, studioId=${studioId ?? 'none'}`
+			`Device ${deviceId} setStatus: statusDetails=${status.statusDetails?.length ?? 'undefined'}, messages=${status.messages?.length ?? 'undefined'}, studioId=${studioId ?? 'none'}`
 		)
-		if (status.statusDetails.length > 0) {
+		if (status.statusDetails && status.statusDetails.length > 0) {
 			if (studioId) {
 				const resolvedMessages = await resolveDeviceStatusDetails(
 					studioId,

--- a/meteor/server/systemStatus/__tests__/systemStatus.test.ts
+++ b/meteor/server/systemStatus/__tests__/systemStatus.test.ts
@@ -90,6 +90,7 @@ describe('systemStatus', () => {
 			$set: {
 				status: literal<PeripheralDeviceStatusObject>({
 					statusCode: StatusCode.WARNING_MAJOR,
+					statusDetails: [],
 					messages: [],
 				}),
 			},
@@ -116,6 +117,7 @@ describe('systemStatus', () => {
 			$set: {
 				status: literal<PeripheralDeviceStatusObject>({
 					statusCode: StatusCode.GOOD,
+					statusDetails: [],
 					messages: [],
 				}),
 			},

--- a/meteor/yarn.lock
+++ b/meteor/yarn.lock
@@ -2421,7 +2421,7 @@ __metadata:
   dependencies:
     "@mos-connection/model": "npm:^5.0.0-alpha.0"
     kairos-lib: "npm:^1.0.0"
-    timeline-state-resolver-types: "npm:10.0.0-nightly-main-20260429-110933-d01800ef9.0"
+    timeline-state-resolver-types: "npm:10.0.0-nightly-main-20260514-152958-5f6033589.0"
     tslib: "npm:^2.8.1"
     type-fest: "npm:^4.41.0"
   languageName: node
@@ -12415,13 +12415,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"timeline-state-resolver-types@npm:10.0.0-nightly-main-20260429-110933-d01800ef9.0":
-  version: 10.0.0-nightly-main-20260429-110933-d01800ef9.0
-  resolution: "timeline-state-resolver-types@npm:10.0.0-nightly-main-20260429-110933-d01800ef9.0"
+"timeline-state-resolver-types@npm:10.0.0-nightly-main-20260514-152958-5f6033589.0":
+  version: 10.0.0-nightly-main-20260514-152958-5f6033589.0
+  resolution: "timeline-state-resolver-types@npm:10.0.0-nightly-main-20260514-152958-5f6033589.0"
   dependencies:
     kairos-lib: "npm:1.0.0"
     tslib: "npm:^2.8.1"
-  checksum: 10/cbd39136ce786cdcde9faa72242e256bb3dbbf27b28088399924544f2f7a655cfc39f77b035ee0b46b4dfed86ee379869104d7ee64b75b04519adb51d367a853
+  checksum: 10/debb3faa9eda1f4ab2a85165c052cfc5b8698367d5a84be8b4095dbdaf6a40175e4c5ec80f09199e7650b53280e8c730f85bbd30685e08d3ea382ca08ee84e8b
   languageName: node
   linkType: hard
 

--- a/packages/blueprints-integration/src/api/studio.ts
+++ b/packages/blueprints-integration/src/api/studio.ts
@@ -41,6 +41,24 @@ import type { MosGatewayConfig } from '@sofie-automation/shared-lib/dist/generat
 import type { PlayoutGatewayConfig } from '@sofie-automation/shared-lib/dist/generated/PlayoutGatewayConfigTypes'
 import type { LiveStatusGatewayConfig } from '@sofie-automation/shared-lib/dist/generated/LiveStatusGatewayOptionsTypes'
 
+/**
+ * Context provided to device error message functions.
+ * Contains the device name, device ID, and any additional context from the TSR error.
+ */
+export interface DeviceErrorContext {
+	/** Human-readable name of the device */
+	deviceName: string
+	/** Internal device ID */
+	deviceId?: string
+	/** Additional context values from the TSR error (e.g., host, port, channel, etc.) */
+	[key: string]: unknown
+}
+
+/**
+ * A function that receives device error context and returns a custom error message.
+ */
+export type DeviceErrorMessageFunction = (context: DeviceErrorContext) => string
+
 export interface StudioBlueprintManifest<
 	TRawConfig = IBlueprintConfig,
 	TProcessedConfig = unknown,
@@ -55,6 +73,39 @@ export interface StudioBlueprintManifest<
 
 	/** Translations connected to the studio (as stringified JSON) */
 	translations?: string
+
+	/**
+	 * Alternate device error messages, to override the default messages from TSR devices.
+	 * Keys are error code strings from TSR devices (e.g., 'DEVICE_ATEM_DISCONNECTED').
+	 *
+	 * Import error codes from 'timeline-state-resolver-types' for type safety.
+	 * Values can be:
+	 * - String templates using {{variable}} syntax for interpolation with context values
+	 * - Functions that receive DeviceErrorContext and return a custom message string
+	 * - Empty string to suppress the error message entirely
+	 *
+	 * @example
+	 * ```typescript
+	 * import { AtemErrorCode, CasparCGErrorCode } from 'timeline-state-resolver-types'
+	 *
+	 * deviceErrorMessages: {
+	 *   // String template with placeholders
+	 *   [AtemErrorCode.DISCONNECTED]: 'Vision mixer offline - check network to {{host}}',
+	 *   [AtemErrorCode.PSU_FAULT]: 'PSU {{psuNumber}} needs attention',
+	 *
+	 *   // Function for complex conditional logic
+	 *   [CasparCGErrorCode.CHANNEL_ERROR]: (context) => {
+	 *     const channel = context.channel as number
+	 *     if (channel === 1) return 'Primary graphics output failed!'
+	 *     return `Graphics channel ${channel} error on ${context.deviceName}`
+	 *   },
+	 *
+	 *   // Suppress a noisy error
+	 *   [SomeErrorCode.NOISY_ERROR]: '',
+	 * }
+	 * ```
+	 */
+	deviceErrorMessages?: Record<string, string | DeviceErrorMessageFunction | undefined>
 
 	/** Returns the items used to build the baseline (default state) of a studio, this is the baseline used when there's no active rundown */
 	getBaseline: (context: IStudioBaselineContext) => BlueprintResultStudioBaseline

--- a/packages/blueprints-integration/src/api/studio.ts
+++ b/packages/blueprints-integration/src/api/studio.ts
@@ -56,8 +56,10 @@ export interface DeviceErrorContext {
 
 /**
  * A function that receives device error context and returns a custom error message.
+ * Return `undefined` to fall back to the default TSR message.
+ * Return an empty string `''` to suppress the message entirely.
  */
-export type DeviceErrorMessageFunction = (context: DeviceErrorContext) => string
+export type DeviceErrorMessageFunction = (context: DeviceErrorContext) => string | undefined
 
 export interface StudioBlueprintManifest<
 	TRawConfig = IBlueprintConfig,

--- a/packages/blueprints-integration/src/api/studio.ts
+++ b/packages/blueprints-integration/src/api/studio.ts
@@ -42,10 +42,10 @@ import type { PlayoutGatewayConfig } from '@sofie-automation/shared-lib/dist/gen
 import type { LiveStatusGatewayConfig } from '@sofie-automation/shared-lib/dist/generated/LiveStatusGatewayOptionsTypes'
 
 /**
- * Context provided to device error message functions.
- * Contains the device name, device ID, and any additional context from the TSR error.
+ * Context provided to device status message functions.
+ * Contains the device name, device ID, and any additional context from the TSR status detail.
  */
-export interface DeviceErrorContext {
+export interface DeviceStatusContext {
 	/** Human-readable name of the device */
 	deviceName: string
 	/** Internal device ID */
@@ -55,11 +55,11 @@ export interface DeviceErrorContext {
 }
 
 /**
- * A function that receives device error context and returns a custom error message.
+ * A function that receives device status context and returns a custom status message.
  * Return `undefined` to fall back to the default TSR message.
  * Return an empty string `''` to suppress the message entirely.
  */
-export type DeviceErrorMessageFunction = (context: DeviceErrorContext) => string | undefined
+export type DeviceStatusMessageFunction = (context: DeviceStatusContext) => string | undefined
 
 export interface StudioBlueprintManifest<
 	TRawConfig = IBlueprintConfig,
@@ -77,37 +77,37 @@ export interface StudioBlueprintManifest<
 	translations?: string
 
 	/**
-	 * Alternate device error messages, to override the default messages from TSR devices.
-	 * Keys are error code strings from TSR devices (e.g., 'DEVICE_ATEM_DISCONNECTED').
+	 * Alternate device status messages, to override the default messages from TSR devices.
+	 * Keys are status code strings from TSR devices (e.g., 'DEVICE_ATEM_DISCONNECTED').
 	 *
-	 * Import error codes from 'timeline-state-resolver-types' for type safety.
+	 * Import status codes from 'timeline-state-resolver-types' for type safety.
 	 * Values can be:
 	 * - String templates using {{variable}} syntax for interpolation with context values
-	 * - Functions that receive DeviceErrorContext and return a custom message string
-	 * - Empty string to suppress the error message entirely
+	 * - Functions that receive DeviceStatusContext and return a custom message string
+	 * - Empty string to suppress the status message entirely
 	 *
 	 * @example
 	 * ```typescript
-	 * import { AtemErrorCode, CasparCGErrorCode } from 'timeline-state-resolver-types'
+	 * import { AtemStatusCode, CasparCGStatusCode } from 'timeline-state-resolver-types'
 	 *
-	 * deviceErrorMessages: {
+	 * deviceStatusMessages: {
 	 *   // String template with placeholders
-	 *   [AtemErrorCode.DISCONNECTED]: 'Vision mixer offline - check network to {{host}}',
-	 *   [AtemErrorCode.PSU_FAULT]: 'PSU {{psuNumber}} needs attention',
+	 *   [AtemStatusCode.DISCONNECTED]: 'Vision mixer offline - check network to {{host}}',
+	 *   [AtemStatusCode.PSU_FAULT]: 'PSU {{psuNumber}} needs attention',
 	 *
 	 *   // Function for complex conditional logic
-	 *   [CasparCGErrorCode.CHANNEL_ERROR]: (context) => {
+	 *   [CasparCGStatusCode.CHANNEL_ERROR]: (context) => {
 	 *     const channel = context.channel as number
 	 *     if (channel === 1) return 'Primary graphics output failed!'
 	 *     return `Graphics channel ${channel} error on ${context.deviceName}`
 	 *   },
 	 *
-	 *   // Suppress a noisy error
-	 *   [SomeErrorCode.NOISY_ERROR]: '',
+	 *   // Suppress a noisy message
+	 *   [SomeStatusCode.NOISY_STATUS]: '',
 	 * }
 	 * ```
 	 */
-	deviceErrorMessages?: Record<string, string | DeviceErrorMessageFunction | undefined>
+	deviceStatusMessages?: Record<string, string | DeviceStatusMessageFunction>
 
 	/** Returns the items used to build the baseline (default state) of a studio, this is the baseline used when there's no active rundown */
 	getBaseline: (context: IStudioBaselineContext) => BlueprintResultStudioBaseline

--- a/packages/blueprints-integration/src/api/system.ts
+++ b/packages/blueprints-integration/src/api/system.ts
@@ -2,12 +2,34 @@ import type { IBlueprintTriggeredActions } from '../triggers.js'
 import type { BlueprintManifestBase, BlueprintManifestType } from './base.js'
 import type { ICoreSystemApplyConfigContext } from '../context/systemApplyConfigContext.js'
 import type { ICoreSystemSettings } from '@sofie-automation/shared-lib/dist/core/model/CoreSystemSettings'
+import type { SystemErrorCode } from '@sofie-automation/shared-lib/dist/systemErrorMessages'
+
+// Re-export so blueprints can import from blueprints-integration
+export { SystemErrorCode } from '@sofie-automation/shared-lib/dist/systemErrorMessages'
 
 export interface SystemBlueprintManifest extends BlueprintManifestBase {
 	blueprintType: BlueprintManifestType.SYSTEM
 
 	/** Translations connected to the studio (as stringified JSON) */
 	translations?: string
+
+	/**
+	 * Alternate system error messages, to override the builtin ones produced by Sofie.
+	 * Keys are SystemErrorCode values (e.g., 'DATABASE_CONNECTION_LOST').
+	 *
+	 * Templates use {{variable}} syntax for interpolation with context values.
+	 *
+	 * @example
+	 * ```typescript
+	 * import { SystemErrorCode } from '@sofie-automation/blueprints-integration'
+	 *
+	 * systemErrorMessages: {
+	 *   [SystemErrorCode.DATABASE_CONNECTION_LOST]: 'Database offline - contact IT support',
+	 *   [SystemErrorCode.SERVICE_UNAVAILABLE]: 'Service {{serviceName}} is not responding',
+	 * }
+	 * ```
+	 */
+	systemErrorMessages?: Partial<Record<SystemErrorCode | string, string | undefined>>
 
 	/**
 	 * Apply the config by generating the data to be saved into the db.

--- a/packages/corelib/src/ErrorMessageResolver.ts
+++ b/packages/corelib/src/ErrorMessageResolver.ts
@@ -1,0 +1,155 @@
+import { BlueprintId } from './dataModel/Ids.js'
+import { generateTranslation } from './lib.js'
+import { ITranslatableMessage, wrapTranslatableMessageFromBlueprints } from './TranslatableMessage.js'
+import { SystemErrorCode } from '@sofie-automation/shared-lib/dist/systemErrorMessages'
+import type { DeviceErrorContext, DeviceErrorMessageFunction } from '@sofie-automation/blueprints-integration'
+
+// Re-export for consumers of corelib
+export type { DeviceErrorContext, DeviceErrorMessageFunction }
+
+/**
+ * Default error messages for system errors
+ */
+const DEFAULT_SYSTEM_ERROR_MESSAGES: Record<SystemErrorCode, ITranslatableMessage> = {
+	[SystemErrorCode.DATABASE_CONNECTION_LOST]: generateTranslation('Database connection to {{database}} lost'),
+	[SystemErrorCode.INSUFFICIENT_RESOURCES]: generateTranslation(
+		'Insufficient {{resource}}: {{available}} available, {{required}} required'
+	),
+	[SystemErrorCode.SERVICE_UNAVAILABLE]: generateTranslation('Service {{service}} unavailable: {{reason}}'),
+}
+
+/**
+ * Device error messages map - can contain string templates or functions.
+ * Functions are evaluated at runtime, strings use {{variable}} interpolation.
+ */
+export type DeviceErrorMessages = Record<string, string | DeviceErrorMessageFunction | undefined>
+
+/**
+ * System error messages map - string templates only.
+ * Uses {{variable}} interpolation.
+ */
+export type SystemErrorMessages = Partial<Record<SystemErrorCode | string, string | undefined>>
+
+/**
+ * Resolves error messages with blueprint customizations.
+ * Works with runtime blueprint manifests (evaluated at setStatus time).
+ *
+ * For device errors, the default message templates come from TSR devices.
+ * Studio blueprints can override these by providing custom templates or functions in deviceErrorMessages.
+ *
+ * For system errors, System blueprints can override the defaults in systemErrorMessages.
+ *
+ * @example
+ * ```typescript
+ * import { AtemErrorCode, AtemErrorMessages } from 'timeline-state-resolver-types'
+ *
+ * // Get blueprint manifest at runtime (from evalBlueprint or similar)
+ * const studioManifest = await getBlueprintManifest(studioBlueprintId)
+ *
+ * // Create resolver for device errors
+ * const resolver = new ErrorMessageResolver(
+ *   studioBlueprintId,
+ *   studioManifest.deviceErrorMessages
+ * )
+ *
+ * // Resolve device error - pass default message from TSR
+ * const message = resolver.getDeviceErrorMessage(
+ *   AtemErrorCode.DISCONNECTED,
+ *   { deviceName: 'Vision Mixer', host: '192.168.1.10' },
+ *   AtemErrorMessages[AtemErrorCode.DISCONNECTED]
+ * )
+ * ```
+ */
+export class ErrorMessageResolver {
+	readonly #blueprintId: BlueprintId | undefined
+	readonly #deviceErrorMessages: DeviceErrorMessages | undefined
+	readonly #systemErrorMessages: SystemErrorMessages | undefined
+
+	constructor(
+		blueprintId: BlueprintId | undefined,
+		deviceErrorMessages?: DeviceErrorMessages | undefined,
+		systemErrorMessages?: SystemErrorMessages | undefined
+	) {
+		this.#blueprintId = blueprintId
+		this.#deviceErrorMessages = deviceErrorMessages
+		this.#systemErrorMessages = systemErrorMessages
+	}
+
+	/**
+	 * Get a translatable message for a device error.
+	 *
+	 * @param errorCode - The error code string from TSR (e.g., 'DEVICE_ATEM_DISCONNECTED')
+	 * @param context - Context values for message interpolation (deviceName, deviceId, and TSR error context)
+	 * @param defaultMessage - The default message template from TSR (e.g., 'ATEM disconnected from {{host}}')
+	 * @returns ITranslatableMessage with the resolved message, or null if suppressed
+	 */
+	getDeviceErrorMessage(
+		errorCode: string,
+		context: DeviceErrorContext,
+		defaultMessage: string
+	): ITranslatableMessage | null {
+		// Check blueprint messages from Studio blueprint manifest
+		if (this.#deviceErrorMessages) {
+			const blueprintMessage = this.#deviceErrorMessages[errorCode]
+
+			if (blueprintMessage === '') {
+				// Empty string means suppress the message
+				return null
+			}
+
+			if (typeof blueprintMessage === 'function') {
+				// Function: evaluate at runtime with full context
+				const result = blueprintMessage(context)
+				if (result === '') return null // Function can also suppress
+
+				return this.#blueprintId
+					? wrapTranslatableMessageFromBlueprints({ key: result, args: context }, [this.#blueprintId])
+					: { key: result, args: context }
+			}
+
+			if (blueprintMessage) {
+				// String template: use as-is with interpolation
+				return this.#blueprintId
+					? wrapTranslatableMessageFromBlueprints({ key: blueprintMessage, args: context }, [this.#blueprintId])
+					: { key: blueprintMessage, args: context }
+			}
+		}
+
+		// Use default message from TSR
+		return {
+			key: defaultMessage,
+			args: context,
+		}
+	}
+
+	/**
+	 * Get a translatable message for a system error.
+	 * Uses customizations from the System blueprint if available.
+	 */
+	getSystemErrorMessage(
+		errorCode: SystemErrorCode | string,
+		args: { [k: string]: unknown }
+	): ITranslatableMessage | null {
+		// Check blueprint messages from System blueprint manifest
+		if (this.#systemErrorMessages) {
+			const blueprintMessage = this.#systemErrorMessages[errorCode]
+
+			if (blueprintMessage === '') {
+				// Empty string means suppress the message
+				return null
+			}
+
+			if (blueprintMessage) {
+				return this.#blueprintId
+					? wrapTranslatableMessageFromBlueprints({ key: blueprintMessage, args }, [this.#blueprintId])
+					: { key: blueprintMessage, args }
+			}
+		}
+
+		// Use default message
+		return {
+			key: DEFAULT_SYSTEM_ERROR_MESSAGES[errorCode as SystemErrorCode]?.key ?? errorCode,
+			args,
+		}
+	}
+}

--- a/packages/corelib/src/ErrorMessageResolver.ts
+++ b/packages/corelib/src/ErrorMessageResolver.ts
@@ -107,9 +107,9 @@ export class ErrorMessageResolver {
 			// undefined or not found - fall through to default
 		}
 
-		// Use default message from TSR
+		// Use default message from TSR with device name prefix
 		return {
-			key: defaultMessage,
+			key: `{{deviceName}}: ${defaultMessage}`,
 			args: context,
 		}
 	}

--- a/packages/corelib/src/ErrorMessageResolver.ts
+++ b/packages/corelib/src/ErrorMessageResolver.ts
@@ -100,7 +100,11 @@ export class ErrorMessageResolver {
 			if (typeof blueprintMessage === 'function') {
 				// Function: evaluate at runtime with full context
 				const result = blueprintMessage(context)
-				if (result === '') return null // Function can also suppress
+				if (result === undefined) {
+					// undefined means fall back to default TSR message
+					return { key: defaultMessage, args: context }
+				}
+				if (result === '') return null // Empty string suppresses the message
 
 				return this.#blueprintId
 					? wrapTranslatableMessageFromBlueprints({ key: result, args: context }, [this.#blueprintId])

--- a/packages/corelib/src/StatusMessageResolver.ts
+++ b/packages/corelib/src/StatusMessageResolver.ts
@@ -2,10 +2,10 @@ import { BlueprintId } from './dataModel/Ids.js'
 import { generateTranslation } from './lib.js'
 import { ITranslatableMessage, wrapTranslatableMessageFromBlueprints } from './TranslatableMessage.js'
 import { SystemErrorCode } from '@sofie-automation/shared-lib/dist/systemErrorMessages'
-import type { DeviceErrorContext, DeviceErrorMessageFunction } from '@sofie-automation/blueprints-integration'
+import type { DeviceStatusContext, DeviceStatusMessageFunction } from '@sofie-automation/blueprints-integration'
 
 // Re-export for consumers of corelib
-export type { DeviceErrorContext, DeviceErrorMessageFunction }
+export type { DeviceStatusContext, DeviceStatusMessageFunction }
 
 /**
  * Default error messages for system errors
@@ -19,10 +19,10 @@ const DEFAULT_SYSTEM_ERROR_MESSAGES: Record<SystemErrorCode, ITranslatableMessag
 }
 
 /**
- * Device error messages map - can contain string templates or functions.
+ * Device status messages map - can contain string templates or functions.
  * Functions are evaluated at runtime, strings use {{variable}} interpolation.
  */
-export type DeviceErrorMessages = Record<string, string | DeviceErrorMessageFunction | undefined>
+export type DeviceStatusMessages = Record<string, string | DeviceStatusMessageFunction | undefined>
 
 /**
  * System error messages map - string templates only.
@@ -31,65 +31,65 @@ export type DeviceErrorMessages = Record<string, string | DeviceErrorMessageFunc
 export type SystemErrorMessages = Partial<Record<SystemErrorCode | string, string | undefined>>
 
 /**
- * Resolves error messages with blueprint customizations.
+ * Resolves status messages with blueprint customizations.
  * Works with runtime blueprint manifests (evaluated at setStatus time).
  *
- * For device errors, the default message templates come from TSR devices.
- * Studio blueprints can override these by providing custom templates or functions in deviceErrorMessages.
+ * For device statuses, the default message templates come from TSR devices.
+ * Studio blueprints can override these by providing custom templates or functions in deviceStatusMessages.
  *
  * For system errors, System blueprints can override the defaults in systemErrorMessages.
  *
  * @example
  * ```typescript
- * import { AtemErrorCode, AtemErrorMessages } from 'timeline-state-resolver-types'
+ * import { AtemStatusCode, AtemStatusMessages } from 'timeline-state-resolver-types'
  *
  * // Get blueprint manifest at runtime (from evalBlueprint or similar)
  * const studioManifest = await getBlueprintManifest(studioBlueprintId)
  *
- * // Create resolver for device errors
- * const resolver = new ErrorMessageResolver(
- *   studioManifest.deviceErrorMessages
+ * // Create resolver for device statuses
+ * const resolver = new StatusMessageResolver(
+ *   studioManifest.deviceStatusMessages
  * )
  *
- * // Resolve device error - pass default message from TSR
- * const message = resolver.getDeviceErrorMessage(
- *   AtemErrorCode.DISCONNECTED,
+ * // Resolve device status - pass default message from TSR
+ * const message = resolver.getDeviceStatusMessage(
+ *   AtemStatusCode.DISCONNECTED,
  *   { deviceName: 'Vision Mixer', host: '192.168.1.10' },
- *   AtemErrorMessages[AtemErrorCode.DISCONNECTED]
+ *   AtemStatusMessages[AtemStatusCode.DISCONNECTED]
  * )
  * ```
  */
-export class ErrorMessageResolver {
+export class StatusMessageResolver {
 	readonly #blueprintId: BlueprintId | undefined
-	readonly #deviceErrorMessages: DeviceErrorMessages | undefined
+	readonly #deviceStatusMessages: DeviceStatusMessages | undefined
 	readonly #systemErrorMessages: SystemErrorMessages | undefined
 
 	constructor(
 		blueprintId: BlueprintId | undefined,
-		deviceErrorMessages?: DeviceErrorMessages | undefined,
-		systemErrorMessages?: SystemErrorMessages | undefined
+		deviceStatusMessages?: DeviceStatusMessages,
+		systemErrorMessages?: SystemErrorMessages
 	) {
 		this.#blueprintId = blueprintId
-		this.#deviceErrorMessages = deviceErrorMessages
+		this.#deviceStatusMessages = deviceStatusMessages
 		this.#systemErrorMessages = systemErrorMessages
 	}
 
 	/**
-	 * Get a translatable message for a device error.
+	 * Get a translatable message for a device status.
 	 *
-	 * @param errorCode - The error code string from TSR (e.g., 'DEVICE_ATEM_DISCONNECTED')
-	 * @param context - Context values for message interpolation (deviceName, deviceId, and TSR error context)
+	 * @param errorCode - The status code string from TSR (e.g., 'DEVICE_ATEM_DISCONNECTED')
+	 * @param context - Context values for message interpolation (deviceName, deviceId, and TSR status context)
 	 * @param defaultMessage - The default message template from TSR (e.g., 'ATEM disconnected')
 	 * @returns ITranslatableMessage with the resolved message, or null if suppressed
 	 */
-	getDeviceErrorMessage(
+	getDeviceStatusMessage(
 		errorCode: string,
-		context: DeviceErrorContext,
+		context: DeviceStatusContext,
 		defaultMessage: string
 	): ITranslatableMessage | null {
 		// Check blueprint messages from Studio blueprint manifest
-		if (this.#deviceErrorMessages) {
-			const blueprintMessage = this.#deviceErrorMessages[errorCode]
+		if (this.#deviceStatusMessages) {
+			const blueprintMessage = this.#deviceStatusMessages[errorCode]
 
 			// Evaluate if function or use as string template
 			const result = typeof blueprintMessage === 'function' ? blueprintMessage(context) : blueprintMessage

--- a/packages/corelib/src/StatusMessageResolver.ts
+++ b/packages/corelib/src/StatusMessageResolver.ts
@@ -100,16 +100,18 @@ export class StatusMessageResolver {
 			}
 
 			if (result) {
-				// Custom message from blueprint - use as-is (no prefix)
-				return { key: result, args: context }
+				// Custom message from blueprint - wrap with blueprint namespace if ID provided
+				return this.#blueprintId
+					? wrapTranslatableMessageFromBlueprints({ key: result, args: context }, [this.#blueprintId])
+					: { key: result, args: context }
 			}
 
 			// undefined or not found - fall through to default
 		}
 
-		// Use default message from TSR with device name prefix
+		// Use default message from TSR as-is (TSR messages already include device name prefix)
 		return {
-			key: `{{deviceName}}: ${defaultMessage}`,
+			key: defaultMessage,
 			args: context,
 		}
 	}

--- a/packages/corelib/src/StatusMessageResolver.ts
+++ b/packages/corelib/src/StatusMessageResolver.ts
@@ -109,7 +109,7 @@ export class StatusMessageResolver {
 				return null
 			}
 
-			if (result) {
+			if (typeof result === 'string') {
 				// Custom message from blueprint - wrap with blueprint namespace if ID provided
 				return this.#blueprintId
 					? wrapTranslatableMessageFromBlueprints({ key: result, args: context }, [this.#blueprintId])
@@ -143,7 +143,7 @@ export class StatusMessageResolver {
 				return null
 			}
 
-			if (blueprintMessage) {
+			if (typeof blueprintMessage === 'string') {
 				return this.#blueprintId
 					? wrapTranslatableMessageFromBlueprints({ key: blueprintMessage, args }, [this.#blueprintId])
 					: { key: blueprintMessage, args }

--- a/packages/corelib/src/StatusMessageResolver.ts
+++ b/packages/corelib/src/StatusMessageResolver.ts
@@ -48,6 +48,7 @@ export type SystemErrorMessages = Partial<Record<SystemErrorCode | string, strin
  *
  * // Create resolver for device statuses
  * const resolver = new StatusMessageResolver(
+ *   studioBlueprintId,
  *   studioManifest.deviceStatusMessages
  * )
  *
@@ -92,7 +93,16 @@ export class StatusMessageResolver {
 			const blueprintMessage = this.#deviceStatusMessages[errorCode]
 
 			// Evaluate if function or use as string template
-			const result = typeof blueprintMessage === 'function' ? blueprintMessage(context) : blueprintMessage
+			let result: string | undefined
+			if (typeof blueprintMessage === 'function') {
+				try {
+					result = blueprintMessage(context)
+				} catch {
+					// Blueprint function threw - fall through to default message
+				}
+			} else {
+				result = blueprintMessage
+			}
 
 			if (result === '') {
 				// Empty string means suppress the message

--- a/packages/corelib/src/__tests__/ErrorMessageResolver.test.ts
+++ b/packages/corelib/src/__tests__/ErrorMessageResolver.test.ts
@@ -1,0 +1,304 @@
+import { ErrorMessageResolver } from '../ErrorMessageResolver.js'
+import { SystemErrorCode } from '@sofie-automation/shared-lib/dist/systemErrorMessages'
+import { protectString } from '../protectedString.js'
+
+// Mock device error codes (these would come from TSR in production)
+const MockDeviceErrorCode = {
+	HTTP_TIMEOUT: 'DEVICE_HTTP_TIMEOUT',
+	CASPARCG_DISCONNECTED: 'DEVICE_CASPARCG_DISCONNECTED',
+	CASPARCG_FILE_NOT_FOUND: 'DEVICE_CASPARCG_FILE_NOT_FOUND',
+} as const
+
+// Mock default messages (these would come from TSR in production)
+const MockDeviceErrorMessages = {
+	[MockDeviceErrorCode.HTTP_TIMEOUT]: '{{deviceName}}: HTTP request to {{url}} timed out after {{timeout}}ms',
+	[MockDeviceErrorCode.CASPARCG_DISCONNECTED]: '{{deviceName}}: CasparCG server at {{host}}:{{port}} disconnected',
+	[MockDeviceErrorCode.CASPARCG_FILE_NOT_FOUND]: '{{deviceName}}: File "{{fileName}}" not found on CasparCG server',
+}
+
+describe('ErrorMessageResolver', () => {
+	describe('Device errors', () => {
+		it('returns default message from TSR when no blueprint provided', () => {
+			const resolver = new ErrorMessageResolver(undefined, undefined, undefined)
+			const message = resolver.getDeviceErrorMessage(
+				MockDeviceErrorCode.HTTP_TIMEOUT,
+				{
+					deviceName: 'Graphics Server',
+					url: 'http://graphics/api',
+					timeout: 5000,
+				},
+				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+			)
+
+			expect(message).toBeTruthy()
+			expect(message?.key).toBe('{{deviceName}}: HTTP request to {{url}} timed out after {{timeout}}ms')
+			expect(message?.args).toMatchObject({
+				deviceName: 'Graphics Server',
+				url: 'http://graphics/api',
+				timeout: 5000,
+			})
+		})
+
+		it('returns blueprint custom message when provided', () => {
+			const resolver = new ErrorMessageResolver(
+				protectString('studioBlueprint123'),
+				{
+					[MockDeviceErrorCode.HTTP_TIMEOUT]: 'Graphics system {{deviceName}} not responding',
+				},
+				undefined
+			)
+
+			const message = resolver.getDeviceErrorMessage(
+				MockDeviceErrorCode.HTTP_TIMEOUT,
+				{
+					deviceName: 'Graphics Server',
+					url: 'http://graphics/api',
+					timeout: 5000,
+				},
+				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+			)
+
+			expect(message).toBeTruthy()
+			expect(message?.key).toBe('Graphics system {{deviceName}} not responding')
+			expect(message?.args?.deviceName).toBe('Graphics Server')
+		})
+
+		it('returns null when blueprint provides empty string (suppression)', () => {
+			const resolver = new ErrorMessageResolver(
+				protectString('studioBlueprint123'),
+				{
+					[MockDeviceErrorCode.HTTP_TIMEOUT]: '',
+				},
+				undefined
+			)
+
+			const message = resolver.getDeviceErrorMessage(
+				MockDeviceErrorCode.HTTP_TIMEOUT,
+				{
+					deviceName: 'Graphics Server',
+				},
+				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+			)
+
+			expect(message).toBeNull()
+		})
+
+		it('evaluates function-based error messages', () => {
+			const resolver = new ErrorMessageResolver(
+				protectString('studioBlueprint123'),
+				{
+					[MockDeviceErrorCode.HTTP_TIMEOUT]: (context) => {
+						const timeout = context.timeout as number
+						if (timeout > 10000) {
+							return `${context.deviceName}: Critical timeout (${timeout}ms) - check network`
+						}
+						return `${context.deviceName}: Request timeout`
+					},
+				},
+				undefined
+			)
+
+			// Test with small timeout
+			const shortMessage = resolver.getDeviceErrorMessage(
+				MockDeviceErrorCode.HTTP_TIMEOUT,
+				{
+					deviceName: 'Graphics Server',
+					timeout: 5000,
+				},
+				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+			)
+
+			expect(shortMessage?.key).toBe('Graphics Server: Request timeout')
+
+			// Test with long timeout
+			const longMessage = resolver.getDeviceErrorMessage(
+				MockDeviceErrorCode.HTTP_TIMEOUT,
+				{
+					deviceName: 'Graphics Server',
+					timeout: 15000,
+				},
+				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+			)
+
+			expect(longMessage?.key).toBe('Graphics Server: Critical timeout (15000ms) - check network')
+		})
+
+		it('suppresses message when function returns empty string', () => {
+			const resolver = new ErrorMessageResolver(
+				protectString('studioBlueprint123'),
+				{
+					[MockDeviceErrorCode.HTTP_TIMEOUT]: () => '', // Always suppress
+				},
+				undefined
+			)
+
+			const message = resolver.getDeviceErrorMessage(
+				MockDeviceErrorCode.HTTP_TIMEOUT,
+				{
+					deviceName: 'Graphics Server',
+				},
+				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+			)
+
+			expect(message).toBeNull()
+		})
+
+		it('returns default for CasparCG errors', () => {
+			const resolver = new ErrorMessageResolver(undefined, undefined, undefined)
+			const message = resolver.getDeviceErrorMessage(
+				MockDeviceErrorCode.CASPARCG_FILE_NOT_FOUND,
+				{
+					deviceName: 'CasparCG1',
+					fileName: 'video.mp4',
+				},
+				MockDeviceErrorMessages[MockDeviceErrorCode.CASPARCG_FILE_NOT_FOUND]
+			)
+
+			expect(message).toBeTruthy()
+			expect(message?.key).toContain('File')
+			expect(message?.key).toContain('not found')
+		})
+
+		it('falls back to TSR default when blueprint has no customization for that error', () => {
+			const resolver = new ErrorMessageResolver(
+				protectString('studioBlueprint123'),
+				{
+					[MockDeviceErrorCode.HTTP_TIMEOUT]: 'Custom timeout message',
+				},
+				undefined
+			)
+
+			// Ask for a different error that has no customization
+			const message = resolver.getDeviceErrorMessage(
+				MockDeviceErrorCode.CASPARCG_DISCONNECTED,
+				{
+					deviceName: 'CasparCG1',
+					host: 'localhost',
+				},
+				MockDeviceErrorMessages[MockDeviceErrorCode.CASPARCG_DISCONNECTED]
+			)
+
+			expect(message).toBeTruthy()
+			expect(message?.key).toContain('CasparCG')
+		})
+	})
+
+	describe('System errors', () => {
+		it('returns default message when no blueprint provided', () => {
+			const resolver = new ErrorMessageResolver(undefined, undefined, undefined)
+			const message = resolver.getSystemErrorMessage(SystemErrorCode.DATABASE_CONNECTION_LOST, {
+				database: 'MongoDB',
+			})
+
+			expect(message).toBeTruthy()
+			expect(message?.key).toContain('Database')
+			expect(message?.args?.database).toBe('MongoDB')
+		})
+
+		it('returns blueprint custom message', () => {
+			const resolver = new ErrorMessageResolver(
+				protectString('systemBlueprint123'),
+				undefined,
+				{
+					[SystemErrorCode.DATABASE_CONNECTION_LOST]: 'System database offline - please wait',
+				}
+			)
+
+			const message = resolver.getSystemErrorMessage(SystemErrorCode.DATABASE_CONNECTION_LOST, {
+				database: 'MongoDB',
+			})
+
+			expect(message?.key).toBe('System database offline - please wait')
+		})
+
+		it('suppresses message with empty string', () => {
+			const resolver = new ErrorMessageResolver(
+				protectString('systemBlueprint123'),
+				undefined,
+				{
+					[SystemErrorCode.INSUFFICIENT_RESOURCES]: '',
+				}
+			)
+
+			const message = resolver.getSystemErrorMessage(SystemErrorCode.INSUFFICIENT_RESOURCES, {
+				resource: 'memory',
+			})
+
+			expect(message).toBeNull()
+		})
+	})
+
+	describe('Combined blueprints', () => {
+		it('resolves device errors and system errors with same blueprint ID', () => {
+			// Note: In practice, device errors use Studio blueprint ID and system errors use System blueprint ID
+			// But the resolver doesn't enforce this - it just associates the ID with any messages it generates
+			const resolver = new ErrorMessageResolver(
+				protectString('blueprint123'),
+				{
+					[MockDeviceErrorCode.HTTP_TIMEOUT]: 'Custom device error',
+				},
+				{
+					[SystemErrorCode.DATABASE_CONNECTION_LOST]: 'Custom system error',
+				}
+			)
+
+			const deviceMessage = resolver.getDeviceErrorMessage(
+				MockDeviceErrorCode.HTTP_TIMEOUT,
+				{ deviceName: 'Server' },
+				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+			)
+
+			const systemMessage = resolver.getSystemErrorMessage(SystemErrorCode.DATABASE_CONNECTION_LOST, {
+				database: 'MongoDB',
+			})
+
+			expect(deviceMessage?.key).toBe('Custom device error')
+			expect(systemMessage?.key).toBe('Custom system error')
+		})
+
+		it('includes correct blueprint namespace for messages', () => {
+			const resolver = new ErrorMessageResolver(
+				protectString('blueprint123'),
+				{
+					[MockDeviceErrorCode.HTTP_TIMEOUT]: 'Custom device error',
+				},
+				{
+					[SystemErrorCode.DATABASE_CONNECTION_LOST]: 'Custom system error',
+				}
+			)
+
+			const deviceMessage = resolver.getDeviceErrorMessage(
+				MockDeviceErrorCode.HTTP_TIMEOUT,
+				{ deviceName: 'Server' },
+				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+			)
+
+			const systemMessage = resolver.getSystemErrorMessage(SystemErrorCode.DATABASE_CONNECTION_LOST, {
+				database: 'MongoDB',
+			})
+
+			// Both messages should have the same blueprint namespace
+			expect(deviceMessage?.namespaces).toContain('blueprint_blueprint123')
+			expect(systemMessage?.namespaces).toContain('blueprint_blueprint123')
+		})
+
+		it('does not add namespace when no blueprint ID provided', () => {
+			const resolver = new ErrorMessageResolver(
+				undefined,
+				{
+					[MockDeviceErrorCode.HTTP_TIMEOUT]: 'Custom device error',
+				},
+				undefined
+			)
+
+			const message = resolver.getDeviceErrorMessage(
+				MockDeviceErrorCode.HTTP_TIMEOUT,
+				{ deviceName: 'Server' },
+				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+			)
+
+			// No namespace when no blueprint ID
+			expect(message?.namespaces).toBeUndefined()
+		})
+	})
+})

--- a/packages/corelib/src/__tests__/StatusMessageResolver.test.ts
+++ b/packages/corelib/src/__tests__/StatusMessageResolver.test.ts
@@ -1,33 +1,33 @@
-import { ErrorMessageResolver } from '../ErrorMessageResolver.js'
+import { StatusMessageResolver } from '../StatusMessageResolver.js'
 import { SystemErrorCode } from '@sofie-automation/shared-lib/dist/systemErrorMessages'
 import { protectString } from '../protectedString.js'
 
-// Mock device error codes (these would come from TSR in production)
-const MockDeviceErrorCode = {
+// Mock device status codes (these would come from TSR in production)
+const MockDeviceStatusCode = {
 	HTTP_TIMEOUT: 'DEVICE_HTTP_TIMEOUT',
 	CASPARCG_DISCONNECTED: 'DEVICE_CASPARCG_DISCONNECTED',
 	CASPARCG_FILE_NOT_FOUND: 'DEVICE_CASPARCG_FILE_NOT_FOUND',
 } as const
 
 // Mock default messages (these would come from TSR in production)
-const MockDeviceErrorMessages = {
-	[MockDeviceErrorCode.HTTP_TIMEOUT]: '{{deviceName}}: HTTP request to {{url}} timed out after {{timeout}}ms',
-	[MockDeviceErrorCode.CASPARCG_DISCONNECTED]: '{{deviceName}}: CasparCG server at {{host}}:{{port}} disconnected',
-	[MockDeviceErrorCode.CASPARCG_FILE_NOT_FOUND]: '{{deviceName}}: File "{{fileName}}" not found on CasparCG server',
+const MockDeviceStatusMessages = {
+	[MockDeviceStatusCode.HTTP_TIMEOUT]: '{{deviceName}}: HTTP request to {{url}} timed out after {{timeout}}ms',
+	[MockDeviceStatusCode.CASPARCG_DISCONNECTED]: '{{deviceName}}: CasparCG server at {{host}}:{{port}} disconnected',
+	[MockDeviceStatusCode.CASPARCG_FILE_NOT_FOUND]: '{{deviceName}}: File "{{fileName}}" not found on CasparCG server',
 }
 
-describe('ErrorMessageResolver', () => {
-	describe('Device errors', () => {
+describe('StatusMessageResolver', () => {
+	describe('Device statuses', () => {
 		it('returns default message from TSR when no blueprint provided', () => {
-			const resolver = new ErrorMessageResolver(undefined, undefined, undefined)
-			const message = resolver.getDeviceErrorMessage(
-				MockDeviceErrorCode.HTTP_TIMEOUT,
+			const resolver = new StatusMessageResolver(undefined, undefined, undefined)
+			const message = resolver.getDeviceStatusMessage(
+				MockDeviceStatusCode.HTTP_TIMEOUT,
 				{
 					deviceName: 'Graphics Server',
 					url: 'http://graphics/api',
 					timeout: 5000,
 				},
-				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+				MockDeviceStatusMessages[MockDeviceStatusCode.HTTP_TIMEOUT]
 			)
 
 			expect(message).toBeTruthy()
@@ -40,22 +40,22 @@ describe('ErrorMessageResolver', () => {
 		})
 
 		it('returns blueprint custom message when provided', () => {
-			const resolver = new ErrorMessageResolver(
+			const resolver = new StatusMessageResolver(
 				protectString('studioBlueprint123'),
 				{
-					[MockDeviceErrorCode.HTTP_TIMEOUT]: 'Graphics system {{deviceName}} not responding',
+					[MockDeviceStatusCode.HTTP_TIMEOUT]: 'Graphics system {{deviceName}} not responding',
 				},
 				undefined
 			)
 
-			const message = resolver.getDeviceErrorMessage(
-				MockDeviceErrorCode.HTTP_TIMEOUT,
+			const message = resolver.getDeviceStatusMessage(
+				MockDeviceStatusCode.HTTP_TIMEOUT,
 				{
 					deviceName: 'Graphics Server',
 					url: 'http://graphics/api',
 					timeout: 5000,
 				},
-				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+				MockDeviceStatusMessages[MockDeviceStatusCode.HTTP_TIMEOUT]
 			)
 
 			expect(message).toBeTruthy()
@@ -64,30 +64,30 @@ describe('ErrorMessageResolver', () => {
 		})
 
 		it('returns null when blueprint provides empty string (suppression)', () => {
-			const resolver = new ErrorMessageResolver(
+			const resolver = new StatusMessageResolver(
 				protectString('studioBlueprint123'),
 				{
-					[MockDeviceErrorCode.HTTP_TIMEOUT]: '',
+					[MockDeviceStatusCode.HTTP_TIMEOUT]: '',
 				},
 				undefined
 			)
 
-			const message = resolver.getDeviceErrorMessage(
-				MockDeviceErrorCode.HTTP_TIMEOUT,
+			const message = resolver.getDeviceStatusMessage(
+				MockDeviceStatusCode.HTTP_TIMEOUT,
 				{
 					deviceName: 'Graphics Server',
 				},
-				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+				MockDeviceStatusMessages[MockDeviceStatusCode.HTTP_TIMEOUT]
 			)
 
 			expect(message).toBeNull()
 		})
 
-		it('evaluates function-based error messages', () => {
-			const resolver = new ErrorMessageResolver(
+		it('evaluates function-based status messages', () => {
+			const resolver = new StatusMessageResolver(
 				protectString('studioBlueprint123'),
 				{
-					[MockDeviceErrorCode.HTTP_TIMEOUT]: (context) => {
+					[MockDeviceStatusCode.HTTP_TIMEOUT]: (context) => {
 						const timeout = context.timeout as number
 						if (timeout > 10000) {
 							return `${context.deviceName}: Critical timeout (${timeout}ms) - check network`
@@ -99,59 +99,59 @@ describe('ErrorMessageResolver', () => {
 			)
 
 			// Test with small timeout
-			const shortMessage = resolver.getDeviceErrorMessage(
-				MockDeviceErrorCode.HTTP_TIMEOUT,
+			const shortMessage = resolver.getDeviceStatusMessage(
+				MockDeviceStatusCode.HTTP_TIMEOUT,
 				{
 					deviceName: 'Graphics Server',
 					timeout: 5000,
 				},
-				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+				MockDeviceStatusMessages[MockDeviceStatusCode.HTTP_TIMEOUT]
 			)
 
 			expect(shortMessage?.key).toBe('Graphics Server: Request timeout')
 
 			// Test with long timeout
-			const longMessage = resolver.getDeviceErrorMessage(
-				MockDeviceErrorCode.HTTP_TIMEOUT,
+			const longMessage = resolver.getDeviceStatusMessage(
+				MockDeviceStatusCode.HTTP_TIMEOUT,
 				{
 					deviceName: 'Graphics Server',
 					timeout: 15000,
 				},
-				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+				MockDeviceStatusMessages[MockDeviceStatusCode.HTTP_TIMEOUT]
 			)
 
 			expect(longMessage?.key).toBe('Graphics Server: Critical timeout (15000ms) - check network')
 		})
 
 		it('suppresses message when function returns empty string', () => {
-			const resolver = new ErrorMessageResolver(
+			const resolver = new StatusMessageResolver(
 				protectString('studioBlueprint123'),
 				{
-					[MockDeviceErrorCode.HTTP_TIMEOUT]: () => '', // Always suppress
+					[MockDeviceStatusCode.HTTP_TIMEOUT]: () => '', // Always suppress
 				},
 				undefined
 			)
 
-			const message = resolver.getDeviceErrorMessage(
-				MockDeviceErrorCode.HTTP_TIMEOUT,
+			const message = resolver.getDeviceStatusMessage(
+				MockDeviceStatusCode.HTTP_TIMEOUT,
 				{
 					deviceName: 'Graphics Server',
 				},
-				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+				MockDeviceStatusMessages[MockDeviceStatusCode.HTTP_TIMEOUT]
 			)
 
 			expect(message).toBeNull()
 		})
 
 		it('returns default for CasparCG errors', () => {
-			const resolver = new ErrorMessageResolver(undefined, undefined, undefined)
-			const message = resolver.getDeviceErrorMessage(
-				MockDeviceErrorCode.CASPARCG_FILE_NOT_FOUND,
+			const resolver = new StatusMessageResolver(undefined, undefined, undefined)
+			const message = resolver.getDeviceStatusMessage(
+				MockDeviceStatusCode.CASPARCG_FILE_NOT_FOUND,
 				{
 					deviceName: 'CasparCG1',
 					fileName: 'video.mp4',
 				},
-				MockDeviceErrorMessages[MockDeviceErrorCode.CASPARCG_FILE_NOT_FOUND]
+				MockDeviceStatusMessages[MockDeviceStatusCode.CASPARCG_FILE_NOT_FOUND]
 			)
 
 			expect(message).toBeTruthy()
@@ -159,23 +159,23 @@ describe('ErrorMessageResolver', () => {
 			expect(message?.key).toContain('not found')
 		})
 
-		it('falls back to TSR default when blueprint has no customization for that error', () => {
-			const resolver = new ErrorMessageResolver(
+		it('falls back to TSR default when blueprint has no customization for that status code', () => {
+			const resolver = new StatusMessageResolver(
 				protectString('studioBlueprint123'),
 				{
-					[MockDeviceErrorCode.HTTP_TIMEOUT]: 'Custom timeout message',
+					[MockDeviceStatusCode.HTTP_TIMEOUT]: 'Custom timeout message',
 				},
 				undefined
 			)
 
 			// Ask for a different error that has no customization
-			const message = resolver.getDeviceErrorMessage(
-				MockDeviceErrorCode.CASPARCG_DISCONNECTED,
+			const message = resolver.getDeviceStatusMessage(
+				MockDeviceStatusCode.CASPARCG_DISCONNECTED,
 				{
 					deviceName: 'CasparCG1',
 					host: 'localhost',
 				},
-				MockDeviceErrorMessages[MockDeviceErrorCode.CASPARCG_DISCONNECTED]
+				MockDeviceStatusMessages[MockDeviceStatusCode.CASPARCG_DISCONNECTED]
 			)
 
 			expect(message).toBeTruthy()
@@ -185,7 +185,7 @@ describe('ErrorMessageResolver', () => {
 
 	describe('System errors', () => {
 		it('returns default message when no blueprint provided', () => {
-			const resolver = new ErrorMessageResolver(undefined, undefined, undefined)
+			const resolver = new StatusMessageResolver(undefined, undefined, undefined)
 			const message = resolver.getSystemErrorMessage(SystemErrorCode.DATABASE_CONNECTION_LOST, {
 				database: 'MongoDB',
 			})
@@ -196,13 +196,9 @@ describe('ErrorMessageResolver', () => {
 		})
 
 		it('returns blueprint custom message', () => {
-			const resolver = new ErrorMessageResolver(
-				protectString('systemBlueprint123'),
-				undefined,
-				{
-					[SystemErrorCode.DATABASE_CONNECTION_LOST]: 'System database offline - please wait',
-				}
-			)
+			const resolver = new StatusMessageResolver(protectString('systemBlueprint123'), undefined, {
+				[SystemErrorCode.DATABASE_CONNECTION_LOST]: 'System database offline - please wait',
+			})
 
 			const message = resolver.getSystemErrorMessage(SystemErrorCode.DATABASE_CONNECTION_LOST, {
 				database: 'MongoDB',
@@ -212,13 +208,9 @@ describe('ErrorMessageResolver', () => {
 		})
 
 		it('suppresses message with empty string', () => {
-			const resolver = new ErrorMessageResolver(
-				protectString('systemBlueprint123'),
-				undefined,
-				{
-					[SystemErrorCode.INSUFFICIENT_RESOURCES]: '',
-				}
-			)
+			const resolver = new StatusMessageResolver(protectString('systemBlueprint123'), undefined, {
+				[SystemErrorCode.INSUFFICIENT_RESOURCES]: '',
+			})
 
 			const message = resolver.getSystemErrorMessage(SystemErrorCode.INSUFFICIENT_RESOURCES, {
 				resource: 'memory',
@@ -229,48 +221,48 @@ describe('ErrorMessageResolver', () => {
 	})
 
 	describe('Combined blueprints', () => {
-		it('resolves device errors and system errors with same blueprint ID', () => {
-			// Note: In practice, device errors use Studio blueprint ID and system errors use System blueprint ID
+		it('resolves device statuses and system errors with same blueprint ID', () => {
+			// Note: In practice, device statuses use Studio blueprint ID and system errors use System blueprint ID
 			// But the resolver doesn't enforce this - it just associates the ID with any messages it generates
-			const resolver = new ErrorMessageResolver(
+			const resolver = new StatusMessageResolver(
 				protectString('blueprint123'),
 				{
-					[MockDeviceErrorCode.HTTP_TIMEOUT]: 'Custom device error',
+					[MockDeviceStatusCode.HTTP_TIMEOUT]: 'Custom device status',
 				},
 				{
 					[SystemErrorCode.DATABASE_CONNECTION_LOST]: 'Custom system error',
 				}
 			)
 
-			const deviceMessage = resolver.getDeviceErrorMessage(
-				MockDeviceErrorCode.HTTP_TIMEOUT,
+			const deviceMessage = resolver.getDeviceStatusMessage(
+				MockDeviceStatusCode.HTTP_TIMEOUT,
 				{ deviceName: 'Server' },
-				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+				MockDeviceStatusMessages[MockDeviceStatusCode.HTTP_TIMEOUT]
 			)
 
 			const systemMessage = resolver.getSystemErrorMessage(SystemErrorCode.DATABASE_CONNECTION_LOST, {
 				database: 'MongoDB',
 			})
 
-			expect(deviceMessage?.key).toBe('Custom device error')
+			expect(deviceMessage?.key).toBe('Custom device status')
 			expect(systemMessage?.key).toBe('Custom system error')
 		})
 
 		it('includes correct blueprint namespace for messages', () => {
-			const resolver = new ErrorMessageResolver(
+			const resolver = new StatusMessageResolver(
 				protectString('blueprint123'),
 				{
-					[MockDeviceErrorCode.HTTP_TIMEOUT]: 'Custom device error',
+					[MockDeviceStatusCode.HTTP_TIMEOUT]: 'Custom device status',
 				},
 				{
 					[SystemErrorCode.DATABASE_CONNECTION_LOST]: 'Custom system error',
 				}
 			)
 
-			const deviceMessage = resolver.getDeviceErrorMessage(
-				MockDeviceErrorCode.HTTP_TIMEOUT,
+			const deviceMessage = resolver.getDeviceStatusMessage(
+				MockDeviceStatusCode.HTTP_TIMEOUT,
 				{ deviceName: 'Server' },
-				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+				MockDeviceStatusMessages[MockDeviceStatusCode.HTTP_TIMEOUT]
 			)
 
 			const systemMessage = resolver.getSystemErrorMessage(SystemErrorCode.DATABASE_CONNECTION_LOST, {
@@ -283,18 +275,18 @@ describe('ErrorMessageResolver', () => {
 		})
 
 		it('does not add namespace when no blueprint ID provided', () => {
-			const resolver = new ErrorMessageResolver(
+			const resolver = new StatusMessageResolver(
 				undefined,
 				{
-					[MockDeviceErrorCode.HTTP_TIMEOUT]: 'Custom device error',
+					[MockDeviceStatusCode.HTTP_TIMEOUT]: 'Custom device status',
 				},
 				undefined
 			)
 
-			const message = resolver.getDeviceErrorMessage(
-				MockDeviceErrorCode.HTTP_TIMEOUT,
+			const message = resolver.getDeviceStatusMessage(
+				MockDeviceStatusCode.HTTP_TIMEOUT,
 				{ deviceName: 'Server' },
-				MockDeviceErrorMessages[MockDeviceErrorCode.HTTP_TIMEOUT]
+				MockDeviceStatusMessages[MockDeviceStatusCode.HTTP_TIMEOUT]
 			)
 
 			// No namespace when no blueprint ID

--- a/packages/corelib/src/index.ts
+++ b/packages/corelib/src/index.ts
@@ -2,3 +2,12 @@
 export { Timecode } from './timecode.js'
 
 export { MOS } from '@sofie-automation/shared-lib/dist/mos'
+
+// Error message resolver
+export { ErrorMessageResolver } from './ErrorMessageResolver.js'
+export type {
+	DeviceErrorContext,
+	DeviceErrorMessageFunction,
+	DeviceErrorMessages,
+	SystemErrorMessages,
+} from './ErrorMessageResolver.js'

--- a/packages/corelib/src/index.ts
+++ b/packages/corelib/src/index.ts
@@ -3,11 +3,11 @@ export { Timecode } from './timecode.js'
 
 export { MOS } from '@sofie-automation/shared-lib/dist/mos'
 
-// Error message resolver
-export { ErrorMessageResolver } from './ErrorMessageResolver.js'
+// Status message resolver
+export { StatusMessageResolver } from './StatusMessageResolver.js'
 export type {
-	DeviceErrorContext,
-	DeviceErrorMessageFunction,
-	DeviceErrorMessages,
+	DeviceStatusContext,
+	DeviceStatusMessageFunction,
+	DeviceStatusMessages,
 	SystemErrorMessages,
-} from './ErrorMessageResolver.js'
+} from './StatusMessageResolver.js'

--- a/packages/documentation/docs/for-developers/for-blueprint-developers/error-message-customization.md
+++ b/packages/documentation/docs/for-developers/for-blueprint-developers/error-message-customization.md
@@ -1,0 +1,214 @@
+---
+sidebar_position: 12
+---
+
+# Error Message Customization
+
+Blueprints can customize the error messages displayed to users in the Sofie UI. This allows you to replace technical error messages with human-friendly ones that are relevant to your broadcast environment.
+
+## Overview
+
+Sofie displays error notifications from several sources:
+
+- **Device errors** - from TSR devices (ATEM, CasparCG, vMix, etc.) - customized via **Studio Blueprint**
+- **Package errors** - from the Package Manager (media files, thumbnails) - customized via **ShowStyle Blueprint**
+- **System errors** - from Sofie Core itself - customized via **System Blueprint**
+
+Each error type is customized in a different blueprint type, matching where the errors originate.
+
+## Device Error Messages (Studio Blueprint)
+
+Device errors come from TSR (Timeline State Resolver) integrations. Customize them in your **Studio Blueprint**:
+
+```typescript
+import { StudioBlueprintManifest } from '@sofie-automation/blueprints-integration'
+import { AtemErrorCode, CasparCGErrorCode } from 'timeline-state-resolver-types'
+
+export const manifest: StudioBlueprintManifest = {
+  // ... other manifest properties ...
+
+  deviceErrorMessages: {
+    // Simple string template with placeholders
+    [AtemErrorCode.DISCONNECTED]: 'Vision mixer offline - check network to {{host}}',
+    
+    // Use {{deviceName}} for the configured device name
+    [CasparCGErrorCode.DISCONNECTED]: '{{deviceName}}: Graphics server offline ({{host}}:{{port}})',
+    
+    // Empty string suppresses the error entirely
+    [AtemErrorCode.SOME_NOISY_WARNING]: '',
+  },
+}
+```
+
+### Using Placeholders
+
+Error messages support `{{placeholder}}` syntax for dynamic values. Common placeholders include:
+
+- `{{deviceName}}` - The configured name of the device in Sofie
+- `{{deviceId}}` - The internal device ID
+- Additional context from the specific error (e.g., `{{host}}`, `{{port}}`, `{{channel}}`)
+
+### Function-Based Messages
+
+For complex logic, use a function instead of a string. Functions can return:
+- A **string** - Use this as the custom message
+- **`undefined`** - Fall back to the default TSR message
+- **`''`** (empty string) - Suppress the message entirely
+
+```typescript
+import { DeviceErrorContext } from '@sofie-automation/blueprints-integration'
+
+deviceErrorMessages: {
+  [CasparCGErrorCode.CHANNEL_ERROR]: (context: DeviceErrorContext) => {
+    const channel = context.channel as number
+    if (channel === 1) return 'Primary graphics output failed!'
+    if (channel === 2) return 'Secondary graphics output failed!'
+    return `Graphics channel ${channel} error on ${context.deviceName}`
+  },
+  
+  // Return undefined to use the default TSR message
+  [SomeErrorCode.COMPLEX_ERROR]: (context) => {
+    if (context.isExpected) return undefined // Fall back to default
+    return `Unexpected error on ${context.deviceName}`
+  },
+  
+  // Return empty string to suppress
+  [SomeErrorCode.NOISY_WARNING]: (context) => {
+    if (context.severity === 'low') return '' // Suppress low severity
+    return `Warning on ${context.deviceName}`
+  },
+}
+```
+
+### Available Error Codes
+
+Import error codes from `timeline-state-resolver-types` for type safety:
+
+```typescript
+import { 
+  AtemErrorCode,
+  CasparCGErrorCode,
+  VmixErrorCode,
+  OBSErrorCode,
+  // ... other device error codes
+} from 'timeline-state-resolver-types'
+```
+
+Each device type exports its own error codes. Check the TSR documentation or source code for the complete list.
+
+## Package Status Messages (ShowStyle Blueprint)
+
+Package Manager messages are customized in your **ShowStyle Blueprint**:
+
+```typescript
+import { ShowStyleBlueprintManifest, PackageStatusMessage } from '@sofie-automation/blueprints-integration'
+
+export const manifest: ShowStyleBlueprintManifest = {
+  // ... other manifest properties ...
+
+  packageStatusMessages: {
+    [PackageStatusMessage.MISSING_FILE_PATH]: 'Media file path not configured - check ingest settings',
+    [PackageStatusMessage.SCAN_FAILED]: 'Could not scan media file - check file permissions',
+    [PackageStatusMessage.FILE_NOT_FOUND]: '', // Suppress this message
+  },
+}
+```
+
+## System Error Messages (System Blueprint)
+
+System-level errors from Sofie Core are customized in your **System Blueprint**:
+
+```typescript
+import { SystemBlueprintManifest, SystemErrorCode } from '@sofie-automation/blueprints-integration'
+
+export const manifest: SystemBlueprintManifest = {
+  // ... other manifest properties ...
+
+  systemErrorMessages: {
+    [SystemErrorCode.DATABASE_CONNECTION_LOST]: 'Database offline - contact IT support',
+    [SystemErrorCode.SERVICE_UNAVAILABLE]: 'Service {{serviceName}} is not responding',
+  },
+}
+```
+
+## Message Resolution
+
+When an error occurs, Sofie resolves the message as follows:
+
+1. **Check blueprint customization** - Look for matching error code in the appropriate blueprint
+2. **If function** - Call it with the error context:
+   - Returns `undefined` → Use default TSR message
+   - Returns `''` (empty string) → Suppress the message
+   - Returns a string → Use that as the message
+3. **If string** - Interpolate placeholders with context values
+4. **If empty string `''`** - Suppress the message entirely
+5. **If not found** - Use the default message from TSR/Sofie
+
+Device error resolution happens **server-side** when the error is received, ensuring consistent messages across all connected clients.
+
+```mermaid
+flowchart TD
+    A[Device reports error with code & context] --> B{Blueprint has customization?}
+    B -->|Yes, function| C[Call function with context]
+    B -->|Yes, string| D{Empty string?}
+    B -->|No| E[Use default TSR message]
+    C --> F{Function returns?}
+    D -->|Yes| H[Suppress message]
+    D -->|No| G[Interpolate & display]
+    F -->|undefined| E
+    F -->|empty string| H
+    F -->|string| G
+    E --> G
+```
+
+## Complete Example
+
+Here's a complete Studio Blueprint example:
+
+```typescript
+import {
+  StudioBlueprintManifest,
+  DeviceErrorContext,
+} from '@sofie-automation/blueprints-integration'
+import { AtemErrorCode, CasparCGErrorCode } from 'timeline-state-resolver-types'
+
+export const deviceErrorMessages: StudioBlueprintManifest['deviceErrorMessages'] = {
+  // Simple string with placeholders
+  [AtemErrorCode.DISCONNECTED]: '🎬 Vision mixer offline - check ATEM at {{host}}',
+  [AtemErrorCode.PSU_FAULT]: '⚠️ ATEM PSU {{psuNumber}} fault - check hardware',
+  
+  // Graphics server with host:port
+  [CasparCGErrorCode.DISCONNECTED]: '{{deviceName}}: Graphics offline ({{host}}:{{port}})',
+  
+  // Function for complex logic
+  [CasparCGErrorCode.CHANNEL_ERROR]: (context: DeviceErrorContext) => {
+    const channel = context.channel as number
+    const channelNames: Record<number, string> = {
+      1: 'Program graphics',
+      2: 'Preview graphics', 
+      3: 'DSK graphics',
+    }
+    const name = channelNames[channel] || `Channel ${channel}`
+    return `${name} failed on ${context.deviceName}`
+  },
+}
+
+export const manifest: StudioBlueprintManifest = {
+  blueprintType: 'studio',
+  // ... other required properties ...
+  deviceErrorMessages,
+}
+```
+
+## Tips
+
+- **Keep messages actionable** - Tell users what to do, not just what's wrong
+- **Use emoji sparingly** - They can help draw attention to critical errors
+- **Test with real devices** - Disconnect devices to verify your messages appear correctly
+- **Check TSR source** - Device error codes and their context values are defined in TSR integrations
+- **Use functions for complex cases** - Conditional logic, pluralization, severity-based filtering
+
+## See Also
+
+- [TSR Device Integrations](https://github.com/nrkno/sofie-timeline-state-resolver) - Device error codes
+- [Demo Blueprints](https://github.com/nrkno/sofie-demo-blueprints) - Working examples

--- a/packages/documentation/docs/for-developers/for-blueprint-developers/error-message-customization.md
+++ b/packages/documentation/docs/for-developers/for-blueprint-developers/error-message-customization.md
@@ -2,40 +2,40 @@
 sidebar_position: 12
 ---
 
-# Error Message Customization
+# Status Message Customization
 
-Blueprints can customize the error messages displayed to users in the Sofie UI. This allows you to replace technical error messages with human-friendly ones that are relevant to your broadcast environment.
+Blueprints can customize the status messages displayed to users in the Sofie UI. This allows you to replace technical status messages with human-friendly ones that are relevant to your broadcast environment.
 
 ## Overview
 
 Sofie displays error notifications from several sources:
 
-- **Device errors** - from TSR devices (ATEM, CasparCG, vMix, etc.) - customized via **Studio Blueprint**
+- **Device statuses** - from TSR devices (ATEM, CasparCG, vMix, etc.) - customized via **Studio Blueprint**
 - **Package errors** - from the Package Manager (media files, thumbnails) - customized via **ShowStyle Blueprint**
 - **System errors** - from Sofie Core itself - customized via **System Blueprint**
 
 Each error type is customized in a different blueprint type, matching where the errors originate.
 
-## Device Error Messages (Studio Blueprint)
+## Device Status Messages (Studio Blueprint)
 
-Device errors come from TSR (Timeline State Resolver) integrations. Customize them in your **Studio Blueprint**:
+Device status messages come from TSR (Timeline State Resolver) integrations. Customize them in your **Studio Blueprint**:
 
 ```typescript
 import { StudioBlueprintManifest } from '@sofie-automation/blueprints-integration'
-import { AtemErrorCode, CasparCGErrorCode } from 'timeline-state-resolver-types'
+import { AtemStatusCode, CasparCGStatusCode } from 'timeline-state-resolver-types'
 
 export const manifest: StudioBlueprintManifest = {
   // ... other manifest properties ...
 
-  deviceErrorMessages: {
+  deviceStatusMessages: {
     // Simple string template with placeholders
-    [AtemErrorCode.DISCONNECTED]: 'Vision mixer offline - check network to {{host}}',
+    [AtemStatusCode.DISCONNECTED]: 'Vision mixer offline - check network to {{host}}',
     
     // Use {{deviceName}} for the configured device name
-    [CasparCGErrorCode.DISCONNECTED]: '{{deviceName}}: Graphics server offline ({{host}}:{{port}})',
+    [CasparCGStatusCode.DISCONNECTED]: '{{deviceName}}: Graphics server offline ({{host}}:{{port}})',
     
     // Empty string suppresses the error entirely
-    [AtemErrorCode.SOME_NOISY_WARNING]: '',
+    [AtemStatusCode.SOME_NOISY_WARNING]: '',
   },
 }
 ```
@@ -56,10 +56,10 @@ For complex logic, use a function instead of a string. Functions can return:
 - **`''`** (empty string) - Suppress the message entirely
 
 ```typescript
-import { DeviceErrorContext } from '@sofie-automation/blueprints-integration'
+import { DeviceStatusContext } from '@sofie-automation/blueprints-integration'
 
-deviceErrorMessages: {
-  [CasparCGErrorCode.CHANNEL_ERROR]: (context: DeviceErrorContext) => {
+deviceStatusMessages: {
+  [CasparCGStatusCode.CHANNEL_ERROR]: (context: DeviceStatusContext) => {
     const channel = context.channel as number
     if (channel === 1) return 'Primary graphics output failed!'
     if (channel === 2) return 'Secondary graphics output failed!'
@@ -80,17 +80,17 @@ deviceErrorMessages: {
 }
 ```
 
-### Available Error Codes
+### Available Status Codes
 
 Import error codes from `timeline-state-resolver-types` for type safety:
 
 ```typescript
 import { 
-  AtemErrorCode,
-  CasparCGErrorCode,
-  VmixErrorCode,
-  OBSErrorCode,
-  // ... other device error codes
+  AtemStatusCode,
+  CasparCGStatusCode,
+  VmixStatusCode,
+  OBSStatusCode,
+  // ... other device status codes
 } from 'timeline-state-resolver-types'
 ```
 
@@ -144,11 +144,11 @@ When an error occurs, Sofie resolves the message as follows:
 4. **If empty string `''`** - Suppress the message entirely
 5. **If not found** - Use the default message from TSR/Sofie
 
-Device error resolution happens **server-side** when the error is received, ensuring consistent messages across all connected clients.
+Device status resolution happens **server-side** when the status is received, ensuring consistent messages across all connected clients.
 
 ```mermaid
 flowchart TD
-    A[Device reports error with code & context] --> B{Blueprint has customization?}
+    A[Device reports status with code & context] --> B{Blueprint has customization?}
     B -->|Yes, function| C[Call function with context]
     B -->|Yes, string| D{Empty string?}
     B -->|No| E[Use default TSR message]
@@ -168,20 +168,20 @@ Here's a complete Studio Blueprint example:
 ```typescript
 import {
   StudioBlueprintManifest,
-  DeviceErrorContext,
+  DeviceStatusContext,
 } from '@sofie-automation/blueprints-integration'
-import { AtemErrorCode, CasparCGErrorCode } from 'timeline-state-resolver-types'
+import { AtemStatusCode, CasparCGStatusCode } from 'timeline-state-resolver-types'
 
-export const deviceErrorMessages: StudioBlueprintManifest['deviceErrorMessages'] = {
+export const deviceStatusMessages: StudioBlueprintManifest['deviceStatusMessages'] = {
   // Simple string with placeholders
-  [AtemErrorCode.DISCONNECTED]: '🎬 Vision mixer offline - check ATEM at {{host}}',
-  [AtemErrorCode.PSU_FAULT]: '⚠️ ATEM PSU {{psuNumber}} fault - check hardware',
+  [AtemStatusCode.DISCONNECTED]: '🎬 Vision mixer offline - check ATEM at {{host}}',
+  [AtemStatusCode.PSU_FAULT]: '⚠️ ATEM PSU {{psuNumber}} fault - check hardware',
   
   // Graphics server with host:port
-  [CasparCGErrorCode.DISCONNECTED]: '{{deviceName}}: Graphics offline ({{host}}:{{port}})',
+  [CasparCGStatusCode.DISCONNECTED]: '{{deviceName}}: Graphics offline ({{host}}:{{port}})',
   
   // Function for complex logic
-  [CasparCGErrorCode.CHANNEL_ERROR]: (context: DeviceErrorContext) => {
+  [CasparCGStatusCode.CHANNEL_ERROR]: (context: DeviceStatusContext) => {
     const channel = context.channel as number
     const channelNames: Record<number, string> = {
       1: 'Program graphics',
@@ -196,7 +196,7 @@ export const deviceErrorMessages: StudioBlueprintManifest['deviceErrorMessages']
 export const manifest: StudioBlueprintManifest = {
   blueprintType: 'studio',
   // ... other required properties ...
-  deviceErrorMessages,
+  deviceStatusMessages,
 }
 ```
 
@@ -205,10 +205,10 @@ export const manifest: StudioBlueprintManifest = {
 - **Keep messages actionable** - Tell users what to do, not just what's wrong
 - **Use emoji sparingly** - They can help draw attention to critical errors
 - **Test with real devices** - Disconnect devices to verify your messages appear correctly
-- **Check TSR source** - Device error codes and their context values are defined in TSR integrations
+- **Check TSR source** - Device status codes and their context values are defined in TSR integrations
 - **Use functions for complex cases** - Conditional logic, pluralization, severity-based filtering
 
 ## See Also
 
-- [TSR Device Integrations](https://github.com/nrkno/sofie-timeline-state-resolver) - Device error codes
+- [TSR Device Integrations](https://github.com/nrkno/sofie-timeline-state-resolver) - Device status codes
 - [Demo Blueprints](https://github.com/nrkno/sofie-demo-blueprints) - Working examples

--- a/packages/job-worker/src/__mocks__/presetCollections.ts
+++ b/packages/job-worker/src/__mocks__/presetCollections.ts
@@ -430,6 +430,7 @@ export async function setupMockPeripheralDevice(
 		created: 1234,
 		status: {
 			statusCode: StatusCode.GOOD,
+			statusDetails: [],
 		},
 		lastSeen: 1234,
 		lastConnected: 1234,

--- a/packages/job-worker/src/playout/model/implementation/__tests__/PlayoutModelImpl.spec.ts
+++ b/packages/job-worker/src/playout/model/implementation/__tests__/PlayoutModelImpl.spec.ts
@@ -317,6 +317,7 @@ function setupMockPlayoutGateway(id: PeripheralDeviceId): PeripheralDevice {
 		status: {
 			statusCode: StatusCode.GOOD,
 			messages: [],
+			statusDetails: [],
 		},
 		token: '',
 	}

--- a/packages/live-status-gateway/src/coreHandler.ts
+++ b/packages/live-status-gateway/src/coreHandler.ts
@@ -20,6 +20,7 @@ import { LIVE_STATUS_DEVICE_CONFIG } from './configManifest.js'
 import {
 	PeripheralDeviceCategory,
 	PeripheralDeviceType,
+	PeripheralDeviceStatusObject,
 } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
 import { protectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 import { PeripheralDeviceCommandId, StudioId } from '@sofie-automation/shared-lib/dist/core/model/Ids'
@@ -314,24 +315,21 @@ export class CoreHandler implements ICoreHandler {
 		this.logger.info('getDevicesInfo')
 		return []
 	}
-	getCoreStatus(): {
-		statusCode: StatusCode
-		messages: string[]
-	} {
+	getCoreStatus(): PeripheralDeviceStatusObject {
 		let statusCode = StatusCode.GOOD
-		const messages: Array<string> = []
+		const statusDetails: Array<{ message: string }> = []
 
 		if (!this._statusInitialized) {
 			statusCode = StatusCode.BAD
-			messages.push('Starting up...')
+			statusDetails.push({ message: 'Starting up...' })
 		}
 		if (this._statusDestroyed) {
 			statusCode = StatusCode.BAD
-			messages.push('Shut down')
+			statusDetails.push({ message: 'Shut down' })
 		}
 		return {
 			statusCode,
-			messages,
+			statusDetails,
 		}
 	}
 	async updateCoreStatus(): Promise<any> {

--- a/packages/mos-gateway/src/CoreMosDeviceHandler.ts
+++ b/packages/mos-gateway/src/CoreMosDeviceHandler.ts
@@ -152,7 +152,7 @@ export class CoreMosDeviceHandler {
 	}
 	onMosConnectionChanged(connectionStatus: IMOSConnectionStatus): void {
 		let statusCode: StatusCode
-		const messages: Array<string> = []
+		const statusDetails: Array<{ message: string }> = []
 
 		if (this._options.openMediaHotStandby) {
 			// OpenMedia treats secondary server as hot-standby
@@ -163,12 +163,12 @@ export class CoreMosDeviceHandler {
 				// Primary not connected is only bad if there is no secondary:
 				if (connectionStatus.SecondaryConnected) {
 					statusCode = StatusCode.GOOD
-					messages.push(connectionStatus.SecondaryStatus || 'Running NRCS on hot standby')
+					statusDetails.push({ message: connectionStatus.SecondaryStatus || 'Running NRCS on hot standby' })
 				} else {
 					statusCode = StatusCode.BAD
 					// Send messages for both connections
-					messages.push(connectionStatus.PrimaryStatus || 'Primary and hot standby are not connected')
-					messages.push(connectionStatus.SecondaryStatus || 'Primary and hot standby are not connected')
+					statusDetails.push({ message: connectionStatus.PrimaryStatus || 'Primary and hot standby are not connected' })
+					statusDetails.push({ message: connectionStatus.SecondaryStatus || 'Primary and hot standby are not connected' })
 				}
 			}
 		} else {
@@ -190,17 +190,17 @@ export class CoreMosDeviceHandler {
 			}
 
 			if (!connectionStatus.PrimaryConnected) {
-				messages.push(connectionStatus.PrimaryStatus || 'Primary not connected')
+				statusDetails.push({ message: connectionStatus.PrimaryStatus || 'Primary not connected' })
 			}
 			if (this._mosDevice.idSecondary && !connectionStatus.SecondaryConnected) {
-				messages.push(connectionStatus.SecondaryStatus || 'Fallback not connected')
+				statusDetails.push({ message: connectionStatus.SecondaryStatus || 'Fallback not connected' })
 			}
 		}
 
 		this.core
 			.setStatus({
 				statusCode: statusCode,
-				messages: messages,
+				statusDetails,
 			})
 			.catch((e) => this._coreParentHandler.logger.warn('Error when setting status:' + e))
 
@@ -450,7 +450,7 @@ export class CoreMosDeviceHandler {
 
 		await this.core.setStatus({
 			statusCode: StatusCode.BAD,
-			messages: ['Uninitialized'],
+			statusDetails: [{ message: 'Uninitialized' }],
 		})
 
 		if (subdevice === 'removeSubDevice') await this.core.unInitialize()

--- a/packages/mos-gateway/src/coreHandler.ts
+++ b/packages/mos-gateway/src/coreHandler.ts
@@ -92,24 +92,21 @@ export class CoreHandler implements ICoreHandler {
 
 		await this.updateCoreStatus()
 	}
-	getCoreStatus(): {
-		statusCode: StatusCode
-		messages: string[]
-	} {
+	getCoreStatus(): PeripheralDeviceAPI.PeripheralDeviceStatusObject {
 		let statusCode = StatusCode.GOOD
-		const messages: string[] = []
+		const statusDetails: Array<{ message: string }> = []
 
 		if (!this._isInitialized) {
 			statusCode = StatusCode.BAD
-			messages.push('Starting up...')
+			statusDetails.push({ message: 'Starting up...' })
 		}
 		if (this._isDestroyed) {
 			statusCode = StatusCode.FATAL
-			messages.push('Shut down')
+			statusDetails.push({ message: 'Shut down' })
 		}
 		return {
 			statusCode,
-			messages,
+			statusDetails,
 		}
 	}
 	async updateCoreStatus(): Promise<void> {

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -55,7 +55,7 @@
 		"@sofie-automation/shared-lib": "26.3.0-2",
 		"debug": "^4.4.3",
 		"influx": "^5.12.0",
-		"timeline-state-resolver": "10.0.0-nightly-main-20260429-110933-d01800ef9.0",
+		"timeline-state-resolver": "10.0.0-nightly-main-20260514-152958-5f6033589.0",
 		"tslib": "^2.8.1",
 		"underscore": "^1.13.8",
 		"winston": "^3.19.0"

--- a/packages/playout-gateway/src/coreHandler.ts
+++ b/packages/playout-gateway/src/coreHandler.ts
@@ -375,24 +375,21 @@ export class CoreHandler implements ICoreHandler {
 
 		return Object.fromEntries(this._tsrHandler.getDebugStates().entries())
 	}
-	getCoreStatus(): {
-		statusCode: StatusCode
-		messages: string[]
-	} {
+	getCoreStatus(): PeripheralDeviceAPI.PeripheralDeviceStatusObject {
 		let statusCode = StatusCode.GOOD
-		const messages: string[] = []
+		const statusDetails: Array<{ message: string }> = []
 
 		if (!this._statusInitialized) {
 			statusCode = StatusCode.BAD
-			messages.push('Starting up...')
+			statusDetails.push({ message: 'Starting up...' })
 		}
 		if (this._statusDestroyed) {
 			statusCode = StatusCode.BAD
-			messages.push('Shut down')
+			statusDetails.push({ message: 'Shut down' })
 		}
 		return {
 			statusCode,
-			messages,
+			statusDetails,
 		}
 	}
 	async updateCoreStatus(): Promise<any> {
@@ -410,7 +407,7 @@ export class CoreTSRDeviceHandler {
 	private _hasGottenStatusChange = false
 	private _deviceStatus: PeripheralDeviceAPI.PeripheralDeviceStatusObject = {
 		statusCode: StatusCode.BAD,
-		messages: ['Starting up...'],
+		statusDetails: [{ message: 'Starting up...' }],
 	}
 	private disposed = false
 
@@ -535,7 +532,7 @@ export class CoreTSRDeviceHandler {
 
 		await this.core.setStatus({
 			statusCode: StatusCode.BAD,
-			messages: ['Uninitialized'],
+			statusDetails: [{ message: 'Uninitialized' }],
 		})
 
 		if (subdevice === 'removeSubDevice') await this.core.unInitialize()

--- a/packages/playout-gateway/src/coreHandler.ts
+++ b/packages/playout-gateway/src/coreHandler.ts
@@ -15,7 +15,7 @@ import {
 	ICoreHandler,
 	CoreConnectionChild,
 } from '@sofie-automation/server-core-integration'
-import { MediaObject, DeviceOptionsAny, ActionExecutionResult } from 'timeline-state-resolver'
+import { MediaObject, DeviceOptionsAny, ActionExecutionResult, DeviceStatus } from 'timeline-state-resolver'
 import _ from 'underscore'
 import { DeviceConfig } from './connector.js'
 import { TSRHandler } from './tsrHandler.js'
@@ -438,7 +438,15 @@ export class CoreTSRDeviceHandler {
 
 		console.log('has got status? ' + this._hasGottenStatusChange)
 		if (!this._hasGottenStatusChange) {
-			this._deviceStatus = await this._device.device.getStatus()
+			const rawStatus = await this._device.device.getStatus()
+			if ('statusDetails' in rawStatus) {
+				this._deviceStatus = rawStatus
+			} else {
+				this._deviceStatus = {
+					statusCode: rawStatus.statusCode,
+					statusDetails: rawStatus.messages.map((m) => ({ message: m })),
+				}
+			}
 		}
 		this.sendStatus()
 		if (this.disposed) throw new Error('CoreTSRDeviceHandler cant init, is disposed')
@@ -472,13 +480,14 @@ export class CoreTSRDeviceHandler {
 		// setup observers
 		this._coreParentHandler.setupObserverForPeripheralDeviceCommands(this)
 	}
-	statusChanged(deviceStatus: Partial<PeripheralDeviceAPI.PeripheralDeviceStatusObject>, fromDevice = true): void {
+	statusChanged(deviceStatus: DeviceStatus, fromDevice = true): void {
 		console.log('device ' + this._deviceId + ' status set to ' + deviceStatus.statusCode)
 		if (fromDevice) this._hasGottenStatusChange = true
 
 		this._deviceStatus = {
 			...this._deviceStatus,
-			...deviceStatus,
+			statusCode: deviceStatus.statusCode,
+			statusDetails: deviceStatus.statusDetails ?? deviceStatus.messages.map((m) => ({ message: m })),
 		}
 		this.sendStatus()
 	}

--- a/packages/playout-gateway/src/coreHandler.ts
+++ b/packages/playout-gateway/src/coreHandler.ts
@@ -444,7 +444,7 @@ export class CoreTSRDeviceHandler {
 			} else {
 				this._deviceStatus = {
 					statusCode: rawStatus.statusCode,
-					statusDetails: rawStatus.messages.map((m) => ({ message: m })),
+					statusDetails: (rawStatus.messages ?? []).map((m) => ({ message: m })),
 				}
 			}
 		}
@@ -487,7 +487,7 @@ export class CoreTSRDeviceHandler {
 		this._deviceStatus = {
 			...this._deviceStatus,
 			statusCode: deviceStatus.statusCode,
-			statusDetails: deviceStatus.statusDetails ?? deviceStatus.messages.map((m) => ({ message: m })),
+			statusDetails: deviceStatus.statusDetails ?? (deviceStatus.messages ?? []).map((m) => ({ message: m })),
 		}
 		this.sendStatus()
 	}

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -241,7 +241,7 @@ export class TSRHandler {
 			coreTsrHandler.statusChanged(
 				{
 					statusCode: StatusCode.BAD,
-					messages: ['Device initialising...'],
+					statusDetails: [{ message: 'Device initialising...' }],
 				},
 				false
 			)

--- a/packages/playout-gateway/src/tsrHandler.ts
+++ b/packages/playout-gateway/src/tsrHandler.ts
@@ -241,7 +241,9 @@ export class TSRHandler {
 			coreTsrHandler.statusChanged(
 				{
 					statusCode: StatusCode.BAD,
+					messages: ['Device initialising...'],
 					statusDetails: [{ message: 'Device initialising...' }],
+					active: false,
 				},
 				false
 			)

--- a/packages/server-core-integration/examples/client.ts
+++ b/packages/server-core-integration/examples/client.ts
@@ -69,7 +69,7 @@ const setup = async () => {
 
 		await core.setStatus({
 			statusCode: StatusCode.GOOD,
-			messages: [''],
+			statusDetails: [],
 		})
 
 		setupObserver()
@@ -80,7 +80,7 @@ const setup = async () => {
 			console.log('updating status')
 			core.setStatus({
 				statusCode: StatusCode.GOOD,
-				messages: ['a'],
+				statusDetails: [{ message: 'a' }],
 			}).catch((e) => {
 				console.error(`Failed to set status`, e)
 			})
@@ -95,7 +95,7 @@ const setup = async () => {
 			console.log('updating status')
 			core.setStatus({
 				statusCode: StatusCode.GOOD,
-				messages: ['b'],
+				statusDetails: [{ message: 'b' }],
 			}).catch((e) => {
 				console.error(`Failed to set status`, e)
 			})

--- a/packages/server-core-integration/src/__mocks__/ws.ts
+++ b/packages/server-core-integration/src/__mocks__/ws.ts
@@ -80,7 +80,7 @@ class MockWebSocket extends EventEmitter {
 							})
 						)
 					)
-					if ((message.params![2] as any).messages[0].indexOf('Jest ') >= 0) {
+					if ((message.params![2] as any).statusDetails?.[0]?.message?.indexOf('Jest ') >= 0) {
 						this.emit(
 							'message',
 							EJSON.stringify(

--- a/packages/server-core-integration/src/__tests__/index.spec.ts
+++ b/packages/server-core-integration/src/__tests__/index.spec.ts
@@ -93,7 +93,7 @@ describe('coreConnection', () => {
 
 		let statusResponse = await core.setStatus({
 			statusCode: StatusCode.WARNING_MAJOR,
-			messages: ['testing testing'],
+			statusDetails: [{ message: 'testing testing' }],
 		})
 
 		expect(statusResponse).toMatchObject({
@@ -102,6 +102,7 @@ describe('coreConnection', () => {
 
 		statusResponse = await core.setStatus({
 			statusCode: StatusCode.GOOD,
+			statusDetails: [],
 		})
 
 		expect(statusResponse).toMatchObject({
@@ -153,8 +154,7 @@ describe('coreConnection', () => {
 		// Set the status now (should cause an error)
 		await expect(
 			core.setStatus({
-				statusCode: StatusCode.GOOD,
-			})
+				statusCode: StatusCode.GOOD,				statusDetails: [],			})
 		).rejects.toMatchObject({
 			error: 404,
 		})
@@ -304,7 +304,7 @@ describe('coreConnection', () => {
 
 		await core.setStatus({
 			statusCode: StatusCode.GOOD,
-			messages: ['Jest A ' + Date.now()],
+			statusDetails: [{ message: 'Jest A ' + Date.now() }],
 		})
 		await wait(300)
 		expect(observerChanged).toHaveBeenCalledTimes(1)
@@ -322,7 +322,7 @@ describe('coreConnection', () => {
 		observerChanged.mockClear()
 		await core.setStatus({
 			statusCode: StatusCode.GOOD,
-			messages: ['Jest B' + Date.now()],
+			statusDetails: [{ message: 'Jest B' + Date.now() }],
 		})
 		await wait(300)
 		expect(observerChanged).toHaveBeenCalledTimes(1)
@@ -424,7 +424,7 @@ describe('coreConnection', () => {
 		// Set some statuses:
 		let statusResponse = await coreChild.setStatus({
 			statusCode: StatusCode.WARNING_MAJOR,
-			messages: ['testing testing'],
+			statusDetails: [{ message: 'testing testing' }],
 		})
 
 		expect(statusResponse).toMatchObject({
@@ -433,6 +433,7 @@ describe('coreConnection', () => {
 
 		statusResponse = await coreChild.setStatus({
 			statusCode: StatusCode.GOOD,
+			statusDetails: [],
 		})
 
 		expect(statusResponse).toMatchObject({
@@ -448,8 +449,7 @@ describe('coreConnection', () => {
 		// Set the status now (should cause an error)
 		await expect(
 			coreChild.setStatus({
-				statusCode: StatusCode.GOOD,
-			})
+				statusCode: StatusCode.GOOD,				statusDetails: [],			})
 		).rejects.toMatchObject({
 			error: 404,
 		})

--- a/packages/server-core-integration/src/integrationTests/index.spec.ts
+++ b/packages/server-core-integration/src/integrationTests/index.spec.ts
@@ -68,7 +68,7 @@ test('Integration: Test connection and basic Core functionality', async () => {
 
 	let statusResponse = await core.setStatus({
 		statusCode: StatusCode.WARNING_MAJOR,
-		messages: ['testing testing'],
+		statusDetails: [{ message: 'testing testing' }],
 	})
 
 	expect(statusResponse).toMatchObject({
@@ -77,6 +77,7 @@ test('Integration: Test connection and basic Core functionality', async () => {
 
 	statusResponse = await core.setStatus({
 		statusCode: StatusCode.GOOD,
+		statusDetails: [],
 	})
 
 	expect(statusResponse).toMatchObject({
@@ -130,6 +131,7 @@ test('Integration: Test connection and basic Core functionality', async () => {
 	await expect(
 		core.setStatus({
 			statusCode: StatusCode.GOOD,
+			statusDetails: [],
 		})
 	).rejects.toMatchObject({
 		error: 404,
@@ -285,7 +287,7 @@ test('Integration: autoSubscription', async () => {
 
 	await core.setStatus({
 		statusCode: StatusCode.GOOD,
-		messages: ['Jest A ' + Date.now()],
+		statusDetails: [{ message: 'Jest A ' + Date.now() }],
 	})
 	await wait(300)
 	expect(observerChanged).toHaveBeenCalledTimes(1)
@@ -303,7 +305,7 @@ test('Integration: autoSubscription', async () => {
 	observerChanged.mockClear()
 	await core.setStatus({
 		statusCode: StatusCode.GOOD,
-		messages: ['Jest B' + Date.now()],
+		statusDetails: [{ message: 'Jest B' + Date.now() }],
 	})
 	await wait(300)
 	expect(observerChanged).toHaveBeenCalledTimes(1)
@@ -404,7 +406,7 @@ test('Integration: Parent connections', async () => {
 	// Set some statuses:
 	let statusResponse = await coreChild.setStatus({
 		statusCode: StatusCode.WARNING_MAJOR,
-		messages: ['testing testing'],
+		statusDetails: [{ message: 'testing testing' }],
 	})
 
 	expect(statusResponse).toMatchObject({
@@ -413,6 +415,7 @@ test('Integration: Parent connections', async () => {
 
 	statusResponse = await coreChild.setStatus({
 		statusCode: StatusCode.GOOD,
+		statusDetails: [],
 	})
 
 	expect(statusResponse).toMatchObject({
@@ -428,8 +431,7 @@ test('Integration: Parent connections', async () => {
 	// Set the status now (should cause an error)
 	await expect(
 		coreChild.setStatus({
-			statusCode: StatusCode.GOOD,
-		})
+			statusCode: StatusCode.GOOD,			statusDetails: [],		})
 	).rejects.toMatchObject({
 		error: 404,
 	})

--- a/packages/server-core-integration/src/lib/gateway-types.ts
+++ b/packages/server-core-integration/src/lib/gateway-types.ts
@@ -1,4 +1,4 @@
-import type { StatusCode } from '@sofie-automation/shared-lib/dist/lib/status.js'
+import { PeripheralDeviceStatusObject } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
 
 export interface IConnector {
 	initialized: boolean
@@ -6,6 +6,6 @@ export interface IConnector {
 }
 
 export interface ICoreHandler {
-	getCoreStatus: () => { statusCode: StatusCode; messages: string[] }
+	getCoreStatus: () => PeripheralDeviceStatusObject
 	connectedToCore: boolean
 }

--- a/packages/server-core-integration/src/lib/gateway-types.ts
+++ b/packages/server-core-integration/src/lib/gateway-types.ts
@@ -1,4 +1,4 @@
-import { PeripheralDeviceStatusObject } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
+import type { PeripheralDeviceStatusObject } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
 
 export interface IConnector {
 	initialized: boolean

--- a/packages/server-core-integration/src/lib/health.ts
+++ b/packages/server-core-integration/src/lib/health.ts
@@ -52,7 +52,8 @@ export class HealthEndpoints {
 			else assertNever(coreStatus.statusCode)
 
 			if (ctx.status !== 200) {
-				ctx.body = `Status: ${StatusCode[coreStatus.statusCode]}, messages: ${coreStatus.messages.join(', ')}`
+				const messages = coreStatus.statusDetails.map((d) => d.message).join(', ')
+				ctx.body = `Status: ${StatusCode[coreStatus.statusCode]}, messages: ${messages}`
 			} else {
 				ctx.body = 'OK'
 			}

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -51,7 +51,7 @@
 	"dependencies": {
 		"@mos-connection/model": "^5.0.0-alpha.0",
 		"kairos-lib": "^1.0.0",
-		"timeline-state-resolver-types": "10.0.0-nightly-main-20260429-110933-d01800ef9.0",
+		"timeline-state-resolver-types": "10.0.0-nightly-main-20260514-152958-5f6033589.0",
 		"tslib": "^2.8.1",
 		"type-fest": "^4.41.0"
 	},

--- a/packages/shared-lib/src/peripheralDevice/peripheralDeviceAPI.ts
+++ b/packages/shared-lib/src/peripheralDevice/peripheralDeviceAPI.ts
@@ -81,11 +81,11 @@ export interface PeripheralDeviceStatusObject {
 	statusCode: StatusCode
 	messages?: Array<string>
 	/**
-	 * Structured status details from TSR devices for blueprint customization.
-	 * When present, blueprints can provide custom translations for these status codes.
-	 * The messages array is still populated for backward compatibility.
+	 * Structured status details for blueprint customization and UI display.
+	 * Blueprints can provide custom translations for status codes when present.
+	 * The messages array is derived from these details for backward compatibility.
 	 */
-	statusDetails?: Array<DeviceStatusDetail>
+	statusDetails: Array<DeviceStatusDetail>
 }
 // Note The actual type of a device is determined by the Category, Type and SubType
 export enum PeripheralDeviceCategory {

--- a/packages/shared-lib/src/peripheralDevice/peripheralDeviceAPI.ts
+++ b/packages/shared-lib/src/peripheralDevice/peripheralDeviceAPI.ts
@@ -1,6 +1,10 @@
 import type { DeviceConfigManifest } from '../core/deviceConfigManifest.js'
 import type { PeripheralDeviceId, RundownPlaylistId, PartInstanceId, PieceInstanceId } from '../core/model/Ids.js'
 import type { StatusCode } from '../lib/status.js'
+import { DeviceStatusError } from 'timeline-state-resolver-types'
+
+// Re-export for use in UI components
+export { DeviceStatusError }
 
 export interface PartPlaybackCallbackData {
 	rundownPlaylistId: RundownPlaylistId
@@ -76,6 +80,12 @@ export type PlayoutChangedResult = {
 export interface PeripheralDeviceStatusObject {
 	statusCode: StatusCode
 	messages?: Array<string>
+	/**
+	 * Structured errors from TSR devices for blueprint customization.
+	 * When present, blueprints can provide custom translations for these error codes.
+	 * The messages array is still populated for backward compatibility.
+	 */
+	errors?: Array<DeviceStatusError>
 }
 // Note The actual type of a device is determined by the Category, Type and SubType
 export enum PeripheralDeviceCategory {

--- a/packages/shared-lib/src/peripheralDevice/peripheralDeviceAPI.ts
+++ b/packages/shared-lib/src/peripheralDevice/peripheralDeviceAPI.ts
@@ -1,10 +1,10 @@
 import type { DeviceConfigManifest } from '../core/deviceConfigManifest.js'
 import type { PeripheralDeviceId, RundownPlaylistId, PartInstanceId, PieceInstanceId } from '../core/model/Ids.js'
 import type { StatusCode } from '../lib/status.js'
-import { DeviceStatusError } from 'timeline-state-resolver-types'
+import { DeviceStatusDetail } from 'timeline-state-resolver-types'
 
 // Re-export for use in UI components
-export { DeviceStatusError }
+export type { DeviceStatusDetail } from 'timeline-state-resolver-types'
 
 export interface PartPlaybackCallbackData {
 	rundownPlaylistId: RundownPlaylistId
@@ -81,11 +81,11 @@ export interface PeripheralDeviceStatusObject {
 	statusCode: StatusCode
 	messages?: Array<string>
 	/**
-	 * Structured errors from TSR devices for blueprint customization.
-	 * When present, blueprints can provide custom translations for these error codes.
+	 * Structured status details from TSR devices for blueprint customization.
+	 * When present, blueprints can provide custom translations for these status codes.
 	 * The messages array is still populated for backward compatibility.
 	 */
-	errors?: Array<DeviceStatusError>
+	statusDetails?: Array<DeviceStatusDetail>
 }
 // Note The actual type of a device is determined by the Category, Type and SubType
 export enum PeripheralDeviceCategory {

--- a/packages/shared-lib/src/peripheralDevice/peripheralDeviceAPI.ts
+++ b/packages/shared-lib/src/peripheralDevice/peripheralDeviceAPI.ts
@@ -1,7 +1,7 @@
 import type { DeviceConfigManifest } from '../core/deviceConfigManifest.js'
 import type { PeripheralDeviceId, RundownPlaylistId, PartInstanceId, PieceInstanceId } from '../core/model/Ids.js'
 import type { StatusCode } from '../lib/status.js'
-import { DeviceStatusDetail } from 'timeline-state-resolver-types'
+import type { DeviceStatusDetail } from 'timeline-state-resolver-types'
 
 // Re-export for use in UI components
 export type { DeviceStatusDetail } from 'timeline-state-resolver-types'

--- a/packages/shared-lib/src/systemErrorMessages.ts
+++ b/packages/shared-lib/src/systemErrorMessages.ts
@@ -1,0 +1,40 @@
+/**
+ * System-level error codes for customizable error messages.
+ *
+ * These are for core Sofie system errors.
+ * Each error code documents the variables available in the translation context.
+ */
+export enum SystemErrorCode {
+	/**
+	 * Database connection lost
+	 * Variables: database
+	 */
+	DATABASE_CONNECTION_LOST = 'SYSTEM_DB_CONNECTION_LOST',
+
+	/**
+	 * System resources running low
+	 * Variables: resource, available, required
+	 */
+	INSUFFICIENT_RESOURCES = 'SYSTEM_INSUFFICIENT_RESOURCES',
+
+	/**
+	 * Service unavailable
+	 * Variables: service, reason
+	 */
+	SERVICE_UNAVAILABLE = 'SYSTEM_SERVICE_UNAVAILABLE',
+}
+
+export interface SystemErrorContexts {
+	[SystemErrorCode.DATABASE_CONNECTION_LOST]: {
+		database: string
+	}
+	[SystemErrorCode.INSUFFICIENT_RESOURCES]: {
+		resource: string
+		available: unknown
+		required: unknown
+	}
+	[SystemErrorCode.SERVICE_UNAVAILABLE]: {
+		service: string
+		reason: string
+	}
+}

--- a/packages/webui/src/client/ui/RundownView/RundownNotifier.tsx
+++ b/packages/webui/src/client/ui/RundownView/RundownNotifier.tsx
@@ -807,7 +807,7 @@ class RundownViewNotifier extends WithManagedTracker {
 		if (!device.connected) {
 			return t('Device {{deviceName}} is disconnected', { deviceName: device.name })
 		}
-		return `${device.name}: ` + (device.status.messages || ['']).join(', ')
+		return (device.status.statusDetails?.map((d) => d.message) || ['']).join(', ')
 	}
 }
 

--- a/packages/webui/src/client/ui/RundownView/RundownNotifier.tsx
+++ b/packages/webui/src/client/ui/RundownView/RundownNotifier.tsx
@@ -807,7 +807,7 @@ class RundownViewNotifier extends WithManagedTracker {
 		if (!device.connected) {
 			return t('Device {{deviceName}} is disconnected', { deviceName: device.name })
 		}
-		return (device.status.statusDetails?.map((d) => d.message) || ['']).join(', ')
+		return `${device.name}: ` + (device.status.statusDetails?.map((d) => d.message) || ['']).join(', ')
 	}
 }
 

--- a/packages/webui/src/client/ui/Settings/DeviceSettings.tsx
+++ b/packages/webui/src/client/ui/Settings/DeviceSettings.tsx
@@ -84,7 +84,7 @@ export default function DeviceSettings(props: IDeviceSettingsProps): JSX.Element
 						<StatusCodePill
 							connected={device.connected}
 							statusCode={device.status?.statusCode}
-							messages={device.status?.messages}
+							statusDetails={device.status?.statusDetails}
 						/>
 					</div>
 					{device.type === PeripheralDeviceType.PACKAGE_MANAGER ? (

--- a/packages/webui/src/client/ui/Status/StatusCodePill.tsx
+++ b/packages/webui/src/client/ui/Status/StatusCodePill.tsx
@@ -29,7 +29,7 @@ export function statusCodeToString(t: TFunction, statusCode: StatusCode): string
 export const StatusCodePill: React.FC<{
 	connected: boolean
 	statusCode: StatusCode
-	messages?: string[]
+	statusDetails?: Array<{ message: string }>
 }> = function StatusCodePill(props) {
 	const { t } = useTranslation()
 
@@ -37,7 +37,7 @@ export const StatusCodePill: React.FC<{
 		return props.connected ? statusCodeToString(t, props.statusCode) : t('Not Connected')
 	}
 	function statusMessages() {
-		const messages = props.messages || []
+		const messages = (props.statusDetails || []).map((d) => d.message)
 		return messages.length ? '"' + messages.join(', ') + '"' : ''
 	}
 	function getStatusClassName(): string {

--- a/packages/webui/src/client/ui/Status/SystemStatus/DeviceItem.tsx
+++ b/packages/webui/src/client/ui/Status/SystemStatus/DeviceItem.tsx
@@ -63,7 +63,7 @@ export function DeviceItem({
 				<StatusCodePill
 					connected={device.connected}
 					statusCode={device?.status.statusCode}
-					messages={device?.status.messages}
+					statusDetails={device?.status.statusDetails}
 				/>
 
 				<div className="device-item__last-seen">

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -7142,7 +7142,7 @@ __metadata:
   dependencies:
     "@mos-connection/model": "npm:^5.0.0-alpha.0"
     kairos-lib: "npm:^1.0.0"
-    timeline-state-resolver-types: "npm:10.0.0-nightly-main-20260429-110933-d01800ef9.0"
+    timeline-state-resolver-types: "npm:10.0.0-nightly-main-20260514-152958-5f6033589.0"
     tslib: "npm:^2.8.1"
     type-fest: "npm:^4.41.0"
   languageName: unknown
@@ -23576,7 +23576,7 @@ asn1@evs-broadcast/node-asn1:
     "@sofie-automation/shared-lib": "npm:26.3.0-2"
     debug: "npm:^4.4.3"
     influx: "npm:^5.12.0"
-    timeline-state-resolver: "npm:10.0.0-nightly-main-20260429-110933-d01800ef9.0"
+    timeline-state-resolver: "npm:10.0.0-nightly-main-20260514-152958-5f6033589.0"
     tslib: "npm:^2.8.1"
     underscore: "npm:^1.13.8"
     winston: "npm:^3.19.0"
@@ -28320,30 +28320,30 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"timeline-state-resolver-api@npm:10.0.0-nightly-main-20260429-110933-d01800ef9.0":
-  version: 10.0.0-nightly-main-20260429-110933-d01800ef9.0
-  resolution: "timeline-state-resolver-api@npm:10.0.0-nightly-main-20260429-110933-d01800ef9.0"
+"timeline-state-resolver-api@npm:10.0.0-nightly-main-20260514-152958-5f6033589.0":
+  version: 10.0.0-nightly-main-20260514-152958-5f6033589.0
+  resolution: "timeline-state-resolver-api@npm:10.0.0-nightly-main-20260514-152958-5f6033589.0"
   dependencies:
     tslib: "npm:^2.8.1"
   peerDependencies:
-    timeline-state-resolver-types: 10.0.0-nightly-main-20260429-110933-d01800ef9.0
-  checksum: 10/3b891fc72961b0892a46c1b9e65c19caa88c0d053c502212e8edf212d45825b670b8452286bac089fee400ae062496dcdfe4ec0c2a655e719d2cf9422435eb14
+    timeline-state-resolver-types: 10.0.0-nightly-main-20260514-152958-5f6033589.0
+  checksum: 10/0dbb7d7f151fc0614d7b1303b1ad876540afb6cdcea193e339c61e247527ea8e2738230ff6a7260cdc368f61c238074bfb868535cdd776f2c040b6a4c5bdb07a
   languageName: node
   linkType: hard
 
-"timeline-state-resolver-types@npm:10.0.0-nightly-main-20260429-110933-d01800ef9.0":
-  version: 10.0.0-nightly-main-20260429-110933-d01800ef9.0
-  resolution: "timeline-state-resolver-types@npm:10.0.0-nightly-main-20260429-110933-d01800ef9.0"
+"timeline-state-resolver-types@npm:10.0.0-nightly-main-20260514-152958-5f6033589.0":
+  version: 10.0.0-nightly-main-20260514-152958-5f6033589.0
+  resolution: "timeline-state-resolver-types@npm:10.0.0-nightly-main-20260514-152958-5f6033589.0"
   dependencies:
     kairos-lib: "npm:1.0.0"
     tslib: "npm:^2.8.1"
-  checksum: 10/cbd39136ce786cdcde9faa72242e256bb3dbbf27b28088399924544f2f7a655cfc39f77b035ee0b46b4dfed86ee379869104d7ee64b75b04519adb51d367a853
+  checksum: 10/debb3faa9eda1f4ab2a85165c052cfc5b8698367d5a84be8b4095dbdaf6a40175e4c5ec80f09199e7650b53280e8c730f85bbd30685e08d3ea382ca08ee84e8b
   languageName: node
   linkType: hard
 
-"timeline-state-resolver@npm:10.0.0-nightly-main-20260429-110933-d01800ef9.0":
-  version: 10.0.0-nightly-main-20260429-110933-d01800ef9.0
-  resolution: "timeline-state-resolver@npm:10.0.0-nightly-main-20260429-110933-d01800ef9.0"
+"timeline-state-resolver@npm:10.0.0-nightly-main-20260514-152958-5f6033589.0":
+  version: 10.0.0-nightly-main-20260514-152958-5f6033589.0
+  resolution: "timeline-state-resolver@npm:10.0.0-nightly-main-20260514-152958-5f6033589.0"
   dependencies:
     "@tv2media/v-connection": "npm:^7.3.4"
     atem-connection: "npm:3.7.0"
@@ -28368,8 +28368,8 @@ asn1@evs-broadcast/node-asn1:
     sprintf-js: "npm:^1.1.3"
     superfly-timeline: "npm:^9.2.0"
     threadedclass: "npm:^1.4.0"
-    timeline-state-resolver-api: "npm:10.0.0-nightly-main-20260429-110933-d01800ef9.0"
-    timeline-state-resolver-types: "npm:10.0.0-nightly-main-20260429-110933-d01800ef9.0"
+    timeline-state-resolver-api: "npm:10.0.0-nightly-main-20260514-152958-5f6033589.0"
+    timeline-state-resolver-types: "npm:10.0.0-nightly-main-20260514-152958-5f6033589.0"
     tslib: "npm:^2.8.1"
     tv-automation-quantel-gateway-client: "npm:^3.1.7"
     type-fest: "npm:^3.13.1"
@@ -28377,7 +28377,7 @@ asn1@evs-broadcast/node-asn1:
     utf-8-validate: "npm:^6.0.6"
     ws: "npm:^8.19.0"
     xml-js: "npm:^1.6.11"
-  checksum: 10/7d130c614f95cdbe466e180f73b50284128bffc3c515f0b22f2a804552df1c08a035670ce9a788c600725a938df61a6c43bd8d02809190ce88c0ffc8dffca002
+  checksum: 10/1587b2d9e3c33b2f2754e0ae6caa0cb76e0cf1fd9c57cfeb240cbf2039e050477ba38bba03ea2717137b6943977bf82dc5f5c5b7b3ca4e17efa6aa7f90a15209
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the BBC.

## Type of Contribution

This is a Feature

## Current Behavior

Errors are reported as plain strings. This makes them hard to understand in an machine readable way by e.g. sofie blueprints or translate (localization).

<https://github.com/Sofie-Automation/sofie-timeline-state-resolver/pull/418>

## New Behavior

Errors will include error codes and context arguments.

Errors can be overridden by blueprints that will be able to either supply strings to be interpolated (now supporting custom string codes easily), or a function to generate a message given strictly typed data. This allows for complex logic like pluralisation or unwrapping errors from HTTP responses of custom devices.


## Testing

- [x] I have added one or more unit tests for this PR
- [x] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

- **Blueprint API:** Updated `resolveErrorMessage` signature for better type safety.
- **Error Resolution:** Core logic updated to handle event-based error resolution.
- **Type Definitions:** Added `BlueprintErrorContexts` for strict argument typing.

## Time Frame

- Not urgent, but we would like to get this merged into the in-development release.

## Other Information

This enables safer and richer error handling in blueprints without needing boilerplate type guards.

## Status

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
