### PR TITLE
Approve uncontested PRs after a week

### DIFF
--- a/.github/workflows/approve-uncontested-prs.yml
+++ b/.github/workflows/approve-uncontested-prs.yml
@@ -20,41 +20,59 @@ jobs:
             const sevenDaysAgo = new Date();
             sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
             
-            // Fetch all open pull requests, sorted by creation date (oldest first)
+            // Fetch all open pull requests, sorted by last update (oldest first)
             const { data: pullRequests } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              sort: 'created',
+              sort: 'updated',
               direction: 'asc'
             });
             
             for (const pr of pullRequests) {
-              const createdAt = new Date(pr.created_at);
+              // Skip draft PRs
+              if (pr.draft) {
+                console.log(`Skipping PR #${pr.number}: Draft PR`);
+                continue;
+              }
               
-              // Only process PRs older than 7 days
-              if (createdAt < sevenDaysAgo) {
-                // Check if already approved by this action to avoid spamming
+              // Use updated_at instead of created_at to ensure we don't auto-approve
+              // code that was just pushed to an old PR
+              const lastActivity = new Date(pr.updated_at);
+              
+              // Only process PRs that haven't been updated in 7+ days
+              if (lastActivity < sevenDaysAgo) {
+                // Fetch reviews to check for objections and prior bot approval
                 const { data: reviews } = await github.rest.pulls.listReviews({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   pull_request_number: pr.number
                 });
                 
+                // Check if any reviewer has requested changes
+                const hasChangesRequested = reviews.some(
+                  review => review.state === 'CHANGES_REQUESTED'
+                );
+                
+                if (hasChangesRequested) {
+                  console.log(`Skipping PR #${pr.number}: Has changes requested`);
+                  continue;
+                }
+                
+                // Check if already approved by this action to avoid spamming
                 const alreadyApproved = reviews.some(
                   review => review.user.login === 'github-actions[bot]' && review.state === 'APPROVED'
                 );
                 
                 if (!alreadyApproved) {
-                  // Uncomment the below to make it actually work
-                  // // Submit an approval review
-                  // await github.rest.pulls.createReview({
-                  //   owner: context.repo.owner,
-                  //   repo: context.repo.repo,
-                  //   pull_request_number: pr.number,
-                  //   body: '✅ Auto-approving: This PR has been open for 7+ days with no objections.',
-                  //   event: 'APPROVE'
-                  // });
+                  // Submit an approval review
+                  await github.rest.pulls.createReview({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_request_number: pr.number,
+                    body: '✅ Auto-approving: This PR has been inactive for 7+ days with no objections.',
+                    event: 'APPROVE'
+                  });
                   
                   console.log(`Approved PR #${pr.number}: ${pr.title}`);
                 }

--- a/.github/workflows/approve-uncontested-prs.yml
+++ b/.github/workflows/approve-uncontested-prs.yml
@@ -46,14 +46,15 @@ jobs:
                 );
                 
                 if (!alreadyApproved) {
-                  // Submit an approval review
-                  await github.rest.pulls.createReview({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    pull_request_number: pr.number,
-                    body: '✅ Auto-approving: This PR has been open for 7+ days with no objections.',
-                    event: 'APPROVE'
-                  });
+                  // Uncomment the below to make it actually work
+                  // // Submit an approval review
+                  // await github.rest.pulls.createReview({
+                  //   owner: context.repo.owner,
+                  //   repo: context.repo.repo,
+                  //   pull_request_number: pr.number,
+                  //   body: '✅ Auto-approving: This PR has been open for 7+ days with no objections.',
+                  //   event: 'APPROVE'
+                  // });
                   
                   console.log(`Approved PR #${pr.number}: ${pr.title}`);
                 }

--- a/.github/workflows/approve-uncontested-prs.yml
+++ b/.github/workflows/approve-uncontested-prs.yml
@@ -1,0 +1,61 @@
+name: Auto-approve uncontested PRs after 7 days
+
+on:
+  schedule:
+    - cron: '26 5 * * *' # Run every day at 5:26 AM UTC (time chosen randomly to avoid creating peaks)
+  workflow_dispatch: # Allow manual triggering
+
+permissions:
+  pull-requests: write
+
+jobs:
+  approve-uncontested-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-approve uncontested PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Calculate the date 7 days ago
+            const sevenDaysAgo = new Date();
+            sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+            
+            // Fetch all open pull requests, sorted by creation date (oldest first)
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              sort: 'created',
+              direction: 'asc'
+            });
+            
+            for (const pr of pullRequests) {
+              const createdAt = new Date(pr.created_at);
+              
+              // Only process PRs older than 7 days
+              if (createdAt < sevenDaysAgo) {
+                // Check if already approved by this action to avoid spamming
+                const { data: reviews } = await github.rest.pulls.listReviews({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_request_number: pr.number
+                });
+                
+                const alreadyApproved = reviews.some(
+                  review => review.user.login === 'github-actions[bot]' && review.state === 'APPROVED'
+                );
+                
+                if (!alreadyApproved) {
+                  // Submit an approval review
+                  await github.rest.pulls.createReview({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_request_number: pr.number,
+                    body: '✅ Auto-approving: This PR has been open for 7+ days with no objections.',
+                    event: 'APPROVE'
+                  });
+                  
+                  console.log(`Approved PR #${pr.number}: ${pr.title}`);
+                }
+              }
+            }


### PR DESCRIPTION
## About the Contributor

This pull request is posted on behalf of myself.

## Type of Contribution

This is a CI / code management feature.

## Current Behavior

n/a

## New Behavior

The policy has been suggested that PRs should require a single approval and allow a week for people to object before they are merged, or if they are urgent, they can get 2 approvals. This PR adds a daily check that grants an approval to PRs that have been open for a week without objection, meaning the policy can be enforced by setting required approvals to 2 on the main branch.

## Testing

It's basically impossible to test this without making it live.

### Affected areas

This PR affects Github workflow

## Time Frame

* Not urgent, but we would like to get this merged into the in-development release.

## Other Information


## Status

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Introduces a new GitHub Actions workflow (`approve-uncontested-prs.yml`) that automatically grants approvals to pull requests meeting specific criteria, enabling a policy where main branch protection requires 2 approvals while allowing eligible single-approval PRs to be auto-approved after 7 days of inactivity without objections.

## Changes

**File: `.github/workflows/approve-uncontested-prs.yml` (80 new lines)**

Adds a scheduled GitHub Actions workflow with the following behavior:

- **Trigger**: Runs daily at 5:26 AM UTC (via cron schedule) and supports manual triggering via `workflow_dispatch`
- **Permissions**: Requests `pull-requests: write` scope for review submission
- **Logic**: Iterates through open pull requests sorted by last update (oldest first) and:
  - **Skips** draft PRs
  - **Skips** PRs where any reviewer has requested changes
  - **Skips** PRs already approved by `github-actions[bot]` to avoid duplicate approvals
  - **Auto-approves** uncontested PRs that have been inactive (no `updated_at` activity) for 7+ days, submitting an APPROVE review with the message: "✅ Auto-approving: This PR has been inactive for 7+ days with no objections."

Key implementation details:
- Uses `updated_at` field instead of `created_at` to account for new commits on older PRs, preventing premature approval of code pushed to stale PRs
- Leverages GitHub REST API via `actions/github-script@v7` for PR and review queries
- Includes logging to trace approval decisions and skipped PRs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->