### PR TITLE
Fix for AB playback lookahead player assignment

### DIFF
--- a/packages/job-worker/src/playout/abPlayback/__tests__/abPlaybackResolver.spec.ts
+++ b/packages/job-worker/src/playout/abPlayback/__tests__/abPlaybackResolver.spec.ts
@@ -665,7 +665,7 @@ describe('resolveAbAssignmentsFromRequests', () => {
 				name: 'c',
 				start: 10000,
 				end: 15000,
-				playerId: 1,
+				playerId: 2,
 				pieceNames: ['p3'],
 			},
 			// lookaheads (in order of future use)
@@ -686,8 +686,8 @@ describe('resolveAbAssignmentsFromRequests', () => {
 		expect(res.failedRequired).toEqual([])
 		expectGotPlayer(res, 'a', 2)
 		expectGotPlayer(res, 'b', 1)
-		expectGotPlayer(res, 'c', 1)
-		expectGotPlayer(res, 'z', 2)
+		expectGotPlayer(res, 'c', 2)
+		expectGotPlayer(res, 'z', 1)
 	})
 
 	test('Preserve on-air optional over a required', () => {

--- a/packages/job-worker/src/playout/abPlayback/__tests__/abPlaybackResolver.spec.ts
+++ b/packages/job-worker/src/playout/abPlayback/__tests__/abPlaybackResolver.spec.ts
@@ -639,6 +639,57 @@ describe('resolveAbAssignmentsFromRequests', () => {
 		expectGotPlayer(res, 'd', undefined)
 	})
 
+	test('Autonext pgm/pvw', () => {
+		const requests: SessionRequest[] = [
+			// second part
+			{
+				id: 'b',
+				name: 'b',
+				start: 5000,
+				end: 10000,
+				playerId: 1,
+				pieceNames: ['p2'],
+			},
+			// first part
+			{
+				id: 'a',
+				name: 'a',
+				start: 1000,
+				end: 5000,
+				playerId: 2,
+				pieceNames: ['p1'],
+			},
+			// third part
+			{
+				id: 'c',
+				name: 'c',
+				start: 10000,
+				end: 15000,
+				playerId: 1,
+				pieceNames: ['p3'],
+			},
+			// lookaheads (in order of future use)
+			{
+				id: 'z',
+				name: 'z',
+				start: 0,
+				end: 100,
+				playerId: 2,
+				lookaheadRank: 1,
+				pieceNames: [],
+			},
+		]
+
+		const res = resolveAbAssignmentsFromRequests(resolverOptions, TWO_SLOTS, requests, 5100)
+		expect(res).toBeTruthy()
+		expect(res.failedOptional).toEqual([])
+		expect(res.failedRequired).toEqual([])
+		expectGotPlayer(res, 'a', 2)
+		expectGotPlayer(res, 'b', 1)
+		expectGotPlayer(res, 'c', 1)
+		expectGotPlayer(res, 'z', 2)
+	})
+
 	test('Preserve on-air optional over a required', () => {
 		const requests: SessionRequest[] = [
 			// current part

--- a/packages/job-worker/src/playout/abPlayback/__tests__/abPlaybackResolver.spec.ts
+++ b/packages/job-worker/src/playout/abPlayback/__tests__/abPlaybackResolver.spec.ts
@@ -639,25 +639,25 @@ describe('resolveAbAssignmentsFromRequests', () => {
 		expectGotPlayer(res, 'd', undefined)
 	})
 
-	test('Autonext pgm/pvw', () => {
+	test('Autonext lookahead assignment with more clips than players', () => {
 		const requests: SessionRequest[] = [
-			// second part
-			{
-				id: 'b',
-				name: 'b',
-				start: 5000,
-				end: 10000,
-				playerId: 1,
-				pieceNames: ['p2'],
-			},
 			// first part
 			{
 				id: 'a',
 				name: 'a',
 				start: 1000,
 				end: 5000,
-				playerId: 2,
+				playerId: 1,
 				pieceNames: ['p1'],
+			},
+			// second part
+			{
+				id: 'b',
+				name: 'b',
+				start: 5000,
+				end: 10000,
+				playerId: 2,
+				pieceNames: ['p2'],
 			},
 			// third part
 			{
@@ -665,7 +665,7 @@ describe('resolveAbAssignmentsFromRequests', () => {
 				name: 'c',
 				start: 10000,
 				end: 15000,
-				playerId: 2,
+				playerId: 1,
 				pieceNames: ['p3'],
 			},
 			// lookaheads (in order of future use)
@@ -674,7 +674,6 @@ describe('resolveAbAssignmentsFromRequests', () => {
 				name: 'z',
 				start: 0,
 				end: 100,
-				playerId: 2,
 				lookaheadRank: 1,
 				pieceNames: [],
 			},
@@ -684,10 +683,10 @@ describe('resolveAbAssignmentsFromRequests', () => {
 		expect(res).toBeTruthy()
 		expect(res.failedOptional).toEqual([])
 		expect(res.failedRequired).toEqual([])
-		expectGotPlayer(res, 'a', 2)
-		expectGotPlayer(res, 'b', 1)
-		expectGotPlayer(res, 'c', 2)
-		expectGotPlayer(res, 'z', 1)
+		expectGotPlayer(res, 'a', 1)
+		expectGotPlayer(res, 'b', 2)
+		expectGotPlayer(res, 'c', 1)
+		expectGotPlayer(res, 'z', 2)
 	})
 
 	test('Preserve on-air optional over a required', () => {

--- a/packages/job-worker/src/playout/abPlayback/abPlaybackResolver.ts
+++ b/packages/job-worker/src/playout/abPlayback/abPlaybackResolver.ts
@@ -361,6 +361,8 @@ function assignPlayersForLookahead(
 		Array.from(lastSessionPerSlot.entries()),
 		(session) => session[1] < safeNow
 	)
+	// We want to assign the ones that are clear soonest first, as they are more likely to be ready in time
+	playersClearSoon.sort((endA, endB) => endA[1] - endB[1])
 
 	// Assign the players which are clear right now
 	const playersClearNowIds = new Set(playersClearNow.map((p) => p[0]))


### PR DESCRIPTION
This PR is posted on behalf of EVS Broadcast Equipment.

## Type of Contribution

This is a:

Bug fix

## Current Behaviour

Assigning a player for a lookahead picked from an array of players that would be free soon. The logic didn't take correct account of current piece end times so the wrong player was assigned

## New Behaviour

The soon to be free players are now sorted by end time so that the lookahead is assigned to the player that will be free first

## Testing

- [x] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

This PR affects the ab playout logic. It particularly affects systems that use an aux output to show the next part.

## Time Frame

Not urgent, but we would like to get this merged into the in-development release.

## Status

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
