### PR TITLE
fix: enable piece actions in context menu

### DIFF
--- a/packages/webui/src/client/styles/contextMenu.scss
+++ b/packages/webui/src/client/styles/contextMenu.scss
@@ -51,6 +51,7 @@ nav.react-contextmenu {
 		flex-direction: row;
 		align-items: center;
 
+		&:hover:not(.react-contextmenu-item--disabled),
 		&.react-contextmenu-item--selected:not(.react-contextmenu-item--disabled) {
 			background: #313334;
 			color: #ffffff;

--- a/packages/webui/src/client/ui/SegmentTimeline/SegmentContextMenu.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/SegmentContextMenu.tsx
@@ -15,6 +15,7 @@ import { PartUi, SegmentUi } from './SegmentTimelineContainer.js'
 import { SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { SegmentOrphanedReason } from '@sofie-automation/corelib/dist/dataModel/Segment'
 import { UserEditOperationMenuItems } from '../UserEditOperations/RenderUserEditOperations.js'
+import { CoreUserEditingDefinition } from '@sofie-automation/corelib/dist/dataModel/UserEditingDefinitions'
 import * as RundownResolver from '../../lib/RundownResolver.js'
 import { SelectedElement } from '../RundownView/SelectedElementsContext.js'
 import { PieceExtended } from '../../lib/RundownResolver.js'
@@ -198,6 +199,22 @@ export const SegmentContextMenu = withTranslation()(
 									userEditOperations={part.instance.part.userEditOperations}
 									isFormEditable={isPartEditAble}
 								/>
+
+								{piece && piece.instance.piece.userEditOperations && (
+									<UserEditOperationMenuItems
+										rundownId={part.instance.rundownId}
+										targetName={piece.instance.piece.name}
+										operationTarget={{
+											segmentExternalId: segment?.externalId,
+											partExternalId: part.instance.part.externalId,
+											pieceExternalId: piece.instance.piece.externalId,
+										}}
+										userEditOperations={
+											piece.instance.piece.userEditOperations as CoreUserEditingDefinition[] | undefined
+										}
+										isFormEditable={isPartEditAble}
+									/>
+								)}
 
 								{this.props.enableUserEdits && (
 									<>


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This PR is made on behalf of the BBC

## Type of Contribution

This is a:

<!-- (pick one) -->

Bug fix

## Current Behavior

Currently, user-defined piece actions are not displayed in the context menu whenever a piece is clicked

## New Behavior

User-defined piece actions are now displayed
<img width="583" height="456" alt="image" src="https://github.com/user-attachments/assets/4a3693d7-34f0-4d5d-8912-6f3a02cedb22" />


## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

This PR affects the rundown screen

## Time Frame

Not urgent, but we would like to get this merged into the in-development release.

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
