### PR TITLE
feat: add informative REST results for TAKE failures (SOFIE-295) 

### DIFF
--- a/meteor/server/api/rest/v1/playlists.ts
+++ b/meteor/server/api/rest/v1/playlists.ts
@@ -32,7 +32,7 @@ import {
 } from '../../../collections'
 import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { ServerClientAPI } from '../../client'
-import { QueueNextSegmentResult, StudioJobs } from '@sofie-automation/corelib/dist/worker/studio'
+import { QueueNextSegmentResult, StudioJobs, TakeNextPartResult } from '@sofie-automation/corelib/dist/worker/studio'
 import { getCurrentTime } from '../../../lib/lib'
 import { TriggerReloadDataResponse } from '@sofie-automation/meteor-lib/dist/api/userActions'
 import { ServerRundownAPI } from '../../rundown'
@@ -559,7 +559,7 @@ class PlaylistsServerAPI implements PlaylistsRestAPI {
 		event: string,
 		rundownPlaylistId: RundownPlaylistId,
 		fromPartInstanceId: PartInstanceId | undefined
-	): Promise<ClientAPI.ClientResponse<void>> {
+	): Promise<ClientAPI.ClientResponse<TakeNextPartResult>> {
 		triggerWriteAccess()
 		const playlist = await this.findPlaylist(rundownPlaylistId)
 
@@ -923,7 +923,7 @@ export function registerRoutes(registerRoute: APIRegisterHook<PlaylistsRestAPI>)
 		}
 	)
 
