### PR TITLE
feat: add info about AB channels (players) to LSG (SOFIE-288)

### DIFF
--- a/packages/live-status-gateway-api/api/components/piece/pieceStatus/abSessionAssignment-example.yaml
+++ b/packages/live-status-gateway-api/api/components/piece/pieceStatus/abSessionAssignment-example.yaml
@@ -1,0 +1,3 @@
+poolName: 'VTR'
+sessionName: 'clip_intro'
+playerId: 1

--- a/packages/live-status-gateway-api/api/components/piece/pieceStatus/abSessionAssignment.yaml
+++ b/packages/live-status-gateway-api/api/components/piece/pieceStatus/abSessionAssignment.yaml
@@ -1,0 +1,16 @@
+type: object
+title: AbSessionAssignment
+properties:
+  poolName:
+    description: The name of the AB Pool this session is for
+    type: string
+  sessionName:
+    description: Name of the session
+    type: string
+  playerId:
+    description: The assigned player ID
+    oneOf:
+      - type: string
+      - type: number
+required: [poolName, sessionName, playerId]
+additionalProperties: false

--- a/packages/live-status-gateway-api/api/components/piece/pieceStatus/pieceStatus-example.yaml
+++ b/packages/live-status-gateway-api/api/components/piece/pieceStatus/pieceStatus-example.yaml
@@ -6,6 +6,4 @@ tags: ['camera']
 publicData:
   switcherSource: 1
 abSessions:
-  - poolName: 'VTR'
-    sessionName: 'clip_intro'
-    playerId: 1
+  - $ref: './abSessionAssignment-example.yaml'

--- a/packages/live-status-gateway-api/api/components/piece/pieceStatus/pieceStatus-example.yaml
+++ b/packages/live-status-gateway-api/api/components/piece/pieceStatus/pieceStatus-example.yaml
@@ -5,3 +5,7 @@ outputLayer: 'PGM'
 tags: ['camera']
 publicData:
   switcherSource: 1
+abSessions:
+  - poolName: 'VTR'
+    sessionName: 'clip_intro'
+    playerId: 1

--- a/packages/live-status-gateway-api/api/components/piece/pieceStatus/pieceStatus.yaml
+++ b/packages/live-status-gateway-api/api/components/piece/pieceStatus/pieceStatus.yaml
@@ -1,21 +1,4 @@
 $defs:
-  abSessionAssignment:
-    type: object
-    title: AbSessionAssignment
-    properties:
-      poolName:
-        description: The name of the AB Pool this session is for
-        type: string
-      sessionName:
-        description: Name of the session
-        type: string
-      playerId:
-        description: The assigned player ID
-        oneOf:
-          - type: string
-          - type: number
-    required: [poolName, sessionName, playerId]
-    additionalProperties: false
   pieceStatus:
     type: object
     title: PieceStatus
@@ -43,7 +26,7 @@ $defs:
         description: AB playback session assignments for this Piece
         type: array
         items:
-          $ref: '#/$defs/abSessionAssignment'
+          $ref: './abSessionAssignment.yaml'
     required: [id, name, sourceLayer, outputLayer]
     additionalProperties: false
     examples:

--- a/packages/live-status-gateway-api/api/components/piece/pieceStatus/pieceStatus.yaml
+++ b/packages/live-status-gateway-api/api/components/piece/pieceStatus/pieceStatus.yaml
@@ -1,4 +1,21 @@
 $defs:
+  abSessionAssignment:
+    type: object
+    title: AbSessionAssignment
+    properties:
+      poolName:
+        description: The name of the AB Pool this session is for
+        type: string
+      sessionName:
+        description: Name of the session
+        type: string
+      playerId:
+        description: The assigned player ID
+        oneOf:
+          - type: string
+          - type: number
+    required: [poolName, sessionName, playerId]
+    additionalProperties: false
   pieceStatus:
     type: object
     title: PieceStatus
@@ -22,6 +39,11 @@ $defs:
           type: string
       publicData:
         description: Optional arbitrary data
+      abSessions:
+        description: AB playback session assignments for this Piece
+        type: array
+        items:
+          $ref: '#/$defs/abSessionAssignment'
     required: [id, name, sourceLayer, outputLayer]
     additionalProperties: false
     examples:

--- a/packages/live-status-gateway-api/src/generated/asyncapi.yaml
+++ b/packages/live-status-gateway-api/src/generated/asyncapi.yaml
@@ -424,6 +424,29 @@ channels:
                                           type: string
                                       publicData:
                                         description: Optional arbitrary data
