### PR TITLE
feat: fix scroll issues in properties editor and enable properties editor for invalid parts (SOFIE-282 and SOFIE-283)

### DIFF
--- a/packages/webui/src/client/styles/rundownView.scss
+++ b/packages/webui/src/client/styles/rundownView.scss
@@ -1576,7 +1576,7 @@ svg.icon {
 				bottom: 0;
 				right: 1px;
 				z-index: 10;
-				pointer-events: all;
+				pointer-events: none;
 				background-image: repeating-linear-gradient(
 						45deg,
 						var(--invalid-reason-color-transparent) 0%,

--- a/packages/webui/src/client/ui/RundownView/SelectedElementsContext.tsx
+++ b/packages/webui/src/client/ui/RundownView/SelectedElementsContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useReducer, useState } from 'react'
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import {
 	AdLibActionId,
 	PartId,
@@ -215,12 +215,21 @@ export function useSelectedElements(
 	const [segment, setSegment] = useState<DBSegment | undefined>(undefined)
 	const rundownId = piece ? piece.startRundownId : part ? part.rundownId : segment?.rundownId
 
+	const lastValidPiece = useRef<Piece | undefined>(undefined)
+
 	useEffect(() => {
 		clearPendingChange() // element id changed so any pending change is for an old element
 
 		const computation = Tracker.nonreactive(() =>
 			Tracker.autorun(() => {
-				const piece = Pieces.findOne(selectedElement?.elementId)
+				let piece = Pieces.findOne(selectedElement?.elementId)
+
+				if (!piece && lastValidPiece.current && lastValidPiece.current._id === selectedElement?.elementId) {
+					piece = lastValidPiece.current
+				} else if (piece) {
+					lastValidPiece.current = piece
+				}
+
 				const part = UIParts.findOne({ _id: piece?.startPartId ?? selectedElement?.elementId })
 				const segment = Segments.findOne({ _id: part ? part.segmentId : selectedElement?.elementId })
 

--- a/packages/webui/src/client/ui/SegmentTimeline/SegmentContextMenu.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/SegmentContextMenu.tsx
@@ -181,55 +181,59 @@ export function SegmentContextMenu({
 				)}
 				{part && isPartNext !== undefined && isPartOrphaned !== undefined && timecode !== null && (
 					<>
-						<MenuItem
-							onClick={(e) => onSetNext(part.instance.part, e)}
-							disabled={!!part.instance.orphaned || !canSetAsNext}
-						>
-							<span
-								dangerouslySetInnerHTML={{
-									__html: t(`Set part as <strong>Next</strong>`),
-								}}
-							></span>
-						</MenuItem>
-						{startsAt !== undefined && part && enablePlayFromAnywhere ? (
+						{!part.instance.part.invalid && (
 							<>
 								<MenuItem
-									onClick={(e) =>
-										onSetAsNextFromHere(
-											part.instance,
-											playlist?.nextPartInfo?.partInstanceId ?? null,
-											playlist?.currentPartInfo?.partInstanceId ?? null,
-											e
-										)
-									}
-									disabled={getIsPlayFromHereDisabled()}
+									onClick={(e) => onSetNext(part.instance.part, e)}
+									disabled={!!part.instance.orphaned || !canSetAsNext}
 								>
 									<span
 										dangerouslySetInnerHTML={{
-											__html: t(
-												`Set part from ${RundownUtils.formatTimeToShortTime(Math.floor(timecode / 1000) * 1000)} as <strong>Next</strong>`
-											),
+											__html: t(`Set part as <strong>Next</strong>`),
 										}}
 									></span>
 								</MenuItem>
-								<MenuItem
-									onClick={(e) =>
-										onSetAsNextFromHere(
-											part.instance,
-											playlist?.nextPartInfo?.partInstanceId ?? null,
-											playlist?.currentPartInfo?.partInstanceId ?? null,
-											e,
-											true
-										)
-									}
-									disabled={getIsPlayFromHereDisabled(true)}
-								>
-									<span>
-										{t(`Play part from ${RundownUtils.formatTimeToShortTime(Math.floor(timecode / 1000) * 1000)}`)}
-									</span>
-								</MenuItem>
+								{startsAt !== undefined && part && enablePlayFromAnywhere ? (
+									<>
+										<MenuItem
+											onClick={(e) =>
+												onSetAsNextFromHere(
+													part.instance,
+													playlist?.nextPartInfo?.partInstanceId ?? null,
+													playlist?.currentPartInfo?.partInstanceId ?? null,
+													e
+												)
+											}
+											disabled={getIsPlayFromHereDisabled()}
+										>
+											<span
+												dangerouslySetInnerHTML={{
+													__html: t(
+														`Set part from ${RundownUtils.formatTimeToShortTime(Math.floor(timecode / 1000) * 1000)} as <strong>Next</strong>`
+													),
+												}}
+											></span>
+										</MenuItem>
+										<MenuItem
+											onClick={(e) =>
+												onSetAsNextFromHere(
+													part.instance,
+													playlist?.nextPartInfo?.partInstanceId ?? null,
+													playlist?.currentPartInfo?.partInstanceId ?? null,
+													e,
+													true
+												)
+											}
+											disabled={getIsPlayFromHereDisabled(true)}
+										>
+											<span>
+												{t(`Play part from ${RundownUtils.formatTimeToShortTime(Math.floor(timecode / 1000) * 1000)}`)}
+											</span>
+										</MenuItem>
+									</>
+								) : null}
 							</>
-						) : null}
+						)}
 						{enableQuickLoop && !isLoopLocked(playlist) && (
 							<>
 								{isQuickLoopStart(part.partId, playlist) ? (

--- a/packages/webui/src/client/ui/SegmentTimeline/SegmentContextMenu.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/SegmentContextMenu.tsx
@@ -179,144 +179,138 @@ export function SegmentContextMenu({
 						<hr />
 					</>
 				)}
-				{part &&
-					isPartNext !== undefined &&
-					isPartOrphaned !== undefined &&
-					!part.instance.part.invalid &&
-					timecode !== null && (
-						<>
-							<MenuItem
-								onClick={(e) => onSetNext(part.instance.part, e)}
-								disabled={!!part.instance.orphaned || !canSetAsNext}
-							>
-								<span
-									dangerouslySetInnerHTML={{
-										__html: t(`Set part as <strong>Next</strong>`),
-									}}
-								></span>
-							</MenuItem>
-							{startsAt !== undefined && part && enablePlayFromAnywhere ? (
-								<>
+				{part && isPartNext !== undefined && isPartOrphaned !== undefined && timecode !== null && (
+					<>
+						<MenuItem
+							onClick={(e) => onSetNext(part.instance.part, e)}
+							disabled={!!part.instance.orphaned || !canSetAsNext}
+						>
+							<span
+								dangerouslySetInnerHTML={{
+									__html: t(`Set part as <strong>Next</strong>`),
+								}}
+							></span>
+						</MenuItem>
+						{startsAt !== undefined && part && enablePlayFromAnywhere ? (
+							<>
+								<MenuItem
+									onClick={(e) =>
+										onSetAsNextFromHere(
+											part.instance,
+											playlist?.nextPartInfo?.partInstanceId ?? null,
+											playlist?.currentPartInfo?.partInstanceId ?? null,
+											e
+										)
+									}
+									disabled={getIsPlayFromHereDisabled()}
+								>
+									<span
+										dangerouslySetInnerHTML={{
+											__html: t(
+												`Set part from ${RundownUtils.formatTimeToShortTime(Math.floor(timecode / 1000) * 1000)} as <strong>Next</strong>`
+											),
+										}}
+									></span>
+								</MenuItem>
+								<MenuItem
+									onClick={(e) =>
+										onSetAsNextFromHere(
+											part.instance,
+											playlist?.nextPartInfo?.partInstanceId ?? null,
+											playlist?.currentPartInfo?.partInstanceId ?? null,
+											e,
+											true
+										)
+									}
+									disabled={getIsPlayFromHereDisabled(true)}
+								>
+									<span>
+										{t(`Play part from ${RundownUtils.formatTimeToShortTime(Math.floor(timecode / 1000) * 1000)}`)}
+									</span>
+								</MenuItem>
+							</>
+						) : null}
+						{enableQuickLoop && !isLoopLocked(playlist) && (
+							<>
+								{isQuickLoopStart(part.partId, playlist) ? (
+									<MenuItem onClick={(e) => onSetQuickLoopStart(null, e)}>
+										<span>{t('Clear QuickLoop Start')}</span>
+									</MenuItem>
+								) : (
 									<MenuItem
 										onClick={(e) =>
-											onSetAsNextFromHere(
-												part.instance,
-												playlist?.nextPartInfo?.partInstanceId ?? null,
-												playlist?.currentPartInfo?.partInstanceId ?? null,
-												e
-											)
+											onSetQuickLoopStart({ type: QuickLoopMarkerType.PART, id: part.instance.part._id }, e)
 										}
-										disabled={getIsPlayFromHereDisabled()}
+										disabled={!!part.instance.orphaned || !canSetAsNext}
 									>
-										<span
-											dangerouslySetInnerHTML={{
-												__html: t(
-													`Set part from ${RundownUtils.formatTimeToShortTime(Math.floor(timecode / 1000) * 1000)} as <strong>Next</strong>`
-												),
-											}}
-										></span>
+										<span>{t('Set as QuickLoop Start')}</span>
 									</MenuItem>
+								)}
+								{isQuickLoopEnd(part.partId, playlist) ? (
+									<MenuItem onClick={(e) => onSetQuickLoopEnd(null, e)}>
+										<span>{t('Clear QuickLoop End')}</span>
+									</MenuItem>
+								) : (
 									<MenuItem
 										onClick={(e) =>
-											onSetAsNextFromHere(
-												part.instance,
-												playlist?.nextPartInfo?.partInstanceId ?? null,
-												playlist?.currentPartInfo?.partInstanceId ?? null,
-												e,
-												true
-											)
+											onSetQuickLoopEnd({ type: QuickLoopMarkerType.PART, id: part.instance.part._id }, e)
 										}
-										disabled={getIsPlayFromHereDisabled(true)}
+										disabled={!!part.instance.orphaned || !canSetAsNext}
 									>
-										<span>
-											{t(`Play part from ${RundownUtils.formatTimeToShortTime(Math.floor(timecode / 1000) * 1000)}`)}
-										</span>
+										<span>{t('Set as QuickLoop End')}</span>
 									</MenuItem>
-								</>
-							) : null}
-							{enableQuickLoop && !isLoopLocked(playlist) && (
-								<>
-									{isQuickLoopStart(part.partId, playlist) ? (
-										<MenuItem onClick={(e) => onSetQuickLoopStart(null, e)}>
-											<span>{t('Clear QuickLoop Start')}</span>
-										</MenuItem>
-									) : (
-										<MenuItem
-											onClick={(e) =>
-												onSetQuickLoopStart({ type: QuickLoopMarkerType.PART, id: part.instance.part._id }, e)
-											}
-											disabled={!!part.instance.orphaned || !canSetAsNext}
-										>
-											<span>{t('Set as QuickLoop Start')}</span>
-										</MenuItem>
-									)}
-									{isQuickLoopEnd(part.partId, playlist) ? (
-										<MenuItem onClick={(e) => onSetQuickLoopEnd(null, e)}>
-											<span>{t('Clear QuickLoop End')}</span>
-										</MenuItem>
-									) : (
-										<MenuItem
-											onClick={(e) =>
-												onSetQuickLoopEnd({ type: QuickLoopMarkerType.PART, id: part.instance.part._id }, e)
-											}
-											disabled={!!part.instance.orphaned || !canSetAsNext}
-										>
-											<span>{t('Set as QuickLoop End')}</span>
-										</MenuItem>
-									)}
-								</>
-							)}
+								)}
+							</>
+						)}
 
+						<UserEditOperationMenuItems
+							rundownId={part.instance.rundownId}
+							targetName={part.instance.part.title}
+							operationTarget={{
+								segmentExternalId: segment?.externalId,
+								partExternalId: part.instance.part.externalId,
+								pieceExternalId: undefined,
+							}}
+							userEditOperations={part.instance.part.userEditOperations}
+							isFormEditable={isPartEditAble}
+						/>
+
+						{piece && piece.instance.piece.userEditOperations && (
 							<UserEditOperationMenuItems
 								rundownId={part.instance.rundownId}
-								targetName={part.instance.part.title}
+								targetName={piece.instance.piece.name}
 								operationTarget={{
 									segmentExternalId: segment?.externalId,
 									partExternalId: part.instance.part.externalId,
-									pieceExternalId: undefined,
+									pieceExternalId: piece.instance.piece.externalId,
 								}}
-								userEditOperations={part.instance.part.userEditOperations}
+								userEditOperations={piece.instance.piece.userEditOperations as CoreUserEditingDefinition[] | undefined}
 								isFormEditable={isPartEditAble}
 							/>
+						)}
 
-							{piece && piece.instance.piece.userEditOperations && (
-								<UserEditOperationMenuItems
-									rundownId={part.instance.rundownId}
-									targetName={piece.instance.piece.name}
-									operationTarget={{
-										segmentExternalId: segment?.externalId,
-										partExternalId: part.instance.part.externalId,
-										pieceExternalId: piece.instance.piece.externalId,
-									}}
-									userEditOperations={
-										piece.instance.piece.userEditOperations as CoreUserEditingDefinition[] | undefined
-									}
-									isFormEditable={isPartEditAble}
-								/>
-							)}
-
-							{enableUserEdits && (segmentHasEditableContent || partHasEditableContent || pieceHasEditableContent) && (
-								<>
-									<hr />
-									{segmentHasEditableContent && (
-										<MenuItem onClick={() => onEditProps({ type: 'segment', elementId: part.instance.segmentId })}>
-											<span>{t('Edit Segment Properties')}</span>
-										</MenuItem>
-									)}
-									{partHasEditableContent && (
-										<MenuItem onClick={() => onEditProps({ type: 'part', elementId: part.instance.part._id })}>
-											<span>{t('Edit Part Properties')}</span>
-										</MenuItem>
-									)}
-									{pieceHasEditableContent && piece && (
-										<MenuItem onClick={() => onEditProps({ type: 'piece', elementId: piece.instance.piece._id })}>
-											<span>{t('Edit Piece Properties')}</span>
-										</MenuItem>
-									)}
-								</>
-							)}
-						</>
-					)}
+						{enableUserEdits && (segmentHasEditableContent || partHasEditableContent || pieceHasEditableContent) && (
+							<>
+								<hr />
+								{segmentHasEditableContent && (
+									<MenuItem onClick={() => onEditProps({ type: 'segment', elementId: part.instance.segmentId })}>
+										<span>{t('Edit Segment Properties')}</span>
+									</MenuItem>
+								)}
+								{partHasEditableContent && (
+									<MenuItem onClick={() => onEditProps({ type: 'part', elementId: part.instance.part._id })}>
+										<span>{t('Edit Part Properties')}</span>
+									</MenuItem>
+								)}
+								{pieceHasEditableContent && piece && (
+									<MenuItem onClick={() => onEditProps({ type: 'piece', elementId: piece.instance.piece._id })}>
+										<span>{t('Edit Piece Properties')}</span>
+									</MenuItem>
+								)}
+							</>
+						)}
+					</>
+				)}
 			</ContextMenu>
 		</Escape>
 	) : null

--- a/packages/webui/src/client/ui/SegmentTimeline/SourceLayerItem.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/SourceLayerItem.tsx
@@ -191,12 +191,9 @@ export const SourceLayerItem = (props: Readonly<ISourceLayerItemProps>): JSX.Ele
 				if (!hasEditableContent) return
 
 				const pieceId = innerPiece._id
-				if (!selectElementContext.isSelected(pieceId)) {
-					RundownViewEventBus.emit(RundownViewEvents.CLOSE_NOTIFICATIONS)
-					selectElementContext.clearAndSetSelection({ type: 'piece', elementId: pieceId })
-				} else {
-					selectElementContext.clearSelections()
-				}
+
+				RundownViewEventBus.emit(RundownViewEvents.CLOSE_NOTIFICATIONS)
+				selectElementContext.clearAndSetSelection({ type: 'piece', elementId: pieceId })
 			} else if (typeof onDoubleClick === 'function') {
 				onDoubleClick(piece, e)
 			}


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This PR is made on behalf of the BBC

## Type of Contribution

This is a:

<!-- (pick one) -->

Bug fix 

## Current Behavior

Upon scrolling pieces out of the screen in rundown view, the properties editor glitches and stops displaying the piece content
The properties editor is not accessible for invalid parts

## New Behavior

It removes the bug
It enables the properties editor for invalid parts 

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

Properties editor in rundown view

## Time Frame

Not urgent, but we would like to get this merged into the in-development release. **This PR is chained to #62 to facilitate code review, as it changes overlapping areas**

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