-	registerRoute<{ playlistId: string }, { fromPartInstanceId?: string }, void>(
+	registerRoute<{ playlistId: string }, { fromPartInstanceId?: string }, TakeNextPartResult>(
 		'post',
 		'/playlists/:playlistId/take',
 		new Map([

--- a/meteor/server/lib/rest/v1/playlists.ts
+++ b/meteor/server/lib/rest/v1/playlists.ts
@@ -11,7 +11,7 @@ import {
 	RundownPlaylistId,
 	SegmentId,
 } from '@sofie-automation/corelib/dist/dataModel/Ids'
-import { QueueNextSegmentResult } from '@sofie-automation/corelib/dist/worker/studio'
+import { QueueNextSegmentResult, TakeNextPartResult } from '@sofie-automation/corelib/dist/worker/studio'
 import { Meteor } from 'meteor/meteor'
 
 /* *************************************************************************
@@ -238,7 +238,7 @@ export interface PlaylistsRestAPI {
 		event: string,
 		rundownPlaylistId: RundownPlaylistId,
 		fromPartInstanceId: PartInstanceId | undefined
-	): Promise<ClientAPI.ClientResponse<void>>
+	): Promise<ClientAPI.ClientResponse<TakeNextPartResult>>
 	/**
 	 * Clears the specified SourceLayers.
 	 *

--- a/packages/corelib/src/worker/studio.ts
+++ b/packages/corelib/src/worker/studio.ts
@@ -380,6 +380,10 @@ export interface CleanupOrphanedExpectedPackageReferencesProps {
 	rundownId: RundownId
 }
 
+export interface TakeNextPartResult {
+	nextTakeTime: number
+}
+
 /**
  * Set of valid functions, of form:
  * `id: (data) => return`
@@ -404,7 +408,7 @@ export type StudioJobFunc = {
 	[StudioJobs.QueueNextSegment]: (data: QueueNextSegmentProps) => QueueNextSegmentResult
 	[StudioJobs.ExecuteAction]: (data: ExecuteActionProps) => ExecuteActionResult
 	[StudioJobs.ExecuteBucketAdLibOrAction]: (data: ExecuteBucketAdLibOrActionProps) => ExecuteActionResult
-	[StudioJobs.TakeNextPart]: (data: TakeNextPartProps) => void
+	[StudioJobs.TakeNextPart]: (data: TakeNextPartProps) => TakeNextPartResult
 	[StudioJobs.DisableNextPiece]: (data: DisableNextPieceProps) => void
 	[StudioJobs.RemovePlaylist]: (data: RemovePlaylistProps) => void
 	[StudioJobs.RegeneratePlaylist]: (data: RegeneratePlaylistProps) => void

--- a/packages/meteor-lib/src/api/__tests__/client.test.ts
+++ b/packages/meteor-lib/src/api/__tests__/client.test.ts
@@ -50,7 +50,7 @@ describe('ClientAPI', () => {
 			})
 		}
 	})
-	it('Extracts nextAllowedTakeTime from error args', () => {
+	it('Extracts additionalInfo from error args', () => {
 		const error = ClientAPI.responseError(
 			UserError.create(
 				UserErrorMessage.TakeRateLimit,
@@ -61,12 +61,12 @@ describe('ClientAPI', () => {
 				429
 			)
 		)
-		expect(error.nextAllowedTakeTime).toBe(1234567890)
+		expect(error.additionalInfo).toEqual({ duration: 1000, nextAllowedTakeTime: 1234567890 })
 		expect(error.errorCode).toBe(429)
 	})
-	it('Does not include nextAllowedTakeTime when not in args', () => {
+	it('Does not include additionalInfo when no args', () => {
 		const error = ClientAPI.responseError(UserError.create(UserErrorMessage.InactiveRundown))
-		expect(error.nextAllowedTakeTime).toBeUndefined()
+		expect(error.additionalInfo).toBeUndefined()
 	})
 	describe('isClientResponseSuccess', () => {
 		it('Correctly recognizes a responseSuccess object', () => {

--- a/packages/meteor-lib/src/api/__tests__/client.test.ts
+++ b/packages/meteor-lib/src/api/__tests__/client.test.ts
@@ -50,6 +50,24 @@ describe('ClientAPI', () => {
 			})
 		}
 	})
+	it('Extracts nextAllowedTakeTime from error args', () => {
+		const error = ClientAPI.responseError(
+			UserError.create(
+				UserErrorMessage.TakeRateLimit,
+				{
+					duration: 1000,
+					nextAllowedTakeTime: 1234567890,
+				},
+				429
+			)
+		)
+		expect(error.nextAllowedTakeTime).toBe(1234567890)
+		expect(error.errorCode).toBe(429)
+	})
+	it('Does not include nextAllowedTakeTime when not in args', () => {
+		const error = ClientAPI.responseError(UserError.create(UserErrorMessage.InactiveRundown))
+		expect(error.nextAllowedTakeTime).toBeUndefined()
+	})
 	describe('isClientResponseSuccess', () => {
 		it('Correctly recognizes a responseSuccess object', () => {
 			const response = ClientAPI.responseSuccess(undefined)

--- a/packages/meteor-lib/src/api/client.ts
+++ b/packages/meteor-lib/src/api/client.ts
@@ -50,6 +50,8 @@ export namespace ClientAPI {
 		errorCode: number
 		/** On error, provide a human-readable error message */
 		error: SerializedUserError
+		/** For blocked TAKE operations, the next allowed take time (Unix timestamp ms) */
+		nextAllowedTakeTime?: number
 	}
 
 	/**
@@ -59,7 +61,12 @@ export namespace ClientAPI {
 	 * @returns A `ClientResponseError` object containing the error and the resolved error code.
 	 */
 	export function responseError(userError: UserError): ClientResponseError {
-		return { error: UserError.serialize(userError), errorCode: userError.errorCode }
+		const nextAllowedTakeTime = userError.userMessage.args?.nextAllowedTakeTime as number | undefined
+		return {
+			error: UserError.serialize(userError),
+			errorCode: userError.errorCode,
+			...(nextAllowedTakeTime !== undefined && { nextAllowedTakeTime }),
+		}
 	}
 	export interface ClientResponseSuccess<Result> {
 		/** On success, return success code (by default, use 200) */

--- a/packages/meteor-lib/src/api/client.ts
+++ b/packages/meteor-lib/src/api/client.ts
@@ -50,8 +50,8 @@ export namespace ClientAPI {
 		errorCode: number
 		/** On error, provide a human-readable error message */
 		error: SerializedUserError
-		/** For blocked TAKE operations, the next allowed take time (Unix timestamp ms) */
-		nextAllowedTakeTime?: number
+		/** Optional additional information about the error, forwarded from UserError args */
+		additionalInfo?: Record<string, unknown>
 	}
 
 	/**
@@ -61,11 +61,11 @@ export namespace ClientAPI {
 	 * @returns A `ClientResponseError` object containing the error and the resolved error code.
 	 */
 	export function responseError(userError: UserError): ClientResponseError {
-		const nextAllowedTakeTime = userError.userMessage.args?.nextAllowedTakeTime as number | undefined
+		const args = userError.userMessage.args
 		return {
 			error: UserError.serialize(userError),
 			errorCode: userError.errorCode,
-			...(nextAllowedTakeTime !== undefined && { nextAllowedTakeTime }),
+			...(args !== undefined && Object.keys(args).length > 0 && { additionalInfo: args }),
 		}
 	}
 	export interface ClientResponseSuccess<Result> {

--- a/packages/meteor-lib/src/api/userActions.ts
+++ b/packages/meteor-lib/src/api/userActions.ts
@@ -6,7 +6,11 @@ import { BucketAdLib } from '@sofie-automation/corelib/dist/dataModel/BucketAdLi
 import { AdLibActionCommon } from '@sofie-automation/corelib/dist/dataModel/AdlibAction'
 import { BucketAdLibAction } from '@sofie-automation/corelib/dist/dataModel/BucketAdLibAction'
 import { Time } from '@sofie-automation/blueprints-integration'
-import { ExecuteActionResult, QueueNextSegmentResult } from '@sofie-automation/corelib/dist/worker/studio'
+import {
+	ExecuteActionResult,
+	QueueNextSegmentResult,
+	TakeNextPartResult,
+} from '@sofie-automation/corelib/dist/worker/studio'
 import {
 	AdLibActionId,
 	BucketAdLibActionId,
@@ -34,7 +38,7 @@ export interface NewUserActionAPI {
 		eventTime: Time,
 		rundownPlaylistId: RundownPlaylistId,
 		fromPartInstanceId: PartInstanceId | null
-	): Promise<ClientAPI.ClientResponse<void>>
+	): Promise<ClientAPI.ClientResponse<TakeNextPartResult>>
 	setNext(
 		userEvent: string,
 		eventTime: Time,

--- a/packages/openapi/api/definitions/playlists.yaml
+++ b/packages/openapi/api/definitions/playlists.yaml
@@ -589,7 +589,22 @@ resources:
                   description: May be specified to ensure that multiple take requests from the same Part do not result in multiple takes.
       responses:
         200:
-          $ref: '#/components/responses/putSuccess'
+          description: Take was successful - returns the next allowed take time.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: number
+                    example: 200
+                  result:
+                    type: object
+                    properties:
+                      nextTakeTime:
+                        type: number
+                        description: Unix timestamp (ms) of when the next take will be allowed.
+                        example: 1707024000000
         404:
           $ref: '#/components/responses/playlistNotFound'
         412:
@@ -605,6 +620,40 @@ resources:
                   message:
                     type: string
                     example: No Next point found, please set a part as Next before doing a TAKE.
+        425:
+          description: Take is blocked due to a transition or adlib action.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: number
+                    example: 425
+                  message:
+                    type: string
+                    example: Cannot take during a transition
+                  nextAllowedTakeTime:
+                    type: number
+                    description: Unix timestamp (ms) of when the next take will be allowed.
+                    example: 1707024000000
+        429:
+          description: Take rate limit exceeded - takes are happening too quickly.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: number
+                    example: 429
+                  message:
+                    type: string
+                    example: Ignoring TAKES that are too quick after eachother (1000 ms)
+                  nextAllowedTakeTime:
+                    type: number
+                    description: Unix timestamp (ms) of when the next take will be allowed.
+                    example: 1707024000000
         500:
           $ref: '#/components/responses/internalServerError'
 

--- a/packages/openapi/api/definitions/playlists.yaml
+++ b/packages/openapi/api/definitions/playlists.yaml
@@ -633,10 +633,10 @@ resources:
                   message:
                     type: string
                     example: Cannot take during a transition
-                  nextAllowedTakeTime:
-                    type: number
-                    description: Unix timestamp (ms) of when the next take will be allowed.
-                    example: 1707024000000
+                  additionalInfo:
+                    type: object
+                    description: Additional error details, e.g. includes nextAllowedTakeTime (Unix timestamp ms) for blocked takes.
+                    additionalProperties: true
         429:
           description: Take rate limit exceeded - takes are happening too quickly.
           content:
@@ -650,10 +650,10 @@ resources:
                   message:
                     type: string
                     example: Ignoring TAKES that are too quick after eachother (1000 ms)
-                  nextAllowedTakeTime:
-                    type: number
-                    description: Unix timestamp (ms) of when the next take will be allowed.
-                    example: 1707024000000
+                  additionalInfo:
+                    type: object
+                    description: Additional error details, e.g. includes nextAllowedTakeTime (Unix timestamp ms) for blocked takes.
+                    additionalProperties: true
         500:
           $ref: '#/components/responses/internalServerError'
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This PR is made on behalf of the BBC

## Type of Contribution

This is a:


Feature

## Current Behavior

The TAKE endpoint returns either 200 or 500, without any additional information

## New Behavior

HTTP Rest codes 400, 425 and 429 are added as possible failure reasons, and a UTC timestamp for next possible take is added

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

the TAKE endpoint

## Time Frame

Not urgent, but we would like to get this merged into the in-development release.

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds informative REST results for TAKE failures by extending the TAKE endpoint to return additional HTTP status codes, include timing information in responses, and propagate additional error details to clients.

## Changes

### New Data Types
-	Introduced `TakeNextPartResult` in `packages/corelib/src/worker/studio.ts` with `nextTakeTime: number` to communicate the next available TAKE time.

### Enhanced Error Handling & Return Values
-	`handleTakeNextPart` in `packages/job-worker/src/playout/take.ts` now returns `Promise<TakeNextPartResult>` and supplies `nextTakeTime` on success.
-	Error handling augmented to include additional contextual information and HTTP-like status semantics:
	-	HTTP 425 used for blocked TAKE conditions (transition, adlib, too-close-to-autonext); error payloads include `nextAllowedTakeTime`.
	-	HTTP 429 used for rate-limited TAKE requests; error payloads include `nextAllowedTakeTime`.
-	Several Take-related error branches (`TakeBlockedDuration`, `TakeDuringTransition`, `TakeCloseToAutonext`, rate-limit) now attach `nextAllowedTakeTime` in their error objects.

### API Surface Updates
-	Return types updated to expose `TakeNextPartResult`:
	-	`PlaylistsServerAPI.take` in `meteor/server/api/rest/v1/playlists.ts`: `ClientAPI.ClientResponse<TakeNextPartResult>`.
	-	`PlaylistsRestAPI.take` in `meteor/server/lib/rest/v1/playlists.ts`: `Promise<ClientAPI.ClientResponse<TakeNextPartResult>>`.
	-	`NewUserActionAPI.take` in `packages/meteor-lib/src/api/userActions.ts`: `Promise<ClientAPI.ClientResponse<TakeNextPartResult>>`.
-	`ClientAPI.ClientResponseError` in `packages/meteor-lib/src/api/client.ts` now includes an optional `additionalInfo?: Record<string, unknown>`, and `responseError` populates this from user error args when present.
-	Server-side REST error propagation (`meteor/server/api/rest/v1/index.ts`) now accepts and forwards `additionalInfo` from client errors into HTTP responses.

### OpenAPI Documentation
-	`packages/openapi/api/definitions/playlists.yaml` updated:
	-	Explicit 200 response schema for TAKE including `nextTakeTime`.
	-	New 425 and 429 response definitions including `additionalInfo` (e.g. `nextAllowedTakeTime`).

### Tests
-	Added tests in `packages/meteor-lib/src/api/__tests__/client.test.ts` to verify extraction and propagation of `additionalInfo` (including `nextAllowedTakeTime`) when present, and absence when not provided.

## Impact

Clients calling the TAKE endpoint now receive:
-	Clearer failure reasons (blocked vs. rate-limited) via distinct status codes.
-	A UTC timestamp (`nextTakeTime` / `nextAllowedTakeTime` in `additionalInfo`) indicating when the next TAKE is allowed, enabling smarter client retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->