### PR TITLE
fix: looping behavior and timing calculations in QuickLoopService for looping Rundown Playlists

### DIFF
--- a/packages/job-worker/src/playout/model/implementation/__tests__/PlayoutModelImpl.spec.ts
+++ b/packages/job-worker/src/playout/model/implementation/__tests__/PlayoutModelImpl.spec.ts
@@ -1,4 +1,9 @@
-import { JSONBlobStringify, PieceLifespan, StatusCode } from '@sofie-automation/blueprints-integration'
+import {
+	ForceQuickLoopAutoNext,
+	JSONBlobStringify,
+	PieceLifespan,
+	StatusCode,
+} from '@sofie-automation/blueprints-integration'
 import { AdLibPiece } from '@sofie-automation/corelib/dist/dataModel/AdLibPiece'
 import {
 	PartInstanceId,
@@ -14,6 +19,7 @@ import {
 } from '@sofie-automation/corelib/dist/dataModel/PeripheralDevice'
 import { EmptyPieceTimelineObjectsBlob, Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
 import { PieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
+import { QuickLoopMarkerType } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist'
 import { DBRundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
 import { RundownBaselineAdLibItem } from '@sofie-automation/corelib/dist/dataModel/RundownBaselineAdLibPiece'
 import { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
@@ -175,6 +181,76 @@ describe('PlayoutModelImpl', () => {
 
 				const now3 = model.getNowInPlayout()
 				expect(now3).toBeGreaterThanOrEqual(now2)
+			})
+		})
+	})
+
+	describe('quickLoop for locked playlist loops', () => {
+		it('keeps the quickLoop locked state on activation/reset/deactivation', async () => {
+			const rundownId = protectString('rundown01')
+			const playlistId = await context.mockCollections.RundownPlaylists.insertOne({
+				...defaultRundownPlaylist(protectString(`playlist_${rundownId}`), context.studioId),
+				quickLoop: {
+					start: { type: QuickLoopMarkerType.PLAYLIST },
+					end: { type: QuickLoopMarkerType.PLAYLIST },
+					locked: true,
+					running: false,
+					forceAutoNext: ForceQuickLoopAutoNext.DISABLED,
+				},
+			})
+
+			const playlist = await context.mockCollections.RundownPlaylists.findOne(playlistId)
+
+			const rundown: DBRundown = defaultRundown(
+				unprotectString(rundownId),
+				context.studioId,
+				null,
+				playlistId,
+				showStyleCompound._id,
+				showStyleCompound.showStyleVariantId
+			)
+			rundown._id = rundownId
+			await context.mockCollections.Rundowns.insertOne(rundown)
+
+			const peripheralDevices = [setupMockPlayoutGateway(protectString('playoutGateway0'))]
+
+			const { partInstances, groupedPieceInstances, rundowns } = await getPlayoutModelImplArugments(
+				context,
+				playlistId,
+				rundownId
+			)
+
+			if (!playlist) throw new Error('Playlist not found!')
+
+			await runWithPlaylistLock(context, playlistId, async (lock) => {
+				const model = new PlayoutModelImpl(
+					context,
+					lock,
+					playlistId,
+					peripheralDevices,
+					playlist,
+					partInstances,
+					groupedPieceInstances,
+					rundowns,
+					undefined
+				)
+
+				const activationId = model.activatePlaylist(false)
+				expect(model.playlist.quickLoop?.locked).toBe(true)
+				expect(model.playlist.quickLoop?.start?.type).toBe(QuickLoopMarkerType.PLAYLIST)
+				expect(model.playlist.quickLoop?.end?.type).toBe(QuickLoopMarkerType.PLAYLIST)
+
+				model.resetPlaylist(true)
+				expect(model.playlist.quickLoop?.locked).toBe(true)
+				expect(model.playlist.quickLoop?.start?.type).toBe(QuickLoopMarkerType.PLAYLIST)
+				expect(model.playlist.quickLoop?.end?.type).toBe(QuickLoopMarkerType.PLAYLIST)
+
+				model.deactivatePlaylist()
+				expect(model.playlist.quickLoop?.locked).toBe(true)
+				expect(model.playlist.quickLoop?.start?.type).toBe(QuickLoopMarkerType.PLAYLIST)
+				expect(model.playlist.quickLoop?.end?.type).toBe(QuickLoopMarkerType.PLAYLIST)
+				expect(model.playlist.activationId).not.toBe(activationId)
+				expect(model.playlist.currentPartInfo).toBeNull()
 			})
 		})
 	})

--- a/packages/job-worker/src/playout/model/services/QuickLoopService.ts
+++ b/packages/job-worker/src/playout/model/services/QuickLoopService.ts
@@ -142,7 +142,13 @@ export class QuickLoopService {
 	}
 
 	getUpdatedPropsByClearingMarkers(): QuickLoopProps | undefined {
-		if (!this.playoutModel.playlist.quickLoop || this.playoutModel.playlist.quickLoop.locked) return undefined
+		if (!this.playoutModel.playlist.quickLoop) return undefined
+
+		if (this.playoutModel.playlist.quickLoop.locked) {
+			const quickLoopProps = clone(this.playoutModel.playlist.quickLoop)
+			quickLoopProps.running = false
+			return quickLoopProps
+		}
 
 		const quickLoopProps = clone(this.playoutModel.playlist.quickLoop)
 		delete quickLoopProps.start

--- a/packages/webui/src/client/lib/rundownTiming.ts
+++ b/packages/webui/src/client/lib/rundownTiming.ts
@@ -140,6 +140,8 @@ export class RundownTimingCalculator {
 		let lastSegmentIds: { segmentId: SegmentId; segmentPlayoutId: SegmentPlayoutId } | undefined = undefined
 		let nextRundownAnchor: number | undefined = undefined
 
+		const entirePlaylistIsLooping = isEntirePlaylistLooping(playlist)
+
 		if (playlist) {
 			const breakProps = currentRundown ? this.getRundownsBeforeNextBreak(rundowns, currentRundown) : undefined
 
@@ -509,7 +511,7 @@ export class RundownTimingCalculator {
 					// this is a line before next line
 					localAccum = this.linearParts[i][1] || 0
 					// only null the values if not looping, if looping, these will be offset by the countdown for the last part
-					if (!partsInQuickLoop[unprotectString(this.linearParts[i][0])]) {
+					if (!partsInQuickLoop[unprotectString(this.linearParts[i][0])] && !entirePlaylistIsLooping) {
 						this.linearParts[i][1] = null // we use null to express 'will not probably be played out, if played in order'
 					}
 				} else if (i === currentAIndex) {
@@ -541,7 +543,7 @@ export class RundownTimingCalculator {
 					// this away from this line.
 					this.linearParts[i][1] = (this.linearParts[i][1] || 0) - localAccum + currentRemaining
 
-					if (!partsInQuickLoop[unprotectString(this.linearParts[i][0])]) {
+					if (!partsInQuickLoop[unprotectString(this.linearParts[i][0])] && !entirePlaylistIsLooping) {
 						timeTillEndLoop = timeTillEndLoop ?? this.linearParts[i][1] ?? undefined
 					}
 
@@ -563,7 +565,7 @@ export class RundownTimingCalculator {
 				// if timeTillEndLoop was undefined then we can assume the end of the loop is the last line in the rundown
 				timeTillEndLoop = timeTillEndLoop ?? waitAccumulator - localAccum + currentRemaining
 				for (let i = 0; i < nextAIndex; i++) {
-					if (!partsInQuickLoop[unprotectString(this.linearParts[i][0])]) continue
+					if (!partsInQuickLoop[unprotectString(this.linearParts[i][0])] && !entirePlaylistIsLooping) continue
 
 					// this countdown is the wait until the loop ends + whatever waits occur before this part but inside the loop
 					this.linearParts[i][1] = timeTillEndLoop + waitInLoop

--- a/packages/webui/src/client/ui/SegmentList/LinePart.tsx
+++ b/packages/webui/src/client/ui/SegmentList/LinePart.tsx
@@ -31,6 +31,7 @@ interface IProps {
 	isQuickLoopEnd: boolean
 	// isLastSegment?: boolean
 	// isLastPartInSegment?: boolean
+	isEntirePlaylistLooping: boolean
 	isPlaylistLooping: boolean
 	indicatorColumns: Record<string, ISourceLayerExtended[]>
 	adLibIndicatorColumns: Record<string, ISourceLayerExtended[]>
@@ -57,6 +58,7 @@ export function LinePart({
 	indicatorColumns,
 	adLibIndicatorColumns,
 	isPlaylistLooping,
+	isEntirePlaylistLooping,
 	isQuickLoopStart,
 	isQuickLoopEnd,
 	onContextMenu,
@@ -80,7 +82,8 @@ export function LinePart({
 
 	const timingId = getPartInstanceTimingId(part.instance)
 	const isInsideQuickLoop = (timingDurations.partsInQuickLoop || {})[timingId]
-	const isOutsideActiveQuickLoop = isPlaylistLooping && !isInsideQuickLoop && !isNextPart && !hasAlreadyPlayed
+	const isOutsideActiveQuickLoop =
+		isPlaylistLooping && !isInsideQuickLoop && !isEntirePlaylistLooping && !isNextPart && !hasAlreadyPlayed
 
 	const getPartContext = useCallback(() => {
 		const partElement = document.querySelector('#' + SegmentTimelinePartElementId + part.instance._id)

--- a/packages/webui/src/client/ui/SegmentList/SegmentList.tsx
+++ b/packages/webui/src/client/ui/SegmentList/SegmentList.tsx
@@ -18,9 +18,10 @@ import { NoteSeverity } from '@sofie-automation/blueprints-integration'
 import { PieceUi } from '@sofie-automation/corelib/src/dataModel/Piece.js'
 import { ISourceLayerExtended } from '@sofie-automation/corelib/src/dataModel/ShowStyleBase.js'
 import {
-	isLoopRunning,
-	isQuickLoopStart,
-	isQuickLoopEnd,
+	isLoopRunning as getIsLoopRunning,
+	isQuickLoopStart as getIsQuickLoopStart,
+	isQuickLoopEnd as getIsQuickLoopEnd,
+	isEntirePlaylistLooping as getIsEntirePlaylistLooping,
 } from '@sofie-automation/corelib/src/playout/stateCacheResolver.js'
 
 interface IProps {
@@ -139,6 +140,9 @@ const SegmentListInner = React.forwardRef<HTMLDivElement, IProps>(function Segme
 		// if (isLivePart) currentPartIndex = index
 		// if (isNextPart) nextPartIndex = index
 
+		const isPlaylistLooping = getIsLoopRunning(props.playlist)
+		const isEntirePlaylistLooping = getIsEntirePlaylistLooping(props.playlist)
+
 		if (part.instance.part.invalid && part.instance.part.gap) return null
 
 		const partComponent = (
@@ -161,9 +165,10 @@ const SegmentListInner = React.forwardRef<HTMLDivElement, IProps>(function Segme
 				doesPlaylistHaveNextPart={playlistHasNextPart}
 				onPieceDoubleClick={props.onPieceDoubleClick}
 				onContextMenu={props.onContextMenu}
-				isPlaylistLooping={isLoopRunning(props.playlist)}
-				isQuickLoopStart={isQuickLoopStart(part.partId, props.playlist)}
-				isQuickLoopEnd={isQuickLoopEnd(part.partId, props.playlist)}
+				isPlaylistLooping={isPlaylistLooping}
+				isEntirePlaylistLooping={isEntirePlaylistLooping}
+				isQuickLoopStart={getIsQuickLoopStart(part.partId, props.playlist)}
+				isQuickLoopEnd={getIsQuickLoopEnd(part.partId, props.playlist)}
 			/>
 		)
 

--- a/packages/webui/src/client/ui/SegmentStoryboard/SegmentStoryboard.tsx
+++ b/packages/webui/src/client/ui/SegmentStoryboard/SegmentStoryboard.tsx
@@ -42,10 +42,11 @@ import { logger } from '../../lib/logging.js'
 import { UIStudio } from '@sofie-automation/corelib/src/dataModel/Studio.js'
 import { PieceUi } from '@sofie-automation/corelib/src/dataModel/Piece.js'
 import {
-	isLoopRunning,
-	isEndOfLoopingShow,
-	isQuickLoopStart,
-	isQuickLoopEnd,
+	isLoopRunning as getIsLoopRunning,
+	isEndOfLoopingShow as getIsEndOfLoopingShow,
+	isQuickLoopStart as getIsQuickLoopStart,
+	isQuickLoopEnd as getIsQuickLoopEnd,
+	isEntirePlaylistLooping as getIsEntirePlaylistLooping,
 } from '@sofie-automation/corelib/src/playout/stateCacheResolver.js'
 
 interface IProps {
@@ -206,7 +207,8 @@ export const SegmentStoryboard = React.memo(
 			squishedPartsNum > 1 ? Math.max(4, (spaceLeft - PART_WIDTH) / (squishedPartsNum - 1)) : null
 
 		const playlistHasNextPart = !!props.playlist.nextPartInfo
-		const playlistIsLooping = isLoopRunning(props.playlist)
+		const isPlaylistLooping = getIsLoopRunning(props.playlist)
+		const isEntirePlaylistLooping = getIsEntirePlaylistLooping(props.playlist)
 
 		renderedParts.forEach((part, index) => {
 			const isLivePart = part.instance._id === props.playlist.currentPartInfo?.partInstanceId
@@ -227,15 +229,16 @@ export const SegmentStoryboard = React.memo(
 					isNextPart={isNextPart}
 					isLastPartInSegment={part.instance._id === lastValidPartId}
 					isLastSegment={props.isLastSegment}
-					isEndOfLoopingShow={isEndOfLoopingShow(
+					isEndOfLoopingShow={getIsEndOfLoopingShow(
 						props.playlist,
 						props.isLastSegment,
 						part.instance._id === lastValidPartId,
 						part.instance.part
 					)}
-					isQuickLoopStart={isQuickLoopStart(part.partId, props.playlist)}
-					isQuickLoopEnd={isQuickLoopEnd(part.partId, props.playlist)}
-					isPlaylistLooping={playlistIsLooping}
+					isQuickLoopStart={getIsQuickLoopStart(part.partId, props.playlist)}
+					isQuickLoopEnd={getIsQuickLoopEnd(part.partId, props.playlist)}
+					isPlaylistLooping={isPlaylistLooping}
+					isEntirePlaylistLooping={isEntirePlaylistLooping}
 					doesPlaylistHaveNextPart={playlistHasNextPart}
 					displayLiveLineCounter={props.displayLiveLineCounter}
 					inHold={!!(props.playlist.holdState && props.playlist.holdState !== RundownHoldState.COMPLETE)}

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPart.tsx
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPart.tsx
@@ -34,6 +34,7 @@ interface IProps {
 	isLastSegment?: boolean
 	isLastPartInSegment?: boolean
 	isPlaylistLooping?: boolean
+	isEntirePlaylistLooping?: boolean
 	isEndOfLoopingShow?: boolean
 	isQuickLoopStart: boolean
 	isQuickLoopEnd: boolean
@@ -56,6 +57,7 @@ export function StoryboardPart({
 	isLastPartInSegment,
 	isLastSegment,
 	isPlaylistLooping,
+	isEntirePlaylistLooping,
 	isEndOfLoopingShow,
 	isQuickLoopStart,
 	isQuickLoopEnd,
@@ -127,7 +129,7 @@ export function StoryboardPart({
 	const isInvalid = part.instance.part.invalid
 	const isFloated = part.instance.part.floated
 	const isInsideQuickLoop = timingDurations.partsInQuickLoop?.[getPartInstanceTimingId(part.instance)] ?? false
-	const isOutsideActiveQuickLoop = !isInsideQuickLoop && isPlaylistLooping && !isNextPart
+	const isOutsideActiveQuickLoop = !isInsideQuickLoop && isPlaylistLooping && !isEntirePlaylistLooping && !isNextPart
 
 	return (
 		<ContextMenuTrigger

--- a/packages/webui/src/client/ui/SegmentTimeline/Parts/SegmentTimelinePart.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/Parts/SegmentTimelinePart.tsx
@@ -42,10 +42,11 @@ import { Events as MOSEvents } from '../../../lib/data/mos/plugin-support.js'
 import { UIStudio } from '@sofie-automation/corelib/src/dataModel/Studio.js'
 import { PieceUi } from '@sofie-automation/corelib/src/dataModel/Piece.js'
 import {
-	isLoopRunning,
+	isLoopRunning as getIsLoopRunning,
 	isQuickLoopStart as getIsQuickLoopStart,
 	isQuickLoopEnd as getIsQuickLoopEnd,
-	isEndOfLoopingShow,
+	isEndOfLoopingShow as getIsEndOfLoopingShow,
+	isEntirePlaylistLooping as getIsEntirePlaylistLooping,
 } from '@sofie-automation/corelib/src/playout/stateCacheResolver.js'
 
 export const SegmentTimelineLineElementId = 'rundown__segment__line__'
@@ -673,8 +674,8 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 			this.props.isLastSegment &&
 			this.props.isLastInSegment &&
 			(!this.state.isLive || (this.state.isLive && !this.props.playlist.nextPartInfo))
-		const isPlaylistLooping = isLoopRunning(this.props.playlist)
-		const isPartEndOfLoopingShow = isEndOfLoopingShow(
+		const isPlaylistLooping = getIsLoopRunning(this.props.playlist)
+		const isPartEndOfLoopingShow = getIsEndOfLoopingShow(
 			this.props.playlist,
 			this.props.isLastSegment,
 			this.props.isLastInSegment,
@@ -692,7 +693,10 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 		}
 
 		const isOutsideActiveQuickLoop =
-			!this.state.isInQuickLoop && isLoopRunning(this.props.playlist) && !this.state.isNext
+			!this.state.isInQuickLoop &&
+			getIsLoopRunning(this.props.playlist) &&
+			!getIsEntirePlaylistLooping(this.props.playlist) &&
+			!this.state.isNext
 		const isQuickLoopStart = getIsQuickLoopStart(this.props.part.partId, this.props.playlist)
 		const isQuickLoopEnd = getIsQuickLoopEnd(this.props.part.partId, this.props.playlist)
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a:

<!-- (pick one) -->

Bug fix

## Current Behavior

Countdowns for Parts before the current playing part don't show up if the entire playlist is looping. Looping playlist state is cleared when a Playlist is reset or deactivated.

## New Behavior

Countdowns for Parts before the current playing Part are correctly shown and calculated for entire looping playlists. Looping playlist state is kept across resets and deactivations.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

* This PR affects the reset & deactivation logic for QuickLoop
* This PR affects the Rundown timing calculations for QuickLoop/looping playlists.

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

## Time Frame

This Bug Fix is critical for us, please review and merge it as soon as possible.

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
