### PR TITLE
fix: Mini shelf text wrapping

### DIFF
--- a/packages/webui/src/client/styles/shelf/dashboard.scss
+++ b/packages/webui/src/client/styles/shelf/dashboard.scss
@@ -120,7 +120,7 @@ $dashboard-button-height: 3.625em;
 			> svg {
 				height: 1em;
 				vertical-align: top;
-    			margin-top: 0.05em;
+				margin-top: 0.05em;
 			}
 		}
 	}
@@ -437,7 +437,9 @@ $dashboard-button-height: 3.625em;
 						1px -1px 0px rgba(0, 0, 0, 0.5),
 						0.5px 0.5px 2px rgba(0, 0, 0, 1);
 					z-index: 2;
-					text-wrap: balance;
+					word-break: break-word;
+					overflow-wrap: break-word;
+					white-space: normal;
 
 					&.dashboard-panel__panel__button__label--editable {
 						text-shadow: none;


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This PR is made on behalf of the BBC

## Type of Contribution

This is a:

<!-- (pick one) -->

Bug fix 

## Current Behavior

Sometimes, text in adlibs breaks words in the middle 
<img width="991" height="324" alt="image" src="https://github.com/user-attachments/assets/ce1fcf92-1ec9-4b13-99cb-d167038696fb" />


## New Behavior

It doesn't break words in the middle anymore
<img width="928" height="300" alt="image" src="https://github.com/user-attachments/assets/2a702476-1bc3-4a97-9081-c0fdbf9c890e" />


## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

Rundown view

## Time Frame

Not urgent, but we would like to get this merged into the in-development release.

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