+                                      abSessions:
+                                        description: AB playback session assignments for this Piece
+                                        type: array
+                                        items:
+                                          type: object
+                                          title: AbSessionAssignment
+                                          properties:
+                                            poolName:
+                                              description: The name of the AB Pool this session is for
+                                              type: string
+                                            sessionName:
+                                              description: Name of the session
+                                              type: string
+                                            playerId:
+                                              description: The assigned player ID
+                                              oneOf:
+                                                - type: string
+                                                - type: number
+                                          required:
+                                            - poolName
+                                            - sessionName
+                                            - playerId
+                                          additionalProperties: false
                                     required:
                                       - id
                                       - name
@@ -440,6 +463,10 @@ channels:
                                           - camera
                                         publicData:
                                           switcherSource: 1
+                                        abSessions:
+                                          - poolName: VTR
+                                            sessionName: clip_intro
+                                            playerId: 1
                                 publicData:
                                   description: Optional arbitrary data
                               required:

--- a/packages/live-status-gateway-api/src/generated/schema.ts
+++ b/packages/live-status-gateway-api/src/generated/schema.ts
@@ -245,6 +245,25 @@ interface PieceStatus {
 	 * Optional arbitrary data
 	 */
 	publicData?: any
+	/**
+	 * AB playback session assignments for this Piece
+	 */
+	abSessions?: AbSessionAssignment[]
+}
+
+interface AbSessionAssignment {
+	/**
+	 * The name of the AB Pool this session is for
+	 */
+	poolName: string
+	/**
+	 * Name of the session
+	 */
+	sessionName: string
+	/**
+	 * The assigned player ID
+	 */
+	playerId: string | number
 }
 
 /**
@@ -912,6 +931,7 @@ export {
 	ActivePlaylistEvent,
 	CurrentPartStatus,
 	PieceStatus,
+	AbSessionAssignment,
 	CurrentPartTiming,
 	CurrentSegment,
 	CurrentSegmentTiming,

--- a/packages/live-status-gateway/src/topics/activePlaylistTopic.ts
+++ b/packages/live-status-gateway/src/topics/activePlaylistTopic.ts
@@ -50,8 +50,6 @@ const PLAYLIST_KEYS = [
 	'timing',
 	'startedPlayback',
 	'quickLoop',
-	'assignedAbSessions',
-	'trackedAbSessions',
 ] as const
 type Playlist = PickKeys<DBRundownPlaylist, typeof PLAYLIST_KEYS>
 

--- a/packages/live-status-gateway/src/topics/activePlaylistTopic.ts
+++ b/packages/live-status-gateway/src/topics/activePlaylistTopic.ts
@@ -50,6 +50,8 @@ const PLAYLIST_KEYS = [
 	'timing',
 	'startedPlayback',
 	'quickLoop',
+	'assignedAbSessions',
+	'trackedAbSessions',
 ] as const
 type Playlist = PickKeys<DBRundownPlaylist, typeof PLAYLIST_KEYS>
 

--- a/packages/live-status-gateway/src/topics/helpers/pieceStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/pieceStatus.ts
@@ -3,13 +3,20 @@ import type { ShowStyleBaseExt } from '../../collections/showStyleBaseHandler.js
 import type { PieceInstanceMin } from '../../collections/pieceInstancesHandler.js'
 import type { PieceStatus } from '@sofie-automation/live-status-gateway-api'
 import { clone } from '@sofie-automation/corelib/dist/lib'
+import type { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
+import type { PickKeys } from '@sofie-automation/shared-lib/dist/lib/types'
+
+const _PLAYLIST_AB_SESSION_KEYS = ['assignedAbSessions', 'trackedAbSessions'] as const
+type PlaylistAbSessions = PickKeys<DBRundownPlaylist, typeof _PLAYLIST_AB_SESSION_KEYS>
 
 export function toPieceStatus(
 	pieceInstance: PieceInstanceMin,
-	showStyleBaseExt: ShowStyleBaseExt | undefined
+	showStyleBaseExt: ShowStyleBaseExt | undefined,
+	playlist?: PlaylistAbSessions
 ): PieceStatus {
 	const sourceLayerName = showStyleBaseExt?.sourceLayerNamesById.get(pieceInstance.piece.sourceLayerId)
 	const outputLayerName = showStyleBaseExt?.outputLayerNamesById.get(pieceInstance.piece.outputLayerId)
+
 	return {
 		id: unprotectString(pieceInstance._id),
 		name: pieceInstance.piece.name,
@@ -17,5 +24,35 @@ export function toPieceStatus(
 		outputLayer: outputLayerName ?? 'invalid',
 		tags: clone<string[] | undefined>(pieceInstance.piece.tags),
 		publicData: pieceInstance.piece.publicData,
+		abSessions: getAbSessions(pieceInstance, playlist),
 	}
+}
+
+function getAbSessions(pieceInstance: PieceInstanceMin, playlist?: PlaylistAbSessions) {
+	if (!pieceInstance.piece.abSessions || !playlist?.trackedAbSessions || !playlist?.assignedAbSessions) {
+		return []
+	}
+
+	const abSessions = []
+
+	for (const session of pieceInstance.piece.abSessions) {
+		const trackedSession = playlist.trackedAbSessions.find(
+			(s) => s.name === `${session.poolName}_${session.sessionName}`
+		)
+
+		if (trackedSession) {
+			const poolAssignments = playlist.assignedAbSessions[session.poolName]
+			const assignment = poolAssignments?.[trackedSession.id]
+
+			if (assignment) {
+				abSessions.push({
+					poolName: session.poolName,
+					sessionName: session.sessionName,
+					playerId: assignment.playerId,
+				})
+			}
+		}
+	}
+
+	return abSessions
 }

--- a/packages/live-status-gateway/src/topics/helpers/pieceStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/pieceStatus.ts
@@ -1,7 +1,7 @@
 import { unprotectString } from '@sofie-automation/server-core-integration'
 import type { ShowStyleBaseExt } from '../../collections/showStyleBaseHandler.js'
 import type { PieceInstanceMin } from '../../collections/pieceInstancesHandler.js'
-import type { PieceStatus } from '@sofie-automation/live-status-gateway-api'
+import type { AbSessionAssignment, PieceStatus } from '@sofie-automation/live-status-gateway-api'
 import { clone } from '@sofie-automation/corelib/dist/lib'
 import type { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import type { PickKeys } from '@sofie-automation/shared-lib/dist/lib/types'
@@ -33,7 +33,7 @@ function getAbSessions(pieceInstance: PieceInstanceMin, playlist?: PlaylistAbSes
 		return []
 	}
 
-	const abSessions = []
+	const abSessions: AbSessionAssignment[] = []
 
 	for (const session of pieceInstance.piece.abSessions) {
 		const trackedSession = playlist.trackedAbSessions.find(


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This PR is made on behalf of the BBC

## Type of Contribution

This is a:

<!-- (pick one) -->

Feature

## Current Behavior

Currently, information about currently resolved/assigned AB channels for a piece is not present in LSG

## New Behavior

This PR adds information about assigned AB player/channel to LSG

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

Information passed from core to LSG regarding piece state

## Time Frame

 Not urgent, but we would like to get this merged into the in-development release.

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds support for broadcasting information about assigned AB playback channel/player sessions to LSG (Live Status Gateway). Currently, the LSG does not include data about which AB channels or players are assigned to a piece, even though this information is tracked in the core system.

## Changes

The implementation spans across the LSG API schema and backend services:

### API Schema Updates
- **pieceStatus.yaml**: Introduces a new `abSessionAssignment` schema definition with fields for `poolName` (string), `sessionName` (string), and `playerId` (string or number), all required with no additional properties allowed
- **pieceStatus.yaml**: Adds a new `abSessions` property to the `PieceStatus` type as an array of `abSessionAssignment` objects
- **pieceStatus-example.yaml**: Includes an example with a sample AB session assignment (pool: 'VTR', session: 'clip_intro', player: 1)

### Backend Implementation
- **pieceStatus.ts**: 
  - Extends `toPieceStatus()` function signature to accept an optional `playlist` parameter of type `PlaylistAbSessions`
  - Introduces internal helper `getAbSessions()` to derive AB session data by mapping piece AB sessions against tracked and assigned sessions from the playlist
  - Updates the returned `PieceStatus` object to include the computed `abSessions` field
  
- **activePiecesTopic.ts**:
  - Adds a private `_playlist` member to store the current playlist
  - Passes the stored playlist to `toPieceStatus()` calls when mapping active pieces
  - Updates `onPlaylistUpdate()` to store the incoming playlist data
  
- **activePlaylistTopic.ts**:
  - Extends the `PLAYLIST_KEYS` constant to include `assignedAbSessions` and `trackedAbSessions`
  - Updates the `Playlist` type to reflect these additional fields from the underlying `DBRundownPlaylist`

## Technical Details

The feature enables the LSG to track and communicate which AB (audio/video playback) channels or sessions are currently assigned to each piece in the active part of a rundown. This information flows from the core system through the LSG API to downstream consumers, allowing external systems to have visibility into playback resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->