### PR TITLE
test: Fix openapi ingest test by reordering

### DIFF
--- a/packages/openapi/src/__tests__/ingest.spec.ts
+++ b/packages/openapi/src/__tests__/ingest.spec.ts
@@ -53,19 +53,6 @@ describe('Ingest API', () => {
 		})
 	})
 
-	test('Can delete multiple playlists', async () => {
-		const result = await ingestApi.deletePlaylists({ studioId })
-		expect(result).toBe(undefined)
-	})
-
-	test('Can delete playlist by id', async () => {
-		const result = await ingestApi.deletePlaylist({
-			studioId,
-			playlistId: playlistIds[0],
-		})
-		expect(result).toBe(undefined)
-	})
-
 	/**
 	 * RUNDOWNS
 	 */
@@ -159,20 +146,6 @@ describe('Ingest API', () => {
 		expect(result).toBe(undefined)
 	})
 
-	test('Can delete multiple rundowns', async () => {
-		const result = await ingestApi.deleteRundowns({ studioId, playlistId: playlistIds[0] })
-		expect(result).toBe(undefined)
-	})
-
-	test('Can delete rundown by id', async () => {
-		const result = await ingestApi.deleteRundown({
-			studioId,
-			playlistId: playlistIds[0],
-			rundownId: updatedRundownId,
-		})
-		expect(result).toBe(undefined)
-	})
-
 	/**
 	 * INGEST SEGMENT
 	 */
@@ -258,25 +231,6 @@ describe('Ingest API', () => {
 			rundownId: rundownIds[0],
 			segmentId: updatedSegmentId,
 			segment,
-		})
-		expect(result).toBe(undefined)
-	})
-
-	test('Can delete multiple segments', async () => {
-		const result = await ingestApi.deleteSegments({
-			studioId,
-			playlistId: playlistIds[0],
-			rundownId: rundownIds[0],
-		})
-		expect(result).toBe(undefined)
-	})
-
-	test('Can delete segment by id', async () => {
-		const result = await ingestApi.deleteSegment({
-			studioId,
-			playlistId: playlistIds[0],
-			rundownId: rundownIds[0],
-			segmentId: updatedSegmentId,
 		})
 		expect(result).toBe(undefined)
 	})
@@ -401,7 +355,9 @@ describe('Ingest API', () => {
 
 	const updatedPartId = 'part2'
 	test('Can update a part', async () => {
-		newIngestPart.name = newIngestPart.name + ' added'
+		if (newIngestPart) {
+			newIngestPart.name = newIngestPart.name + ' added'
+		}
 		const result = await ingestApi.putPart({
 			studioId,
 			playlistId: playlistIds[0],
@@ -431,6 +387,9 @@ describe('Ingest API', () => {
 		expect(result).toBe(undefined)
 	})
 
+	/**
+	 * DELETIONS - All delete tests at the end to avoid breaking subsequent tests
+	 */
 	test('Can delete multiple parts', async () => {
 		const result = await ingestApi.deleteParts({
 			studioId,
@@ -448,6 +407,52 @@ describe('Ingest API', () => {
 			rundownId: rundownIds[0],
 			segmentId: segmentIds[0],
 			partId: updatedPartId,
+		})
+		expect(result).toBe(undefined)
+	})
+
+	test('Can delete multiple segments', async () => {
+		const result = await ingestApi.deleteSegments({
+			studioId,
+			playlistId: playlistIds[0],
+			rundownId: rundownIds[0],
+		})
+		expect(result).toBe(undefined)
+	})
+
+	test('Can delete segment by id', async () => {
+		const result = await ingestApi.deleteSegment({
+			studioId,
+			playlistId: playlistIds[0],
+			rundownId: rundownIds[0],
+			segmentId: updatedSegmentId,
+		})
+		expect(result).toBe(undefined)
+	})
+
+	test('Can delete multiple rundowns', async () => {
+		const result = await ingestApi.deleteRundowns({ studioId, playlistId: playlistIds[0] })
+		expect(result).toBe(undefined)
+	})
+
+	test('Can delete rundown by id', async () => {
+		const result = await ingestApi.deleteRundown({
+			studioId,
+			playlistId: playlistIds[0],
+			rundownId: updatedRundownId,
+		})
+		expect(result).toBe(undefined)
+	})
+
+	test('Can delete multiple playlists', async () => {
+		const result = await ingestApi.deletePlaylists({ studioId })
+		expect(result).toBe(undefined)
+	})
+
+	test('Can delete playlist by id', async () => {
+		const result = await ingestApi.deletePlaylist({
+			studioId,
+			playlistId: playlistIds[0],
 		})
 		expect(result).toBe(undefined)
 	})


### PR DESCRIPTION

<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

## Type of Contribution

This is a Bug fix

## Current Behavior

`main` is failing CI.

## New Behavior

Fix `main`.

Move all deletion tests to the end of the test suite to prevent cascading failures. Previously, deletion tests were interspersed throughout, causing subsequent tests to fail when trying to access deleted resources (playlists, rundowns, segments, parts).

Also add null check for newIngestPart before accessing its properties.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [x] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR reorders the OpenAPI ingest test suite to prevent test failures caused by later tests attempting to access resources that have been deleted. All deletion-related tests (for playlists, rundowns, segments, and parts) have been moved to a consolidated section at the end of the test file. Additionally, a null check has been added to guard against accessing properties on `newIngestPart` before it's validated.

## Changes

**File: `packages/openapi/src/__tests__/ingest.spec.ts`**

- Consolidated all deletion tests into a single "DELETIONS" block at the end of the test suite, including:
  - Playlist deletion tests (delete-by-id and bulk-delete)
  - Rundown deletion tests
  - Segment deletion tests
  - Part deletion tests

- Added a null/undefined check for `newIngestPart` before accessing its properties during part update operations

- Test semantics and expected outcomes remain unchanged; only execution order has been modified

**Statistics**
- Lines changed: +52/-47
- Single file modified
- No changes to public APIs or method signatures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->