### PR TITLE
 feat(LSG): new resolvedPlaylistTopic

### DIFF
--- a/packages/corelib/src/dataModel/RundownPlaylist/TTimers.ts
+++ b/packages/corelib/src/dataModel/RundownPlaylist/TTimers.ts
@@ -116,6 +116,10 @@ export function timerStateToZeroTime(state: TimerState, now: number): number {
 
 export type RundownTTimerIndex = 1 | 2 | 3
 
+export function isRundownTTimerIndex(index: unknown): index is RundownTTimerIndex {
+	return typeof index === 'number' && (index === 1 || index === 2 || index === 3)
+}
+
 export interface RundownTTimer {
 	readonly index: RundownTTimerIndex
 

--- a/packages/live-status-gateway-api/api/asyncapi.yaml
+++ b/packages/live-status-gateway-api/api/asyncapi.yaml
@@ -37,6 +37,8 @@ channels:
     $ref: './topics/studio/studioTopic.yaml'
   activePlaylist:
     $ref: './topics/activePlaylist/activePlaylistTopic.yaml'
+  resolvedPlaylist:
+    $ref: './topics/resolvedPlaylist/resolvedPlaylistTopic.yaml'
   activePieces:
     $ref: './topics/activePieces/activePiecesTopic.yaml'
   segments:

--- a/packages/live-status-gateway-api/api/components/layers/outputLayer/outputLayer-example.yaml
+++ b/packages/live-status-gateway-api/api/components/layers/outputLayer/outputLayer-example.yaml
@@ -2,6 +2,5 @@ id: 'ol_pgm'
 name: 'PGM'
 isFlattened: false
 isPGM: true
-type: 0
 sourceLayerIds:
   - 'sl_camera'

--- a/packages/live-status-gateway-api/api/components/layers/outputLayer/outputLayer-example.yaml
+++ b/packages/live-status-gateway-api/api/components/layers/outputLayer/outputLayer-example.yaml
@@ -1,0 +1,7 @@
+id: 'ol_pgm'
+name: 'PGM'
+isFlattened: false
+isPGM: true
+type: 0
+sourceLayerIds:
+  - 'sl_camera'

--- a/packages/live-status-gateway-api/api/components/layers/outputLayer/outputLayer.yaml
+++ b/packages/live-status-gateway-api/api/components/layers/outputLayer/outputLayer.yaml
@@ -1,0 +1,30 @@
+$defs:
+  outputLayer:
+    type: object
+    title: OutputLayer
+    description: Definition of an output layer used in a segment
+    properties:
+      id:
+        type: string
+        description: Unique id of the output layer
+      name:
+        type: string
+        description: User-presentable name of the output layer
+      isFlattened:
+        type: boolean
+        description: Whether the output layer is flattened
+      isPGM:
+        type: boolean
+        description: Whether PGM treatment should be in effect
+      type:
+        type: number
+        description: Output layer type (numeric enum)
+      sourceLayerIds:
+        description: The set of sourceLayer ids that feed this output layer
+        type: array
+        items:
+          type: string
+    required: [id, name, isFlattened, isPGM, type, sourceLayerIds]
+    additionalProperties: false
+    examples:
+      - $ref: './outputLayer-example.yaml'

--- a/packages/live-status-gateway-api/api/components/layers/outputLayer/outputLayer.yaml
+++ b/packages/live-status-gateway-api/api/components/layers/outputLayer/outputLayer.yaml
@@ -16,15 +16,12 @@ $defs:
       isPGM:
         type: boolean
         description: Whether PGM treatment should be in effect
-      type:
-        type: number
-        description: Output layer type (numeric enum)
       sourceLayerIds:
         description: The set of sourceLayer ids that feed this output layer
         type: array
         items:
           type: string
-    required: [id, name, isFlattened, isPGM, type, sourceLayerIds]
+    required: [id, name, isFlattened, isPGM, sourceLayerIds]
     additionalProperties: false
     examples:
       - $ref: './outputLayer-example.yaml'

--- a/packages/live-status-gateway-api/api/components/layers/sourceLayer/sourceLayer-example.yaml
+++ b/packages/live-status-gateway-api/api/components/layers/sourceLayer/sourceLayer-example.yaml
@@ -1,0 +1,6 @@
+id: 'sl_camera'
+name: 'Camera'
+abbreviation: 'CAM'
+isHidden: false
+type: 1
+rank: 0

--- a/packages/live-status-gateway-api/api/components/layers/sourceLayer/sourceLayer.yaml
+++ b/packages/live-status-gateway-api/api/components/layers/sourceLayer/sourceLayer.yaml
@@ -1,0 +1,28 @@
+$defs:
+  sourceLayer:
+    type: object
+    title: SourceLayer
+    description: Definition of a source layer used in a segment
+    properties:
+      id:
+        type: string
+        description: Unique id of the source layer
+      name:
+        type: string
+        description: User-presentable name of the source layer
+      abbreviation:
+        type: string
+        description: Abbreviation for display
+      isHidden:
+        type: boolean
+        description: Whether the source layer is hidden in the UI
+      type:
+        type: number
+        description: Source layer content type (numeric enum)
+      rank:
+        type: number
+        description: Rank for ordering
+    required: [id, name, abbreviation, isHidden, type, rank]
+    additionalProperties: false
+    examples:
+      - $ref: './sourceLayer-example.yaml'

--- a/packages/live-status-gateway-api/api/components/part/partInvalidReason/partInvalidReason-example.yaml
+++ b/packages/live-status-gateway-api/api/components/part/partInvalidReason/partInvalidReason-example.yaml
@@ -1,0 +1,3 @@
+message: 'Invalid clip reference'
+severity: warning
+color: '#ff0000'

--- a/packages/live-status-gateway-api/api/components/part/partInvalidReason/partInvalidReason.yaml
+++ b/packages/live-status-gateway-api/api/components/part/partInvalidReason/partInvalidReason.yaml
@@ -1,0 +1,19 @@
+$defs:
+  partInvalidReason:
+    title: PartInvalidReason
+    description: Explanation for why a part is invalid
+    type: object
+    properties:
+      message:
+        type: string
+        description: Human-readable message explaining why the part is invalid
+      severity:
+        description: Severity hint for displaying the invalid reason
+        $ref: '../../notifications/notificationSeverity.yaml#/$defs/severity'
+      color:
+        description: Optional UI color hint
+        type: string
+    required: [message]
+    additionalProperties: false
+    examples:
+      - $ref: './partInvalidReason-example.yaml'

--- a/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart-example.yaml
+++ b/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart-example.yaml
@@ -3,6 +3,7 @@ instanceId: 'partInstance_current_1'
 externalId: 'ext_part_1'
 rank: 10
 invalid: false
+floated: false
 invalidReason:
   $ref: '../partInvalidReason/partInvalidReason-example.yaml'
 state: current

--- a/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart-example.yaml
+++ b/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart-example.yaml
@@ -3,6 +3,7 @@ instanceId: 'partInstance_current_1'
 externalId: 'ext_part_1'
 rank: 10
 state: current
+createdByAdLib: false
 publicData:
   partType: 'intro'
 timing:

--- a/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart-example.yaml
+++ b/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart-example.yaml
@@ -2,6 +2,9 @@ $ref: '../partBase/partBase-example.yaml'
 instanceId: 'partInstance_current_1'
 externalId: 'ext_part_1'
 rank: 10
+invalid: false
+invalidReason:
+  $ref: '../partInvalidReason/partInvalidReason-example.yaml'
 state: current
 createdByAdLib: false
 publicData:

--- a/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart-example.yaml
+++ b/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart-example.yaml
@@ -1,0 +1,11 @@
+$ref: '../partBase/partBase-example.yaml'
+instanceId: 'partInstance_current_1'
+externalId: 'ext_part_1'
+rank: 10
+state: current
+publicData:
+  partType: 'intro'
+timing:
+  $ref: '../../timing/resolvedPartTiming/resolvedPartTiming-example.yaml'
+pieces:
+  - $ref: '../../piece/resolvedPiece/resolvedPiece-example.yaml'

--- a/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart-example.yaml
+++ b/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart-example.yaml
@@ -4,6 +4,7 @@ externalId: 'ext_part_1'
 rank: 10
 invalid: false
 floated: false
+untimed: false
 invalidReason:
   $ref: '../partInvalidReason/partInvalidReason-example.yaml'
 state: current

--- a/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart.yaml
+++ b/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart.yaml
@@ -30,6 +30,9 @@ $defs:
           floated:
             type: boolean
             description: Whether this part is floated and cannot be taken/nexted
+          untimed:
+            type: boolean
+            description: Whether this part is excluded from normal timing calculations
           invalidReason:
             description: Optional explanation for why the part is invalid
             $ref: '../partInvalidReason/partInvalidReason.yaml#/$defs/partInvalidReason'
@@ -48,6 +51,6 @@ $defs:
             type: array
             items:
               $ref: '../../piece/resolvedPiece/resolvedPiece.yaml#/$defs/resolvedPiece'
-        required: [instanceId, externalId, rank, createdByAdLib, timing, pieces, invalid, floated]
+        required: [instanceId, externalId, rank, createdByAdLib, timing, pieces, invalid, floated, untimed]
     examples:
       - $ref: './resolvedPart-example.yaml'

--- a/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart.yaml
+++ b/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart.yaml
@@ -24,6 +24,12 @@ $defs:
           rank:
             type: number
             description: Rank for ordering
+          invalid:
+            type: boolean
+            description: Whether this part is invalid and should not be taken
+          invalidReason:
+            description: Optional explanation for why the part is invalid
+            $ref: '../partInvalidReason/partInvalidReason.yaml#/$defs/partInvalidReason'
           state:
             description: Set only for the current or next part
             $ref: '#/$defs/resolvedPartState'
@@ -39,6 +45,6 @@ $defs:
             type: array
             items:
               $ref: '../../piece/resolvedPiece/resolvedPiece.yaml#/$defs/resolvedPiece'
-        required: [instanceId, externalId, rank, createdByAdLib, timing, pieces]
+        required: [instanceId, externalId, rank, createdByAdLib, timing, pieces, invalid]
     examples:
       - $ref: './resolvedPart-example.yaml'

--- a/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart.yaml
+++ b/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart.yaml
@@ -27,6 +27,9 @@ $defs:
           state:
             description: Set only for the current or next part
             $ref: '#/$defs/resolvedPartState'
+          createdByAdLib:
+            type: boolean
+            description: Whether this part was created by an adlib
           publicData:
             description: Optional arbitrary data
           timing:
@@ -36,6 +39,6 @@ $defs:
             type: array
             items:
               $ref: '../../piece/resolvedPiece/resolvedPiece.yaml#/$defs/resolvedPiece'
-        required: [instanceId, externalId, rank, timing, pieces]
+        required: [instanceId, externalId, rank, createdByAdLib, timing, pieces]
     examples:
       - $ref: './resolvedPart-example.yaml'

--- a/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart.yaml
+++ b/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart.yaml
@@ -1,0 +1,41 @@
+$defs:
+  resolvedPartState:
+    title: ResolvedPartState
+    type: string
+    enum:
+      - current
+      - next
+
+  resolvedPart:
+    title: ResolvedPart
+    description: A part within a resolved segment
+    allOf:
+      - $ref: '../partBase/partBase.yaml#/$defs/partBase'
+      - type: object
+        title: ResolvedPart
+        description: A part within a resolved segment
+        properties:
+          instanceId:
+            type: string
+            description: Unique id of the part instance
+          externalId:
+            type: string
+            description: Id normally sourced from the ingest system
+          rank:
+            type: number
+            description: Rank for ordering
+          state:
+            description: Set only for the current or next part
+            $ref: '#/$defs/resolvedPartState'
+          publicData:
+            description: Optional arbitrary data
+          timing:
+            $ref: '../../timing/resolvedPartTiming/resolvedPartTiming.yaml#/$defs/resolvedPartTiming'
+          pieces:
+            description: Pieces in this part
+            type: array
+            items:
+              $ref: '../../piece/resolvedPiece/resolvedPiece.yaml#/$defs/resolvedPiece'
+        required: [instanceId, externalId, rank, timing, pieces]
+    examples:
+      - $ref: './resolvedPart-example.yaml'

--- a/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart.yaml
+++ b/packages/live-status-gateway-api/api/components/part/resolvedPart/resolvedPart.yaml
@@ -27,6 +27,9 @@ $defs:
           invalid:
             type: boolean
             description: Whether this part is invalid and should not be taken
+          floated:
+            type: boolean
+            description: Whether this part is floated and cannot be taken/nexted
           invalidReason:
             description: Optional explanation for why the part is invalid
             $ref: '../partInvalidReason/partInvalidReason.yaml#/$defs/partInvalidReason'
@@ -45,6 +48,6 @@ $defs:
             type: array
             items:
               $ref: '../../piece/resolvedPiece/resolvedPiece.yaml#/$defs/resolvedPiece'
-        required: [instanceId, externalId, rank, createdByAdLib, timing, pieces, invalid]
+        required: [instanceId, externalId, rank, createdByAdLib, timing, pieces, invalid, floated]
     examples:
       - $ref: './resolvedPart-example.yaml'

--- a/packages/live-status-gateway-api/api/components/piece/resolvedPiece/resolvedPiece-example.yaml
+++ b/packages/live-status-gateway-api/api/components/piece/resolvedPiece/resolvedPiece-example.yaml
@@ -6,6 +6,7 @@ priority: 0
 sourceLayerId: 'sl_camera'
 outputLayerId: 'ol_pgm'
 createdByAdLib: false
+invalid: false
 publicData:
   switcherSource: 1
 timing:

--- a/packages/live-status-gateway-api/api/components/piece/resolvedPiece/resolvedPiece-example.yaml
+++ b/packages/live-status-gateway-api/api/components/piece/resolvedPiece/resolvedPiece-example.yaml
@@ -5,6 +5,7 @@ name: 'Camera 1'
 priority: 0
 sourceLayerId: 'sl_camera'
 outputLayerId: 'ol_pgm'
+createdByAdLib: false
 publicData:
   switcherSource: 1
 timing:

--- a/packages/live-status-gateway-api/api/components/piece/resolvedPiece/resolvedPiece-example.yaml
+++ b/packages/live-status-gateway-api/api/components/piece/resolvedPiece/resolvedPiece-example.yaml
@@ -1,0 +1,15 @@
+id: 'piece_1'
+instanceId: 'pieceInstance_1'
+externalId: 'ext_piece_1'
+name: 'Camera 1'
+priority: 0
+sourceLayerId: 'sl_camera'
+outputLayerId: 'ol_pgm'
+publicData:
+  switcherSource: 1
+timing:
+  $ref: '../../timing/resolvedPieceTiming/resolvedPieceTiming-example.yaml'
+tags:
+  - 'camera'
+abSessions:
+  - $ref: '../pieceStatus/abSessionAssignment-example.yaml'

--- a/packages/live-status-gateway-api/api/components/piece/resolvedPiece/resolvedPiece.yaml
+++ b/packages/live-status-gateway-api/api/components/piece/resolvedPiece/resolvedPiece.yaml
@@ -25,6 +25,9 @@ $defs:
       outputLayerId:
         type: string
         description: Id of the output layer for this piece
+      createdByAdLib:
+        type: boolean
+        description: Whether this piece was created by an adlib
       publicData:
         description: Optional arbitrary data
       timing:
@@ -39,7 +42,7 @@ $defs:
         type: array
         items:
           $ref: '../pieceStatus/abSessionAssignment.yaml'
-    required: [id, instanceId, externalId, name, priority, sourceLayerId, outputLayerId, timing]
+    required: [id, instanceId, externalId, name, priority, sourceLayerId, outputLayerId, createdByAdLib, timing]
     additionalProperties: false
     examples:
       - $ref: './resolvedPiece-example.yaml'

--- a/packages/live-status-gateway-api/api/components/piece/resolvedPiece/resolvedPiece.yaml
+++ b/packages/live-status-gateway-api/api/components/piece/resolvedPiece/resolvedPiece.yaml
@@ -28,6 +28,9 @@ $defs:
       createdByAdLib:
         type: boolean
         description: Whether this piece was created by an adlib
+      invalid:
+        type: boolean
+        description: Whether this piece is invalid and should be ignored
       publicData:
         description: Optional arbitrary data
       timing:
@@ -42,7 +45,8 @@ $defs:
         type: array
         items:
           $ref: '../pieceStatus/abSessionAssignment.yaml'
-    required: [id, instanceId, externalId, name, priority, sourceLayerId, outputLayerId, createdByAdLib, timing]
+    required:
+      [id, instanceId, externalId, name, priority, sourceLayerId, outputLayerId, createdByAdLib, invalid, timing]
     additionalProperties: false
     examples:
       - $ref: './resolvedPiece-example.yaml'

--- a/packages/live-status-gateway-api/api/components/piece/resolvedPiece/resolvedPiece.yaml
+++ b/packages/live-status-gateway-api/api/components/piece/resolvedPiece/resolvedPiece.yaml
@@ -1,0 +1,45 @@
+$defs:
+  resolvedPiece:
+    type: object
+    title: ResolvedPiece
+    description: A piece within a resolved part
+    properties:
+      id:
+        type: string
+        description: Unique id of the piece
+      instanceId:
+        type: string
+        description: Unique id of the piece instance
+      externalId:
+        type: string
+        description: Id normally sourced from the ingest system
+      name:
+        type: string
+        description: User-facing name of the piece
+      priority:
+        type: number
+        description: Priority of the piece
+      sourceLayerId:
+        type: string
+        description: Id of the source layer for this piece
+      outputLayerId:
+        type: string
+        description: Id of the output layer for this piece
+      publicData:
+        description: Optional arbitrary data
+      timing:
+        $ref: '../../timing/resolvedPieceTiming/resolvedPieceTiming.yaml#/$defs/resolvedPieceTiming'
+      tags:
+        description: Optional tags attached to this piece
+        type: array
+        items:
+          type: string
+      abSessions:
+        description: Optional AB playback session assignments for this piece
+        type: array
+        items:
+          $ref: '../pieceStatus/abSessionAssignment.yaml'
+    required: [id, instanceId, externalId, name, priority, sourceLayerId, outputLayerId, timing]
+    additionalProperties: false
+    examples:
+      - $ref: './resolvedPiece-example.yaml'

--- a/packages/live-status-gateway-api/api/components/piece/resolvedPiece/resolvedPiece.yaml
+++ b/packages/live-status-gateway-api/api/components/piece/resolvedPiece/resolvedPiece.yaml
@@ -45,8 +45,7 @@ $defs:
         type: array
         items:
           $ref: '../pieceStatus/abSessionAssignment.yaml'
-    required:
-      [id, externalId, name, priority, sourceLayerId, outputLayerId, createdByAdLib, invalid, timing]
+    required: [id, externalId, name, priority, sourceLayerId, outputLayerId, createdByAdLib, invalid, timing]
     additionalProperties: false
     examples:
       - $ref: './resolvedPiece-example.yaml'

--- a/packages/live-status-gateway-api/api/components/piece/resolvedPiece/resolvedPiece.yaml
+++ b/packages/live-status-gateway-api/api/components/piece/resolvedPiece/resolvedPiece.yaml
@@ -46,7 +46,7 @@ $defs:
         items:
           $ref: '../pieceStatus/abSessionAssignment.yaml'
     required:
-      [id, instanceId, externalId, name, priority, sourceLayerId, outputLayerId, createdByAdLib, invalid, timing]
+      [id, externalId, name, priority, sourceLayerId, outputLayerId, createdByAdLib, invalid, timing]
     additionalProperties: false
     examples:
       - $ref: './resolvedPiece-example.yaml'

--- a/packages/live-status-gateway-api/api/components/playlist/playlistStatus/playlistStatus.yaml
+++ b/packages/live-status-gateway-api/api/components/playlist/playlistStatus/playlistStatus.yaml
@@ -21,6 +21,5 @@ $defs:
           - rehearsal
           - activated
     required: [id, externalId, name, activationStatus]
-    additionalProperties: false
     examples:
       - $ref: './playlistStatus-example.yaml'

--- a/packages/live-status-gateway-api/api/components/resolvedPlaylist/messages/resolvedPlaylistMessage.yaml
+++ b/packages/live-status-gateway-api/api/components/resolvedPlaylist/messages/resolvedPlaylistMessage.yaml
@@ -1,0 +1,11 @@
+components:
+  messages:
+    resolvedPlaylistMessage:
+      name: resolvedPlaylist
+      messageId: resolvedPlaylistUpdate
+      description: Resolved Playlist status
+      payload:
+        $ref: '../resolvedPlaylistEvent/resolvedPlaylistEvent.yaml#/$defs/resolvedPlaylistEvent'
+      examples:
+        - payload:
+            $ref: '../resolvedPlaylistEvent/resolvedPlaylistEvent-example.yaml'

--- a/packages/live-status-gateway-api/api/components/resolvedPlaylist/resolvedPlaylistEvent/resolvedPlaylistEvent-example.yaml
+++ b/packages/live-status-gateway-api/api/components/resolvedPlaylist/resolvedPlaylistEvent/resolvedPlaylistEvent-example.yaml
@@ -1,0 +1,18 @@
+$ref: '../../playlist/playlistStatus/playlistStatus-example.yaml'
+event: resolvedPlaylist
+currentPartInstanceId: 'partInstance_current_1'
+nextPartInstanceId: 'partInstance_next_1'
+playoutState:
+  mode: 'AUTO'
+publicData:
+  category: 'Evening News'
+timing:
+  $ref: '../../timing/resolvedPlaylistTiming/resolvedPlaylistTiming-example.yaml'
+tTimers:
+  - $ref: '../../tTimers/tTimerStatus-countdownRunning-example.yaml'
+  - $ref: '../../tTimers/tTimerStatus-freeRunRunning-example.yaml'
+  - $ref: '../../tTimers/tTimerStatus-unconfigured-example.yaml'
+quickLoop:
+  $ref: '../../quickLoop/activePlaylistQuickLoop/activePlaylistQuickLoop-example.yaml'
+rundowns:
+  - $ref: '../../rundown/resolvedRundown/resolvedRundown-example.yaml'

--- a/packages/live-status-gateway-api/api/components/resolvedPlaylist/resolvedPlaylistEvent/resolvedPlaylistEvent.yaml
+++ b/packages/live-status-gateway-api/api/components/resolvedPlaylist/resolvedPlaylistEvent/resolvedPlaylistEvent.yaml
@@ -1,0 +1,51 @@
+title: Resolved Playlist
+description: Resolved Playlist schema for websocket subscriptions
+$defs:
+  resolvedPlaylistEvent:
+    title: ResolvedPlaylistEvent
+    description: Resolved playlist details, including the base playlist status.
+    allOf:
+      - $ref: '../../playlist/playlistStatus/playlistStatus.yaml#/$defs/playlistStatus'
+      - type: object
+        title: ResolvedPlaylistEvent
+        description: Resolved playlist details, including rundown/segment/part/piece structure.
+        properties:
+          event:
+            type: string
+            const: resolvedPlaylist
+          currentPartInstanceId:
+            description: Instance id of the current part, if any
+            oneOf:
+              - type: string
+              - type: 'null'
+          nextPartInstanceId:
+            description: Instance id of the next part, if any
+            oneOf:
+              - type: string
+              - type: 'null'
+          playoutState:
+            description: Blueprint-defined playout state, used to expose arbitrary information about playout
+          publicData:
+            description: Optional arbitrary data
+          timing:
+            $ref: '../../timing/resolvedPlaylistTiming/resolvedPlaylistTiming.yaml#/$defs/resolvedPlaylistTiming'
+          tTimers:
+            description: Status of the 3 T-timers in the playlist
+            type: array
+            items:
+              $ref: '../../tTimers/tTimerStatus.yaml#/$defs/tTimerStatus'
+            minItems: 3
+            maxItems: 3
+          quickLoop:
+            description: Information about the current quickLoop, if any
+            oneOf:
+              - type: 'null'
+              - $ref: '../../quickLoop/activePlaylistQuickLoop/activePlaylistQuickLoop.yaml#/$defs/activePlaylistQuickLoop'
+          rundowns:
+            description: The rundowns in the playlist, in rank order
+            type: array
+            items:
+              $ref: '../../rundown/resolvedRundown/resolvedRundown.yaml#/$defs/resolvedRundown'
+        required: [event, currentPartInstanceId, nextPartInstanceId, timing, tTimers, rundowns]
+    examples:
+      - $ref: './resolvedPlaylistEvent-example.yaml'

--- a/packages/live-status-gateway-api/api/components/rundown/resolvedRundown/resolvedRundown-example.yaml
+++ b/packages/live-status-gateway-api/api/components/rundown/resolvedRundown/resolvedRundown-example.yaml
@@ -1,0 +1,9 @@
+id: 'rd_1'
+externalId: 'ext_rd_1'
+name: 'Rundown 1'
+rank: 10
+description: ''
+publicData:
+  ingestSource: 'NRK'
+segments:
+  - $ref: '../../segment/resolvedSegment/resolvedSegment-example.yaml'

--- a/packages/live-status-gateway-api/api/components/rundown/resolvedRundown/resolvedRundown.yaml
+++ b/packages/live-status-gateway-api/api/components/rundown/resolvedRundown/resolvedRundown.yaml
@@ -26,7 +26,7 @@ $defs:
         type: array
         items:
           $ref: '../../segment/resolvedSegment/resolvedSegment.yaml#/$defs/resolvedSegment'
-    required: [id, externalId, name, rank, description, segments]
+    required: [id, externalId, name, rank, segments]
     additionalProperties: false
     examples:
       - $ref: './resolvedRundown-example.yaml'

--- a/packages/live-status-gateway-api/api/components/rundown/resolvedRundown/resolvedRundown.yaml
+++ b/packages/live-status-gateway-api/api/components/rundown/resolvedRundown/resolvedRundown.yaml
@@ -1,0 +1,32 @@
+$defs:
+  resolvedRundown:
+    type: object
+    title: ResolvedRundown
+    description: A rundown within a resolved playlist
+    properties:
+      id:
+        type: string
+        description: Unique id of the rundown
+      externalId:
+        type: string
+        description: Id normally sourced from the ingest system
+      name:
+        type: string
+        description: User-presentable name of the rundown
+      rank:
+        type: number
+        description: Rank for ordering
+      description:
+        type: string
+        description: Optional description
+      publicData:
+        description: Optional arbitrary data
+      segments:
+        description: Segments in this rundown
+        type: array
+        items:
+          $ref: '../../segment/resolvedSegment/resolvedSegment.yaml#/$defs/resolvedSegment'
+    required: [id, externalId, name, rank, description, segments]
+    additionalProperties: false
+    examples:
+      - $ref: './resolvedRundown-example.yaml'

--- a/packages/live-status-gateway-api/api/components/segment/resolvedSegment/resolvedSegment-example.yaml
+++ b/packages/live-status-gateway-api/api/components/segment/resolvedSegment/resolvedSegment-example.yaml
@@ -1,0 +1,16 @@
+$ref: '../segmentBase/segmentBase-example.yaml'
+externalId: 'ext_seg_1'
+identifier: 'A'
+name: 'Headlines'
+rank: 1
+isHidden: false
+sourceLayers:
+  - $ref: '../../layers/sourceLayer/sourceLayer-example.yaml'
+outputLayers:
+  - $ref: '../../layers/outputLayer/outputLayer-example.yaml'
+publicData:
+  slug: 'HEAD'
+timing:
+  $ref: '../../timing/resolvedSegmentTiming/resolvedSegmentTiming-example.yaml'
+parts:
+  - $ref: '../../part/resolvedPart/resolvedPart-example.yaml'

--- a/packages/live-status-gateway-api/api/components/segment/resolvedSegment/resolvedSegment.yaml
+++ b/packages/live-status-gateway-api/api/components/segment/resolvedSegment/resolvedSegment.yaml
@@ -1,0 +1,47 @@
+$defs:
+  resolvedSegment:
+    title: ResolvedSegment
+    description: A segment within a resolved rundown
+    allOf:
+      - $ref: '../segmentBase/segmentBase.yaml#/$defs/segmentBase'
+      - type: object
+        title: ResolvedSegment
+        description: A segment within a resolved rundown
+        properties:
+          externalId:
+            type: string
+            description: Id normally sourced from the ingest system
+          identifier:
+            type: string
+            description: User-facing identifier from the source system
+          name:
+            type: string
+            description: Name of the segment
+          rank:
+            type: number
+            description: Rank for ordering
+          isHidden:
+            type: boolean
+            description: Whether the segment is hidden
+          sourceLayers:
+            description: Source layers used in this segment
+            type: array
+            items:
+              $ref: '../../layers/sourceLayer/sourceLayer.yaml#/$defs/sourceLayer'
+          outputLayers:
+            description: Output layers used in this segment
+            type: array
+            items:
+              $ref: '../../layers/outputLayer/outputLayer.yaml#/$defs/outputLayer'
+          publicData:
+            description: Optional arbitrary data
+          timing:
+            $ref: '../../timing/resolvedSegmentTiming/resolvedSegmentTiming.yaml#/$defs/resolvedSegmentTiming'
+          parts:
+            description: Parts in this segment
+            type: array
+            items:
+              $ref: '../../part/resolvedPart/resolvedPart.yaml#/$defs/resolvedPart'
+        required: [externalId, identifier, name, rank, isHidden, sourceLayers, outputLayers, timing, parts]
+    examples:
+      - $ref: './resolvedSegment-example.yaml'

--- a/packages/live-status-gateway-api/api/components/subscriptions/subscriptionName.yaml
+++ b/packages/live-status-gateway-api/api/components/subscriptions/subscriptionName.yaml
@@ -6,6 +6,7 @@ $defs:
     enum:
       - studio
       - activePlaylist
+      - resolvedPlaylist
       - activePieces
       - segments
       - adLibs

--- a/packages/live-status-gateway-api/api/components/tTimers/tTimerStatus-countdownRunning-example.yaml
+++ b/packages/live-status-gateway-api/api/components/tTimers/tTimerStatus-countdownRunning-example.yaml
@@ -1,0 +1,12 @@
+index: 1
+label: 'Segment Timer'
+configured: true
+mode:
+  $ref: './timerModeCountdown-example.yaml'
+state:
+  $ref: './timerStateRunning-example.yaml'
+projected:
+  paused: false
+  zeroTime: 1706371925000
+  pauseTime: null
+anchorPartId: 'part_break_1'

--- a/packages/live-status-gateway-api/api/components/tTimers/tTimerStatus-freeRunRunning-example.yaml
+++ b/packages/live-status-gateway-api/api/components/tTimers/tTimerStatus-freeRunRunning-example.yaml
@@ -1,0 +1,11 @@
+index: 2
+label: 'Show Timer'
+configured: true
+mode:
+  $ref: './timerModeFreeRun-example.yaml'
+state:
+  paused: false
+  zeroTime: 1706371800000
+  pauseTime: null
+projected: null
+anchorPartId: null

--- a/packages/live-status-gateway-api/api/components/tTimers/tTimerStatus-unconfigured-example.yaml
+++ b/packages/live-status-gateway-api/api/components/tTimers/tTimerStatus-unconfigured-example.yaml
@@ -1,0 +1,7 @@
+index: 3
+label: ''
+configured: false
+mode: null
+state: null
+projected: null
+anchorPartId: null

--- a/packages/live-status-gateway-api/api/components/tTimers/timerMode.yaml
+++ b/packages/live-status-gateway-api/api/components/tTimers/timerMode.yaml
@@ -15,3 +15,7 @@ $defs:
       - $ref: '#/$defs/timerModeCountdown'
       - $ref: '#/$defs/timerModeFreeRun'
       - $ref: '#/$defs/timerModeTimeOfDay'
+    examples:
+      - $ref: './timerModeCountdown-example.yaml'
+      - $ref: './timerModeFreeRun-example.yaml'
+      - $ref: './timerModeTimeOfDay-example.yaml'

--- a/packages/live-status-gateway-api/api/components/tTimers/timerModeCountdown-example.yaml
+++ b/packages/live-status-gateway-api/api/components/tTimers/timerModeCountdown-example.yaml
@@ -1,0 +1,3 @@
+type: countdown
+duration: 120000
+stopAtZero: true

--- a/packages/live-status-gateway-api/api/components/tTimers/timerModeFreeRun-example.yaml
+++ b/packages/live-status-gateway-api/api/components/tTimers/timerModeFreeRun-example.yaml
@@ -1,0 +1,1 @@
+type: freeRun

--- a/packages/live-status-gateway-api/api/components/tTimers/timerModeTimeOfDay-example.yaml
+++ b/packages/live-status-gateway-api/api/components/tTimers/timerModeTimeOfDay-example.yaml
@@ -1,0 +1,3 @@
+type: timeOfDay
+targetRaw: '14:30'
+stopAtZero: true

--- a/packages/live-status-gateway-api/api/components/tTimers/timerState.yaml
+++ b/packages/live-status-gateway-api/api/components/tTimers/timerState.yaml
@@ -14,3 +14,6 @@ $defs:
     oneOf:
       - $ref: '#/$defs/timerStateRunning'
       - $ref: '#/$defs/timerStatePaused'
+    examples:
+      - $ref: './timerStateRunning-example.yaml'
+      - $ref: './timerStatePaused-example.yaml'

--- a/packages/live-status-gateway-api/api/components/tTimers/timerStatePaused-example.yaml
+++ b/packages/live-status-gateway-api/api/components/tTimers/timerStatePaused-example.yaml
@@ -1,0 +1,3 @@
+paused: true
+duration: 35000
+pauseTime: null

--- a/packages/live-status-gateway-api/api/components/tTimers/timerStateRunning-example.yaml
+++ b/packages/live-status-gateway-api/api/components/tTimers/timerStateRunning-example.yaml
@@ -1,0 +1,3 @@
+paused: false
+zeroTime: 1706371920000
+pauseTime: 1706371900000

--- a/packages/live-status-gateway-api/api/components/timing/resolvedPartTiming/resolvedPartTiming-example.yaml
+++ b/packages/live-status-gateway-api/api/components/timing/resolvedPartTiming/resolvedPartTiming-example.yaml
@@ -1,0 +1,7 @@
+startMs: 0
+durationMs: 15000
+plannedStartedPlayback: 1706371805000
+reportedStartedPlayback: 1706371806000
+playOffset: 1000
+setAsNext: 1706371804000
+take: 1706371806000

--- a/packages/live-status-gateway-api/api/components/timing/resolvedPartTiming/resolvedPartTiming-example.yaml
+++ b/packages/live-status-gateway-api/api/components/timing/resolvedPartTiming/resolvedPartTiming-example.yaml
@@ -2,6 +2,6 @@ startMs: 0
 durationMs: 15000
 plannedStartedPlayback: 1706371805000
 reportedStartedPlayback: 1706371806000
-playOffset: 1000
+playOffsetMs: 1000
 setAsNext: 1706371804000
 take: 1706371806000

--- a/packages/live-status-gateway-api/api/components/timing/resolvedPartTiming/resolvedPartTiming.yaml
+++ b/packages/live-status-gateway-api/api/components/timing/resolvedPartTiming/resolvedPartTiming.yaml
@@ -1,0 +1,31 @@
+$defs:
+  resolvedPartTiming:
+    type: object
+    title: ResolvedPartTiming
+    description: Timing information about the part, relative to the start of the segment
+    properties:
+      startMs:
+        description: Start offset of the part (ms) from the beginning of the segment
+        type: number
+      durationMs:
+        description: Resolved duration of the part (ms)
+        type: number
+      plannedStartedPlayback:
+        description: Unix timestamp (ms) when the part was planned to start playback
+        type: number
+      reportedStartedPlayback:
+        description: Unix timestamp (ms) when the part was reported as started playback
+        type: number
+      playOffset:
+        description: Playback offset relative to planned start (ms)
+        type: number
+      setAsNext:
+        description: Unix timestamp (ms) when the part was set as next
+        type: number
+      take:
+        description: Unix timestamp (ms) when the part was taken
+        type: number
+    required: [startMs, durationMs]
+    additionalProperties: false
+    examples:
+      - $ref: './resolvedPartTiming-example.yaml'

--- a/packages/live-status-gateway-api/api/components/timing/resolvedPartTiming/resolvedPartTiming.yaml
+++ b/packages/live-status-gateway-api/api/components/timing/resolvedPartTiming/resolvedPartTiming.yaml
@@ -14,10 +14,10 @@ $defs:
         description: Unix timestamp (ms) when the part was planned to start playback
         type: number
       reportedStartedPlayback:
-        description: Unix timestamp (ms) when the part was reported as started playback
+        description: Unix timestamp (ms) when the part was reported when it actually started playback
         type: number
-      playOffset:
-        description: Playback offset relative to planned start (ms)
+      playOffsetMs:
+        description: Milliseconds into the part where playback started when taken (eg via “Play/Set Next from Here”; 0 = from the beginning)
         type: number
       setAsNext:
         description: Unix timestamp (ms) when the part was set as next

--- a/packages/live-status-gateway-api/api/components/timing/resolvedPieceTiming/resolvedPieceTiming-example.yaml
+++ b/packages/live-status-gateway-api/api/components/timing/resolvedPieceTiming/resolvedPieceTiming-example.yaml
@@ -1,0 +1,3 @@
+startMs: 6500
+durationMs: 5000
+prerollMs: 250

--- a/packages/live-status-gateway-api/api/components/timing/resolvedPieceTiming/resolvedPieceTiming.yaml
+++ b/packages/live-status-gateway-api/api/components/timing/resolvedPieceTiming/resolvedPieceTiming.yaml
@@ -13,7 +13,6 @@ $defs:
       prerollMs:
         description: Preroll duration for the piece (ms)
         type: number
-    required: [startMs, durationMs, prerollMs]
     additionalProperties: false
     examples:
       - $ref: './resolvedPieceTiming-example.yaml'

--- a/packages/live-status-gateway-api/api/components/timing/resolvedPieceTiming/resolvedPieceTiming.yaml
+++ b/packages/live-status-gateway-api/api/components/timing/resolvedPieceTiming/resolvedPieceTiming.yaml
@@ -1,0 +1,19 @@
+$defs:
+  resolvedPieceTiming:
+    type: object
+    title: ResolvedPieceTiming
+    description: Timing information about the piece, relative to the start of the part
+    properties:
+      startMs:
+        description: Start offset of the piece (ms) from the beginning of the part
+        type: number
+      durationMs:
+        description: Resolved duration of the piece (ms)
+        type: number
+      prerollMs:
+        description: Preroll duration for the piece (ms)
+        type: number
+    required: [startMs, durationMs, prerollMs]
+    additionalProperties: false
+    examples:
+      - $ref: './resolvedPieceTiming-example.yaml'

--- a/packages/live-status-gateway-api/api/components/timing/resolvedPlaylistTiming/resolvedPlaylistTiming-example.yaml
+++ b/packages/live-status-gateway-api/api/components/timing/resolvedPlaylistTiming/resolvedPlaylistTiming-example.yaml
@@ -1,0 +1,4 @@
+type: forward
+startMs: 1706371800000
+durationMs: 1800000
+endMs: 1706373600000

--- a/packages/live-status-gateway-api/api/components/timing/resolvedPlaylistTiming/resolvedPlaylistTiming-example.yaml
+++ b/packages/live-status-gateway-api/api/components/timing/resolvedPlaylistTiming/resolvedPlaylistTiming-example.yaml
@@ -1,4 +1,4 @@
 type: forward
-startMs: 1706371800000
-durationMs: 1800000
-endMs: 1706373600000
+startedPlayback: 1706371800000
+expectedDurationMs: 1800000
+expectedEnd: 1706373600000

--- a/packages/live-status-gateway-api/api/components/timing/resolvedPlaylistTiming/resolvedPlaylistTiming.yaml
+++ b/packages/live-status-gateway-api/api/components/timing/resolvedPlaylistTiming/resolvedPlaylistTiming.yaml
@@ -1,0 +1,35 @@
+$defs:
+  resolvedPlaylistTimingType:
+    title: ResolvedPlaylistTimingType
+    type: string
+    description: Whether timing counts forward from a start time or back from an end time
+    enum:
+      - forward
+      - back
+
+  resolvedPlaylistTiming:
+    type: object
+    title: ResolvedPlaylistTiming
+    description: Timing information about the playlist, expressed as relative offsets (not wall-clock time)
+    properties:
+      type:
+        $ref: '#/$defs/resolvedPlaylistTimingType'
+      startMs:
+        description: Optional start offset of the playlist (ms). When present, this is typically 0.
+        oneOf:
+          - type: number
+          - type: 'null'
+      durationMs:
+        description: Expected duration of the playlist (ms)
+        oneOf:
+          - type: number
+          - type: 'null'
+      endMs:
+        description: Optional end offset of the playlist (ms) from the beginning of the playlist
+        oneOf:
+          - type: number
+          - type: 'null'
+    required: [type, startMs, durationMs, endMs]
+    additionalProperties: false
+    examples:
+      - $ref: './resolvedPlaylistTiming-example.yaml'

--- a/packages/live-status-gateway-api/api/components/timing/resolvedPlaylistTiming/resolvedPlaylistTiming.yaml
+++ b/packages/live-status-gateway-api/api/components/timing/resolvedPlaylistTiming/resolvedPlaylistTiming.yaml
@@ -2,7 +2,7 @@ $defs:
   resolvedPlaylistTimingType:
     title: ResolvedPlaylistTimingType
     type: string
-    description: Whether timing counts forward from a start time or back from an end time
+    description: Whether the playlist is forward-timed from a start time or back-timed from an end time
     enum:
       - forward
       - back
@@ -10,26 +10,26 @@ $defs:
   resolvedPlaylistTiming:
     type: object
     title: ResolvedPlaylistTiming
-    description: Timing information about the playlist, expressed as relative offsets (not wall-clock time)
+    description: Timing information about the playlist using absolute Unix timestamps (ms) and expected duration.
     properties:
       type:
         $ref: '#/$defs/resolvedPlaylistTimingType'
-      startMs:
-        description: Optional start offset of the playlist (ms). When present, this is typically 0.
+      startedPlayback:
+        description: Unix timestamp (ms) when the playlist actually started playback (first timed part confirmed started). Null until known.
         oneOf:
           - type: number
           - type: 'null'
-      durationMs:
-        description: Expected duration of the playlist (ms)
+      expectedDurationMs:
+        description: Expected duration of the playlist (ms). Null when unknown/unavailable.
         oneOf:
           - type: number
           - type: 'null'
-      endMs:
-        description: Optional end offset of the playlist (ms) from the beginning of the playlist
+      expectedEnd:
+        description: Unix timestamp (ms) when the playlist is expected/projected to end. Null when it cannot be resolved from timing configuration.
         oneOf:
           - type: number
           - type: 'null'
-    required: [type, startMs, durationMs, endMs]
+    required: [type, startedPlayback, expectedDurationMs, expectedEnd]
     additionalProperties: false
     examples:
       - $ref: './resolvedPlaylistTiming-example.yaml'

--- a/packages/live-status-gateway-api/api/components/timing/resolvedSegmentTiming/resolvedSegmentTiming-example.yaml
+++ b/packages/live-status-gateway-api/api/components/timing/resolvedSegmentTiming/resolvedSegmentTiming-example.yaml
@@ -1,0 +1,3 @@
+startMs: 0
+endMs: 120000
+budgetDurationMs: 120000

--- a/packages/live-status-gateway-api/api/components/timing/resolvedSegmentTiming/resolvedSegmentTiming.yaml
+++ b/packages/live-status-gateway-api/api/components/timing/resolvedSegmentTiming/resolvedSegmentTiming.yaml
@@ -1,0 +1,19 @@
+$defs:
+  resolvedSegmentTiming:
+    type: object
+    title: ResolvedSegmentTiming
+    description: Timing information about the segment, relative to the start of the segment
+    properties:
+      startMs:
+        description: Start offset of the segment (ms). For segments, this is typically 0.
+        type: number
+      endMs:
+        description: End offset of the segment (ms) from the beginning of the segment
+        type: number
+      budgetDurationMs:
+        description: Planned/budget duration for the segment (ms)
+        type: number
+    required: [startMs, endMs, budgetDurationMs]
+    additionalProperties: false
+    examples:
+      - $ref: './resolvedSegmentTiming-example.yaml'

--- a/packages/live-status-gateway-api/api/topics/resolvedPlaylist/resolvedPlaylistTopic.yaml
+++ b/packages/live-status-gateway-api/api/topics/resolvedPlaylist/resolvedPlaylistTopic.yaml
@@ -1,0 +1,8 @@
+description: Topic for resolved playlist updates
+
+subscribe:
+  operationId: receiveResolvedPlaylist
+  description: Server sends resolved playlist events
+  message:
+    oneOf:
+      - $ref: '../../components/resolvedPlaylist/messages/resolvedPlaylistMessage.yaml#/components/messages/resolvedPlaylistMessage'

--- a/packages/live-status-gateway-api/scripts/generate-schema-types.mjs
+++ b/packages/live-status-gateway-api/scripts/generate-schema-types.mjs
@@ -67,7 +67,7 @@ if (!asyncApiDoc.document) {
 	const filteredDiagnostics = asyncApiDoc.diagnostics.filter((d) => d.code !== 'asyncapi-latest-version')
 
 	console.error('No document was produced from the asyncapi parser')
-	console.error(JSON.stringify(filteredDiagnostics.diagnostics))
+	console.error(JSON.stringify(filteredDiagnostics))
 
 	// eslint-disable-next-line n/no-process-exit
 	process.exit(5)

--- a/packages/live-status-gateway-api/src/generated/asyncapi.yaml
+++ b/packages/live-status-gateway-api/src/generated/asyncapi.yaml
@@ -1070,46 +1070,49 @@ channels:
                     timing:
                       type: object
                       title: ResolvedPlaylistTiming
-                      description: Timing information about the playlist, expressed as relative
-                        offsets (not wall-clock time)
+                      description: Timing information about the playlist using absolute Unix
+                        timestamps (ms) and expected duration.
                       properties:
                         type:
                           title: ResolvedPlaylistTimingType
                           type: string
-                          description: Whether timing counts forward from a start time or back from an end
-                            time
+                          description: Whether the playlist is forward-timed from a start time or
+                            back-timed from an end time
                           enum:
                             - forward
                             - back
-                        startMs:
-                          description: Optional start offset of the playlist (ms). When present, this is
-                            typically 0.
+                        startedPlayback:
+                          description: Unix timestamp (ms) when the playlist actually started playback
+                            (first timed part confirmed started). Null until
+                            known.
                           oneOf:
                             - type: number
                             - type: "null"
-                        durationMs:
-                          description: Expected duration of the playlist (ms)
+                        expectedDurationMs:
+                          description: Expected duration of the playlist (ms). Null when
+                            unknown/unavailable.
                           oneOf:
                             - type: number
                             - type: "null"
-                        endMs:
-                          description: Optional end offset of the playlist (ms) from the beginning of the
-                            playlist
+                        expectedEnd:
+                          description: Unix timestamp (ms) when the playlist is expected/projected to end.
+                            Null when it cannot be resolved from timing
+                            configuration.
                           oneOf:
                             - type: number
                             - type: "null"
                       required:
                         - type
-                        - startMs
-                        - durationMs
-                        - endMs
+                        - startedPlayback
+                        - expectedDurationMs
+                        - expectedEnd
                       additionalProperties: false
                       examples:
                         - &a46
                           type: forward
-                          startMs: 1706371800000
-                          durationMs: 1800000
-                          endMs: 1706373600000
+                          startedPlayback: 1706371800000
+                          expectedDurationMs: 1800000
+                          expectedEnd: 1706373600000
                     tTimers:
                       description: Status of the 3 T-timers in the playlist
                       type: array

--- a/packages/live-status-gateway-api/src/generated/asyncapi.yaml
+++ b/packages/live-status-gateway-api/src/generated/asyncapi.yaml
@@ -1310,6 +1310,9 @@ channels:
                                               floated:
                                                 type: boolean
                                                 description: Whether this part is floated and cannot be taken/nexted
+                                              untimed:
+                                                type: boolean
+                                                description: Whether this part is excluded from normal timing calculations
                                               invalidReason:
                                                 description: Optional explanation for why the part is invalid
                                                 title: PartInvalidReason
@@ -1495,6 +1498,7 @@ channels:
                                               - pieces
                                               - invalid
                                               - floated
+                                              - untimed
                                         examples:
                                           - &a44
                                             instanceId: partInstance_current_1
@@ -1502,6 +1506,7 @@ channels:
                                             rank: 10
                                             invalid: false
                                             floated: false
+                                            untimed: false
                                             invalidReason: *a38
                                             state: current
                                             createdByAdLib: false

--- a/packages/live-status-gateway-api/src/generated/asyncapi.yaml
+++ b/packages/live-status-gateway-api/src/generated/asyncapi.yaml
@@ -1235,9 +1235,6 @@ channels:
                                           isPGM:
                                             type: boolean
                                             description: Whether PGM treatment should be in effect
-                                          type:
-                                            type: number
-                                            description: Output layer type (numeric enum)
                                           sourceLayerIds:
                                             description: The set of sourceLayer ids that feed this output layer
                                             type: array
@@ -1248,7 +1245,6 @@ channels:
                                           - name
                                           - isFlattened
                                           - isPGM
-                                          - type
                                           - sourceLayerIds
                                         additionalProperties: false
                                         examples:
@@ -1257,7 +1253,6 @@ channels:
                                             name: PGM
                                             isFlattened: false
                                             isPGM: true
-                                            type: 0
                                             sourceLayerIds:
                                               - sl_camera
                                     publicData:
@@ -1316,6 +1311,9 @@ channels:
                                                 enum:
                                                   - current
                                                   - next
+                                              createdByAdLib:
+                                                type: boolean
+                                                description: Whether this part was created by an adlib
                                               publicData:
                                                 description: Optional arbitrary data
                                               timing:
@@ -1387,6 +1385,9 @@ channels:
                                                     outputLayerId:
                                                       type: string
                                                       description: Id of the output layer for this piece
+                                                    createdByAdLib:
+                                                      type: boolean
+                                                      description: Whether this piece was created by an adlib
                                                     publicData:
                                                       description: Optional arbitrary data
                                                     timing:
@@ -1404,10 +1405,6 @@ channels:
                                                         prerollMs:
                                                           description: Preroll duration for the piece (ms)
                                                           type: number
-                                                      required:
-                                                        - startMs
-                                                        - durationMs
-                                                        - prerollMs
                                                       additionalProperties: false
                                                       examples:
                                                         - &a36
@@ -1431,6 +1428,7 @@ channels:
                                                     - priority
                                                     - sourceLayerId
                                                     - outputLayerId
+                                                    - createdByAdLib
                                                     - timing
                                                   additionalProperties: false
                                                   examples:
@@ -1442,6 +1440,7 @@ channels:
                                                       priority: 0
                                                       sourceLayerId: sl_camera
                                                       outputLayerId: ol_pgm
+                                                      createdByAdLib: false
                                                       publicData:
                                                         switcherSource: 1
                                                       timing: *a36
@@ -1453,6 +1452,7 @@ channels:
                                               - instanceId
                                               - externalId
                                               - rank
+                                              - createdByAdLib
                                               - timing
                                               - pieces
                                         examples:
@@ -1461,6 +1461,7 @@ channels:
                                             externalId: ext_part_1
                                             rank: 10
                                             state: current
+                                            createdByAdLib: false
                                             publicData:
                                               partType: intro
                                             timing: *a38

--- a/packages/live-status-gateway-api/src/generated/asyncapi.yaml
+++ b/packages/live-status-gateway-api/src/generated/asyncapi.yaml
@@ -1418,6 +1418,9 @@ channels:
                                                     createdByAdLib:
                                                       type: boolean
                                                       description: Whether this piece was created by an adlib
+                                                    invalid:
+                                                      type: boolean
+                                                      description: Whether this piece is invalid and should be ignored
                                                     publicData:
                                                       description: Optional arbitrary data
                                                     timing:
@@ -1459,6 +1462,7 @@ channels:
                                                     - sourceLayerId
                                                     - outputLayerId
                                                     - createdByAdLib
+                                                    - invalid
                                                     - timing
                                                   additionalProperties: false
                                                   examples:
@@ -1471,6 +1475,7 @@ channels:
                                                       sourceLayerId: sl_camera
                                                       outputLayerId: ol_pgm
                                                       createdByAdLib: false
+                                                      invalid: false
                                                       publicData:
                                                         switcherSource: 1
                                                       timing: *a36

--- a/packages/live-status-gateway-api/src/generated/asyncapi.yaml
+++ b/packages/live-status-gateway-api/src/generated/asyncapi.yaml
@@ -155,6 +155,7 @@ channels:
                           enum:
                             - studio
                             - activePlaylist
+                            - resolvedPlaylist
                             - activePieces
                             - segments
                             - adLibs
@@ -275,7 +276,7 @@ channels:
                     playlists:
                       description: The playlists that are currently loaded in the studio
                       type: array
-                      items:
+                      items: &a31
                         title: PlaylistStatus
                         type: object
                         properties:
@@ -301,7 +302,6 @@ channels:
                           - externalId
                           - name
                           - activationStatus
-                        additionalProperties: false
                         examples:
                           - &a11
                             id: OKAgZmZ0Buc99lE_2uPPSKVbMrQ_
@@ -401,7 +401,7 @@ channels:
                                 pieces:
                                   description: All pieces in this part
                                   type: array
-                                  items: &a31
+                                  items: &a51
                                     type: object
                                     title: PieceStatus
                                     properties:
@@ -427,7 +427,7 @@ channels:
                                       abSessions:
                                         description: AB playback session assignments for this Piece
                                         type: array
-                                        items:
+                                        items: &a35
                                           type: object
                                           title: AbSessionAssignment
                                           properties:
@@ -464,7 +464,8 @@ channels:
                                         publicData:
                                           switcherSource: 1
                                         abSessions:
-                                          - poolName: VTR
+                                          - &a37
+                                            poolName: VTR
                                             sessionName: clip_intro
                                             playerId: 1
                                 publicData:
@@ -537,7 +538,7 @@ channels:
                     - type: object
                       title: CurrentSegment
                       allOf:
-                        - &a33
+                        - &a34
                           title: SegmentBase
                           type: object
                           properties:
@@ -556,7 +557,7 @@ channels:
                               title: CurrentSegmentTiming
                               description: Timing information about the current segment
                               allOf:
-                                - &a34
+                                - &a53
                                   type: object
                                   title: SegmentTiming
                                   properties:
@@ -685,7 +686,7 @@ channels:
                       timingMode: forward-time
                       expectedStart: 1728895750727
                       expectedDurationMs: 180000
-                quickLoop:
+                quickLoop: &a33
                   description: Information about the current quickLoop, if any
                   type: object
                   title: ActivePlaylistQuickLoop
@@ -743,7 +744,7 @@ channels:
                 tTimers:
                   description: Status of the 3 T-timers in the playlist
                   type: array
-                  items:
+                  items: &a32
                     type: object
                     title: TTimerStatus
                     description: Status of a single T-timer in the playlist
@@ -831,6 +832,16 @@ channels:
                                   - type: timeOfDay
                                     targetRaw: 14:30
                                     stopAtZero: false
+                            examples:
+                              - &a46
+                                type: countdown
+                                duration: 120000
+                                stopAtZero: true
+                              - &a48
+                                type: freeRun
+                              - type: timeOfDay
+                                targetRaw: 14:30
+                                stopAtZero: true
                       state:
                         description: Current runtime state of the timer. Null if not configured.
                         oneOf:
@@ -899,6 +910,14 @@ channels:
                                   - paused: true
                                     duration: 45000
                                     pauseTime: null
+                            examples:
+                              - &a47
+                                paused: false
+                                zeroTime: 1706371920000
+                                pauseTime: 1706371900000
+                              - paused: true
+                                duration: 35000
+                                pauseTime: null
                       projected:
                         description: Projected timing for when we expect to reach an anchor part. Used
                           to calculate over/under diff. Has the same structure
@@ -1010,6 +1029,546 @@ channels:
                       anchorPartId: null
             examples:
               - payload: *a30
+  resolvedPlaylist:
+    description: Topic for resolved playlist updates
+    subscribe:
+      operationId: receiveResolvedPlaylist
+      description: Server sends resolved playlist events
+      message:
+        oneOf:
+          - name: resolvedPlaylist
+            messageId: resolvedPlaylistUpdate
+            description: Resolved Playlist status
+            payload:
+              title: ResolvedPlaylistEvent
+              description: Resolved playlist details, including the base playlist status.
+              allOf:
+                - *a31
+                - type: object
+                  title: ResolvedPlaylistEvent
+                  description: Resolved playlist details, including rundown/segment/part/piece
+                    structure.
+                  properties:
+                    event:
+                      type: string
+                      const: resolvedPlaylist
+                    currentPartInstanceId:
+                      description: Instance id of the current part, if any
+                      oneOf:
+                        - type: string
+                        - type: "null"
+                    nextPartInstanceId:
+                      description: Instance id of the next part, if any
+                      oneOf:
+                        - type: string
+                        - type: "null"
+                    playoutState:
+                      description: Blueprint-defined playout state, used to expose arbitrary
+                        information about playout
+                    publicData:
+                      description: Optional arbitrary data
+                    timing:
+                      type: object
+                      title: ResolvedPlaylistTiming
+                      description: Timing information about the playlist, expressed as relative
+                        offsets (not wall-clock time)
+                      properties:
+                        type:
+                          title: ResolvedPlaylistTimingType
+                          type: string
+                          description: Whether timing counts forward from a start time or back from an end
+                            time
+                          enum:
+                            - forward
+                            - back
+                        startMs:
+                          description: Optional start offset of the playlist (ms). When present, this is
+                            typically 0.
+                          oneOf:
+                            - type: number
+                            - type: "null"
+                        durationMs:
+                          description: Expected duration of the playlist (ms)
+                          oneOf:
+                            - type: number
+                            - type: "null"
+                        endMs:
+                          description: Optional end offset of the playlist (ms) from the beginning of the
+                            playlist
+                          oneOf:
+                            - type: number
+                            - type: "null"
+                      required:
+                        - type
+                        - startMs
+                        - durationMs
+                        - endMs
+                      additionalProperties: false
+                      examples:
+                        - &a45
+                          type: forward
+                          startMs: 1706371800000
+                          durationMs: 1800000
+                          endMs: 1706373600000
+                    tTimers:
+                      description: Status of the 3 T-timers in the playlist
+                      type: array
+                      items: *a32
+                      minItems: 3
+                      maxItems: 3
+                    quickLoop:
+                      description: Information about the current quickLoop, if any
+                      oneOf:
+                        - type: "null"
+                        - *a33
+                    rundowns:
+                      description: The rundowns in the playlist, in rank order
+                      type: array
+                      items:
+                        type: object
+                        title: ResolvedRundown
+                        description: A rundown within a resolved playlist
+                        properties:
+                          id:
+                            type: string
+                            description: Unique id of the rundown
+                          externalId:
+                            type: string
+                            description: Id normally sourced from the ingest system
+                          name:
+                            type: string
+                            description: User-presentable name of the rundown
+                          rank:
+                            type: number
+                            description: Rank for ordering
+                          description:
+                            type: string
+                            description: Optional description
+                          publicData:
+                            description: Optional arbitrary data
+                          segments:
+                            description: Segments in this rundown
+                            type: array
+                            items:
+                              title: ResolvedSegment
+                              description: A segment within a resolved rundown
+                              allOf:
+                                - *a34
+                                - type: object
+                                  title: ResolvedSegment
+                                  description: A segment within a resolved rundown
+                                  properties:
+                                    externalId:
+                                      type: string
+                                      description: Id normally sourced from the ingest system
+                                    identifier:
+                                      type: string
+                                      description: User-facing identifier from the source system
+                                    name:
+                                      type: string
+                                      description: Name of the segment
+                                    rank:
+                                      type: number
+                                      description: Rank for ordering
+                                    isHidden:
+                                      type: boolean
+                                      description: Whether the segment is hidden
+                                    sourceLayers:
+                                      description: Source layers used in this segment
+                                      type: array
+                                      items:
+                                        type: object
+                                        title: SourceLayer
+                                        description: Definition of a source layer used in a segment
+                                        properties:
+                                          id:
+                                            type: string
+                                            description: Unique id of the source layer
+                                          name:
+                                            type: string
+                                            description: User-presentable name of the source layer
+                                          abbreviation:
+                                            type: string
+                                            description: Abbreviation for display
+                                          isHidden:
+                                            type: boolean
+                                            description: Whether the source layer is hidden in the UI
+                                          type:
+                                            type: number
+                                            description: Source layer content type (numeric enum)
+                                          rank:
+                                            type: number
+                                            description: Rank for ordering
+                                        required:
+                                          - id
+                                          - name
+                                          - abbreviation
+                                          - isHidden
+                                          - type
+                                          - rank
+                                        additionalProperties: false
+                                        examples:
+                                          - &a40
+                                            id: sl_camera
+                                            name: Camera
+                                            abbreviation: CAM
+                                            isHidden: false
+                                            type: 1
+                                            rank: 0
+                                    outputLayers:
+                                      description: Output layers used in this segment
+                                      type: array
+                                      items:
+                                        type: object
+                                        title: OutputLayer
+                                        description: Definition of an output layer used in a segment
+                                        properties:
+                                          id:
+                                            type: string
+                                            description: Unique id of the output layer
+                                          name:
+                                            type: string
+                                            description: User-presentable name of the output layer
+                                          isFlattened:
+                                            type: boolean
+                                            description: Whether the output layer is flattened
+                                          isPGM:
+                                            type: boolean
+                                            description: Whether PGM treatment should be in effect
+                                          type:
+                                            type: number
+                                            description: Output layer type (numeric enum)
+                                          sourceLayerIds:
+                                            description: The set of sourceLayer ids that feed this output layer
+                                            type: array
+                                            items:
+                                              type: string
+                                        required:
+                                          - id
+                                          - name
+                                          - isFlattened
+                                          - isPGM
+                                          - type
+                                          - sourceLayerIds
+                                        additionalProperties: false
+                                        examples:
+                                          - &a41
+                                            id: ol_pgm
+                                            name: PGM
+                                            isFlattened: false
+                                            isPGM: true
+                                            type: 0
+                                            sourceLayerIds:
+                                              - sl_camera
+                                    publicData:
+                                      description: Optional arbitrary data
+                                    timing:
+                                      type: object
+                                      title: ResolvedSegmentTiming
+                                      description: Timing information about the segment, relative to the start of the
+                                        segment
+                                      properties:
+                                        startMs:
+                                          description: Start offset of the segment (ms). For segments, this is typically
+                                            0.
+                                          type: number
+                                        endMs:
+                                          description: End offset of the segment (ms) from the beginning of the segment
+                                          type: number
+                                        budgetDurationMs:
+                                          description: Planned/budget duration for the segment (ms)
+                                          type: number
+                                      required:
+                                        - startMs
+                                        - endMs
+                                        - budgetDurationMs
+                                      additionalProperties: false
+                                      examples:
+                                        - &a42
+                                          startMs: 0
+                                          endMs: 120000
+                                          budgetDurationMs: 120000
+                                    parts:
+                                      description: Parts in this segment
+                                      type: array
+                                      items:
+                                        title: ResolvedPart
+                                        description: A part within a resolved segment
+                                        allOf:
+                                          - *a17
+                                          - type: object
+                                            title: ResolvedPart
+                                            description: A part within a resolved segment
+                                            properties:
+                                              instanceId:
+                                                type: string
+                                                description: Unique id of the part instance
+                                              externalId:
+                                                type: string
+                                                description: Id normally sourced from the ingest system
+                                              rank:
+                                                type: number
+                                                description: Rank for ordering
+                                              state:
+                                                description: Set only for the current or next part
+                                                title: ResolvedPartState
+                                                type: string
+                                                enum:
+                                                  - current
+                                                  - next
+                                              publicData:
+                                                description: Optional arbitrary data
+                                              timing:
+                                                type: object
+                                                title: ResolvedPartTiming
+                                                description: Timing information about the part, relative to the start of the
+                                                  segment
+                                                properties:
+                                                  startMs:
+                                                    description: Start offset of the part (ms) from the beginning of the segment
+                                                    type: number
+                                                  durationMs:
+                                                    description: Resolved duration of the part (ms)
+                                                    type: number
+                                                  plannedStartedPlayback:
+                                                    description: Unix timestamp (ms) when the part was planned to start playback
+                                                    type: number
+                                                  reportedStartedPlayback:
+                                                    description: Unix timestamp (ms) when the part was reported as started playback
+                                                    type: number
+                                                  playOffset:
+                                                    description: Playback offset relative to planned start (ms)
+                                                    type: number
+                                                  setAsNext:
+                                                    description: Unix timestamp (ms) when the part was set as next
+                                                    type: number
+                                                  take:
+                                                    description: Unix timestamp (ms) when the part was taken
+                                                    type: number
+                                                required:
+                                                  - startMs
+                                                  - durationMs
+                                                additionalProperties: false
+                                                examples:
+                                                  - &a38
+                                                    startMs: 0
+                                                    durationMs: 15000
+                                                    plannedStartedPlayback: 1706371805000
+                                                    reportedStartedPlayback: 1706371806000
+                                                    playOffset: 1000
+                                                    setAsNext: 1706371804000
+                                                    take: 1706371806000
+                                              pieces:
+                                                description: Pieces in this part
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  title: ResolvedPiece
+                                                  description: A piece within a resolved part
+                                                  properties:
+                                                    id:
+                                                      type: string
+                                                      description: Unique id of the piece
+                                                    instanceId:
+                                                      type: string
+                                                      description: Unique id of the piece instance
+                                                    externalId:
+                                                      type: string
+                                                      description: Id normally sourced from the ingest system
+                                                    name:
+                                                      type: string
+                                                      description: User-facing name of the piece
+                                                    priority:
+                                                      type: number
+                                                      description: Priority of the piece
+                                                    sourceLayerId:
+                                                      type: string
+                                                      description: Id of the source layer for this piece
+                                                    outputLayerId:
+                                                      type: string
+                                                      description: Id of the output layer for this piece
+                                                    publicData:
+                                                      description: Optional arbitrary data
+                                                    timing:
+                                                      type: object
+                                                      title: ResolvedPieceTiming
+                                                      description: Timing information about the piece, relative to the start of the
+                                                        part
+                                                      properties:
+                                                        startMs:
+                                                          description: Start offset of the piece (ms) from the beginning of the part
+                                                          type: number
+                                                        durationMs:
+                                                          description: Resolved duration of the piece (ms)
+                                                          type: number
+                                                        prerollMs:
+                                                          description: Preroll duration for the piece (ms)
+                                                          type: number
+                                                      required:
+                                                        - startMs
+                                                        - durationMs
+                                                        - prerollMs
+                                                      additionalProperties: false
+                                                      examples:
+                                                        - &a36
+                                                          startMs: 6500
+                                                          durationMs: 5000
+                                                          prerollMs: 250
+                                                    tags:
+                                                      description: Optional tags attached to this piece
+                                                      type: array
+                                                      items:
+                                                        type: string
+                                                    abSessions:
+                                                      description: Optional AB playback session assignments for this piece
+                                                      type: array
+                                                      items: *a35
+                                                  required:
+                                                    - id
+                                                    - instanceId
+                                                    - externalId
+                                                    - name
+                                                    - priority
+                                                    - sourceLayerId
+                                                    - outputLayerId
+                                                    - timing
+                                                  additionalProperties: false
+                                                  examples:
+                                                    - &a39
+                                                      id: piece_1
+                                                      instanceId: pieceInstance_1
+                                                      externalId: ext_piece_1
+                                                      name: Camera 1
+                                                      priority: 0
+                                                      sourceLayerId: sl_camera
+                                                      outputLayerId: ol_pgm
+                                                      publicData:
+                                                        switcherSource: 1
+                                                      timing: *a36
+                                                      tags:
+                                                        - camera
+                                                      abSessions:
+                                                        - *a37
+                                            required:
+                                              - instanceId
+                                              - externalId
+                                              - rank
+                                              - timing
+                                              - pieces
+                                        examples:
+                                          - &a43
+                                            instanceId: partInstance_current_1
+                                            externalId: ext_part_1
+                                            rank: 10
+                                            state: current
+                                            publicData:
+                                              partType: intro
+                                            timing: *a38
+                                            pieces:
+                                              - *a39
+                                            id: H5CBGYjThrMSmaYvRaa5FVKJIzk_
+                                            name: Intro
+                                            autoNext: false
+                                  required:
+                                    - externalId
+                                    - identifier
+                                    - name
+                                    - rank
+                                    - isHidden
+                                    - sourceLayers
+                                    - outputLayers
+                                    - timing
+                                    - parts
+                              examples:
+                                - &a44
+                                  externalId: ext_seg_1
+                                  identifier: A
+                                  name: Headlines
+                                  rank: 1
+                                  isHidden: false
+                                  sourceLayers:
+                                    - *a40
+                                  outputLayers:
+                                    - *a41
+                                  publicData:
+                                    slug: HEAD
+                                  timing: *a42
+                                  parts:
+                                    - *a43
+                                  id: OKAgZmZ0Buc99lE_2uPPSKVbMrQ_
+                        required:
+                          - id
+                          - externalId
+                          - name
+                          - rank
+                          - description
+                          - segments
+                        additionalProperties: false
+                        examples:
+                          - &a49
+                            id: rd_1
+                            externalId: ext_rd_1
+                            name: Rundown 1
+                            rank: 10
+                            description: ""
+                            publicData:
+                              ingestSource: NRK
+                            segments:
+                              - *a44
+                  required:
+                    - event
+                    - currentPartInstanceId
+                    - nextPartInstanceId
+                    - timing
+                    - tTimers
+                    - rundowns
+              examples:
+                - &a50
+                  event: resolvedPlaylist
+                  currentPartInstanceId: partInstance_current_1
+                  nextPartInstanceId: partInstance_next_1
+                  playoutState:
+                    mode: AUTO
+                  publicData:
+                    category: Evening News
+                  timing: *a45
+                  tTimers:
+                    - index: 1
+                      label: Segment Timer
+                      configured: true
+                      mode: *a46
+                      state: *a47
+                      projected:
+                        paused: false
+                        zeroTime: 1706371925000
+                        pauseTime: null
+                      anchorPartId: part_break_1
+                    - index: 2
+                      label: Show Timer
+                      configured: true
+                      mode: *a48
+                      state:
+                        paused: false
+                        zeroTime: 1706371800000
+                        pauseTime: null
+                      projected: null
+                      anchorPartId: null
+                    - index: 3
+                      label: ""
+                      configured: false
+                      mode: null
+                      state: null
+                      projected: null
+                      anchorPartId: null
+                  quickLoop: *a29
+                  rundowns:
+                    - *a49
+                  id: OKAgZmZ0Buc99lE_2uPPSKVbMrQ_
+                  externalId: 1ZIYVYL1aEkNEJbeGsmRXr5s8wtkyxfPRjNSTxZfcoEI
+                  name: Playlist 0
+                  activationStatus: rehearsal
+            examples:
+              - payload: *a50
   activePieces:
     description: Topic for active pieces updates
     subscribe:
@@ -1034,20 +1593,20 @@ channels:
                 activePieces:
                   description: Pieces that are currently active (on air)
                   type: array
-                  items: *a31
+                  items: *a51
               required:
                 - event
                 - rundownPlaylistId
                 - activePieces
               additionalProperties: false
               examples:
-                - &a32
+                - &a52
                   event: activePieces
                   rundownPlaylistId: OKAgZmZ0Buc99lE_2uPPSKVbMrQ_
                   activePieces:
                     - *a13
             examples:
-              - payload: *a32
+              - payload: *a52
   segments:
     description: Topic for Segment updates
     subscribe:
@@ -1076,7 +1635,7 @@ channels:
                 type: object
                 title: Segment
                 allOf:
-                  - *a33
+                  - *a34
                   - type: object
                     title: Segment
                     properties:
@@ -1090,7 +1649,7 @@ channels:
                       name:
                         description: Name of the segment
                         type: string
-                      timing: *a34
+                      timing: *a53
                       publicData:
                         description: Optional arbitrary data
                     required:
@@ -1103,7 +1662,7 @@ channels:
                   - name
                   - timing
                 examples:
-                  - &a35
+                  - &a54
                     identifier: Segment 0 identifier
                     rundownId: y9HauyWkcxQS3XaAOsW40BRLLsI_
                     name: Segment 0
@@ -1119,13 +1678,13 @@ channels:
             - rundownPlaylistId
             - segments
           examples:
-            - &a36
+            - &a55
               event: segments
               rundownPlaylistId: OKAgZmZ0Buc99lE_2uPPSKVbMrQ_
               segments:
-                - *a35
+                - *a54
         examples:
-          - payload: *a36
+          - payload: *a55
   adLibs:
     description: Topic for AdLibs updates
     subscribe:
@@ -1155,7 +1714,7 @@ channels:
                   items:
                     title: AdLibStatus
                     allOf:
-                      - &a41
+                      - &a60
                         title: AdLibBase
                         type: object
                         properties:
@@ -1190,7 +1749,7 @@ channels:
                                 - label
                               additionalProperties: false
                               examples:
-                                - &a37
+                                - &a56
                                   name: pvw
                                   label: Preview
                           tags:
@@ -1210,15 +1769,15 @@ channels:
                           - sourceLayer
                           - actionType
                         examples:
-                          - &a42
+                          - &a61
                             id: C6K_yIMuGFUk8X_L9A9_jRT6aq4_
                             name: Music video clip
                             sourceLayer: Video Clip
-                            actionType: &a38
-                              - *a37
-                            tags: &a39
+                            actionType: &a57
+                              - *a56
+                            tags: &a58
                               - music_video
-                            publicData: &a40
+                            publicData: &a59
                               fileName: MV000123.mxf
                             optionsSchema: '{"$schema":"https://json-schema.org/draft/2020-12/schema","title":"Play
                               Video
@@ -1250,15 +1809,15 @@ channels:
                           - segmentId
                           - partId
                     examples:
-                      - &a43
+                      - &a62
                         segmentId: HsD8_QwE1ZmR5vN3XcK_Ab7y
                         partId: JkL3_OpR6WxT1bF8Vq2_Zy9u
                         id: C6K_yIMuGFUk8X_L9A9_jRT6aq4_
                         name: Music video clip
                         sourceLayer: Video Clip
-                        actionType: *a38
-                        tags: *a39
-                        publicData: *a40
+                        actionType: *a57
+                        tags: *a58
+                        publicData: *a59
                         optionsSchema: '{"$schema":"https://json-schema.org/draft/2020-12/schema","title":"Play
                           Video
                           Clip","type":"object","properties":{"type":"adlib_action_video_clip","label":{"type":"string"},"clipId":{"type":"string"},"vo":{"type":"boolean"},"target":{"$schema":"https://json-schema.org/draft/2020-12/schema","title":"Object
@@ -1282,9 +1841,9 @@ channels:
                   items:
                     title: GlobalAdLibStatus
                     allOf:
-                      - *a41
+                      - *a60
                     examples:
-                      - *a42
+                      - *a61
               required:
                 - event
                 - rundownPlaylistId
@@ -1292,15 +1851,15 @@ channels:
                 - globalAdLibs
               additionalProperties: false
               examples:
-                - &a44
+                - &a63
                   event: adLibs
                   rundownPlaylistId: OKAgZmZ0Buc99lE_2uPPSKVbMrQ_
                   adLibs:
-                    - *a43
+                    - *a62
                   globalAdLibs:
-                    - *a42
+                    - *a61
             examples:
-              - payload: *a44
+              - payload: *a63
   packages:
     description: Packages topic for websocket subscriptions. Packages are assets
       that need to be prepared by Sofie Package Manager or third-party systems
@@ -1408,7 +1967,7 @@ channels:
                       - pieceOrAdLibId
                     additionalProperties: false
                     examples:
-                      - &a45
+                      - &a64
                         packageName: MV000123.mxf
                         status: ok
                         rundownId: y9HauyWkcxQS3XaAOsW40BRLLsI_
@@ -1426,7 +1985,7 @@ channels:
                 - event: packages
                   rundownPlaylistId: y9HauyWkcxQS3XaAOsW40BRLLsI_
                   packages:
-                    - *a45
+                    - *a64
   buckets:
     description: Buckets schema for websocket subscriptions
     subscribe:
@@ -1462,7 +2021,7 @@ channels:
                         items:
                           title: BucketAdLibStatus
                           allOf:
-                            - *a41
+                            - *a60
                             - type: object
                               title: BucketAdLibStatus
                               properties:
@@ -1473,14 +2032,14 @@ channels:
                               required:
                                 - externalId
                           examples:
-                            - &a46
+                            - &a65
                               externalId: C6K_yIMuGFUk8X_L9A9_jRT6aq4_
                               id: C6K_yIMuGFUk8X_L9A9_jRT6aq4_
                               name: Music video clip
                               sourceLayer: Video Clip
-                              actionType: *a38
-                              tags: *a39
-                              publicData: *a40
+                              actionType: *a57
+                              tags: *a58
+                              publicData: *a59
                               optionsSchema: '{"$schema":"https://json-schema.org/draft/2020-12/schema","title":"Play
                                 Video
                                 Clip","type":"object","properties":{"type":"adlib_action_video_clip","label":{"type":"string"},"clipId":{"type":"string"},"vo":{"type":"boolean"},"target":{"$schema":"https://json-schema.org/draft/2020-12/schema","title":"Object
@@ -1504,22 +2063,22 @@ channels:
                       - adLibs
                     additionalProperties: false
                     examples:
-                      - &a47
+                      - &a66
                         id: C6K_yIMuGFUk8X_L9A9_jRT6aq4_
                         name: My Bucket
                         adLibs:
-                          - *a46
+                          - *a65
               required:
                 - event
                 - buckets
               additionalProperties: false
               examples:
-                - &a48
+                - &a67
                   event: buckets
                   buckets:
-                    - *a47
+                    - *a66
             examples:
-              - payload: *a48
+              - payload: *a67
   notifications:
     description: Notifications topic for websocket subscriptions.
     subscribe:
@@ -1583,7 +2142,7 @@ channels:
                                 type: string
                                 title: NotificationTargetType
                                 description: Possible NotificationTarget types
-                                enum: &a49
+                                enum: &a68
                                   - rundown
                                   - playlist
                                   - partInstance
@@ -1595,7 +2154,7 @@ channels:
                                 type: string
                             additionalProperties: false
                             examples:
-                              - &a50
+                              - &a69
                                 type: rundown
                                 studioId: studio01
                                 rundownId: rd123
@@ -1611,14 +2170,14 @@ channels:
                                 type: string
                                 title: NotificationTargetType
                                 description: Possible NotificationTarget types
-                                enum: *a49
+                                enum: *a68
                               studioId:
                                 type: string
                               playlistId:
                                 type: string
                             additionalProperties: false
                             examples:
-                              - &a51
+                              - &a70
                                 type: playlist
                                 studioId: studio01
                                 playlistId: pl456
@@ -1635,7 +2194,7 @@ channels:
                                 type: string
                                 title: NotificationTargetType
                                 description: Possible NotificationTarget types
-                                enum: *a49
+                                enum: *a68
                               studioId:
                                 type: string
                               rundownId:
@@ -1644,7 +2203,7 @@ channels:
                                 type: string
                             additionalProperties: false
                             examples:
-                              - &a52
+                              - &a71
                                 type: partInstance
                                 studioId: studio01
                                 rundownId: rd123
@@ -1663,7 +2222,7 @@ channels:
                                 type: string
                                 title: NotificationTargetType
                                 description: Possible NotificationTarget types
-                                enum: *a49
+                                enum: *a68
                               studioId:
                                 type: string
                               rundownId:
@@ -1674,7 +2233,7 @@ channels:
                                 type: string
                             additionalProperties: false
                             examples:
-                              - &a53
+                              - &a72
                                 type: pieceInstance
                                 studioId: studio01
                                 rundownId: rd123
@@ -1690,17 +2249,17 @@ channels:
                                 type: string
                                 title: NotificationTargetType
                                 description: Possible NotificationTarget types
-                                enum: *a49
+                                enum: *a68
                             additionalProperties: false
                             examples:
-                              - &a54
+                              - &a73
                                 type: unknown
                         examples:
-                          - *a50
-                          - *a51
-                          - *a52
-                          - *a53
-                          - *a54
+                          - *a69
+                          - *a70
+                          - *a71
+                          - *a72
+                          - *a73
                       created:
                         type: integer
                         format: int64
@@ -1711,11 +2270,11 @@ channels:
                         description: Unix timestamp of last modification
                     additionalProperties: false
                     examples:
-                      - &a55
+                      - &a74
                         _id: notif123
                         severity: error
                         message: disk.space.low
-                        relatedTo: *a53
+                        relatedTo: *a72
                         created: 1694784932
                         modified: 1694784950
               required:
@@ -1723,9 +2282,9 @@ channels:
                 - activeNotifications
               additionalProperties: false
               examples:
-                - &a56
+                - &a75
                   event: notifications
                   activeNotifications:
-                    - *a55
+                    - *a74
             examples:
-              - payload: *a56
+              - payload: *a75

--- a/packages/live-status-gateway-api/src/generated/asyncapi.yaml
+++ b/packages/live-status-gateway-api/src/generated/asyncapi.yaml
@@ -1307,6 +1307,9 @@ channels:
                                               invalid:
                                                 type: boolean
                                                 description: Whether this part is invalid and should not be taken
+                                              floated:
+                                                type: boolean
+                                                description: Whether this part is floated and cannot be taken/nexted
                                               invalidReason:
                                                 description: Optional explanation for why the part is invalid
                                                 title: PartInvalidReason
@@ -1491,12 +1494,14 @@ channels:
                                               - timing
                                               - pieces
                                               - invalid
+                                              - floated
                                         examples:
                                           - &a44
                                             instanceId: partInstance_current_1
                                             externalId: ext_part_1
                                             rank: 10
                                             invalid: false
+                                            floated: false
                                             invalidReason: *a38
                                             state: current
                                             createdByAdLib: false

--- a/packages/live-status-gateway-api/src/generated/asyncapi.yaml
+++ b/packages/live-status-gateway-api/src/generated/asyncapi.yaml
@@ -1461,7 +1461,6 @@ channels:
                                                       items: *a35
                                                   required:
                                                     - id
-                                                    - instanceId
                                                     - externalId
                                                     - name
                                                     - priority

--- a/packages/live-status-gateway-api/src/generated/asyncapi.yaml
+++ b/packages/live-status-gateway-api/src/generated/asyncapi.yaml
@@ -1550,7 +1550,6 @@ channels:
                           - externalId
                           - name
                           - rank
-                          - description
                           - segments
                         additionalProperties: false
                         examples:

--- a/packages/live-status-gateway-api/src/generated/asyncapi.yaml
+++ b/packages/live-status-gateway-api/src/generated/asyncapi.yaml
@@ -1368,10 +1368,14 @@ channels:
                                                     description: Unix timestamp (ms) when the part was planned to start playback
                                                     type: number
                                                   reportedStartedPlayback:
-                                                    description: Unix timestamp (ms) when the part was reported as started playback
+                                                    description: Unix timestamp (ms) when the part was reported when it actually
+                                                      started playback
                                                     type: number
-                                                  playOffset:
-                                                    description: Playback offset relative to planned start (ms)
+                                                  playOffsetMs:
+                                                    description: Milliseconds into the part where playback started when taken (eg
+                                                      via “Play/Set Next from
+                                                      Here”; 0 = from the
+                                                      beginning)
                                                     type: number
                                                   setAsNext:
                                                     description: Unix timestamp (ms) when the part was set as next
@@ -1389,7 +1393,7 @@ channels:
                                                     durationMs: 15000
                                                     plannedStartedPlayback: 1706371805000
                                                     reportedStartedPlayback: 1706371806000
-                                                    playOffset: 1000
+                                                    playOffsetMs: 1000
                                                     setAsNext: 1706371804000
                                                     take: 1706371806000
                                               pieces:

--- a/packages/live-status-gateway-api/src/generated/asyncapi.yaml
+++ b/packages/live-status-gateway-api/src/generated/asyncapi.yaml
@@ -401,7 +401,7 @@ channels:
                                 pieces:
                                   description: All pieces in this part
                                   type: array
-                                  items: &a51
+                                  items: &a52
                                     type: object
                                     title: PieceStatus
                                     properties:
@@ -557,7 +557,7 @@ channels:
                               title: CurrentSegmentTiming
                               description: Timing information about the current segment
                               allOf:
-                                - &a53
+                                - &a54
                                   type: object
                                   title: SegmentTiming
                                   properties:
@@ -833,11 +833,11 @@ channels:
                                     targetRaw: 14:30
                                     stopAtZero: false
                             examples:
-                              - &a46
+                              - &a47
                                 type: countdown
                                 duration: 120000
                                 stopAtZero: true
-                              - &a48
+                              - &a49
                                 type: freeRun
                               - type: timeOfDay
                                 targetRaw: 14:30
@@ -911,7 +911,7 @@ channels:
                                     duration: 45000
                                     pauseTime: null
                             examples:
-                              - &a47
+                              - &a48
                                 paused: false
                                 zeroTime: 1706371920000
                                 pauseTime: 1706371900000
@@ -1105,7 +1105,7 @@ channels:
                         - endMs
                       additionalProperties: false
                       examples:
-                        - &a45
+                        - &a46
                           type: forward
                           startMs: 1706371800000
                           durationMs: 1800000
@@ -1208,7 +1208,7 @@ channels:
                                           - rank
                                         additionalProperties: false
                                         examples:
-                                          - &a40
+                                          - &a41
                                             id: sl_camera
                                             name: Camera
                                             abbreviation: CAM
@@ -1248,7 +1248,7 @@ channels:
                                           - sourceLayerIds
                                         additionalProperties: false
                                         examples:
-                                          - &a41
+                                          - &a42
                                             id: ol_pgm
                                             name: PGM
                                             isFlattened: false
@@ -1279,7 +1279,7 @@ channels:
                                         - budgetDurationMs
                                       additionalProperties: false
                                       examples:
-                                        - &a42
+                                        - &a43
                                           startMs: 0
                                           endMs: 120000
                                           budgetDurationMs: 120000
@@ -1304,6 +1304,36 @@ channels:
                                               rank:
                                                 type: number
                                                 description: Rank for ordering
+                                              invalid:
+                                                type: boolean
+                                                description: Whether this part is invalid and should not be taken
+                                              invalidReason:
+                                                description: Optional explanation for why the part is invalid
+                                                title: PartInvalidReason
+                                                type: object
+                                                properties:
+                                                  message:
+                                                    type: string
+                                                    description: Human-readable message explaining why the part is invalid
+                                                  severity:
+                                                    description: Severity hint for displaying the invalid reason
+                                                    type: string
+                                                    title: NotificationSeverity
+                                                    enum: &a69
+                                                      - warning
+                                                      - error
+                                                      - info
+                                                  color:
+                                                    description: Optional UI color hint
+                                                    type: string
+                                                required:
+                                                  - message
+                                                additionalProperties: false
+                                                examples:
+                                                  - &a38
+                                                    message: Invalid clip reference
+                                                    severity: warning
+                                                    color: "#ff0000"
                                               state:
                                                 description: Set only for the current or next part
                                                 title: ResolvedPartState
@@ -1348,7 +1378,7 @@ channels:
                                                   - durationMs
                                                 additionalProperties: false
                                                 examples:
-                                                  - &a38
+                                                  - &a39
                                                     startMs: 0
                                                     durationMs: 15000
                                                     plannedStartedPlayback: 1706371805000
@@ -1432,7 +1462,7 @@ channels:
                                                     - timing
                                                   additionalProperties: false
                                                   examples:
-                                                    - &a39
+                                                    - &a40
                                                       id: piece_1
                                                       instanceId: pieceInstance_1
                                                       externalId: ext_piece_1
@@ -1455,18 +1485,21 @@ channels:
                                               - createdByAdLib
                                               - timing
                                               - pieces
+                                              - invalid
                                         examples:
-                                          - &a43
+                                          - &a44
                                             instanceId: partInstance_current_1
                                             externalId: ext_part_1
                                             rank: 10
+                                            invalid: false
+                                            invalidReason: *a38
                                             state: current
                                             createdByAdLib: false
                                             publicData:
                                               partType: intro
-                                            timing: *a38
+                                            timing: *a39
                                             pieces:
-                                              - *a39
+                                              - *a40
                                             id: H5CBGYjThrMSmaYvRaa5FVKJIzk_
                                             name: Intro
                                             autoNext: false
@@ -1481,21 +1514,21 @@ channels:
                                     - timing
                                     - parts
                               examples:
-                                - &a44
+                                - &a45
                                   externalId: ext_seg_1
                                   identifier: A
                                   name: Headlines
                                   rank: 1
                                   isHidden: false
                                   sourceLayers:
-                                    - *a40
-                                  outputLayers:
                                     - *a41
+                                  outputLayers:
+                                    - *a42
                                   publicData:
                                     slug: HEAD
-                                  timing: *a42
+                                  timing: *a43
                                   parts:
-                                    - *a43
+                                    - *a44
                                   id: OKAgZmZ0Buc99lE_2uPPSKVbMrQ_
                         required:
                           - id
@@ -1506,7 +1539,7 @@ channels:
                           - segments
                         additionalProperties: false
                         examples:
-                          - &a49
+                          - &a50
                             id: rd_1
                             externalId: ext_rd_1
                             name: Rundown 1
@@ -1515,7 +1548,7 @@ channels:
                             publicData:
                               ingestSource: NRK
                             segments:
-                              - *a44
+                              - *a45
                   required:
                     - event
                     - currentPartInstanceId
@@ -1524,7 +1557,7 @@ channels:
                     - tTimers
                     - rundowns
               examples:
-                - &a50
+                - &a51
                   event: resolvedPlaylist
                   currentPartInstanceId: partInstance_current_1
                   nextPartInstanceId: partInstance_next_1
@@ -1532,13 +1565,13 @@ channels:
                     mode: AUTO
                   publicData:
                     category: Evening News
-                  timing: *a45
+                  timing: *a46
                   tTimers:
                     - index: 1
                       label: Segment Timer
                       configured: true
-                      mode: *a46
-                      state: *a47
+                      mode: *a47
+                      state: *a48
                       projected:
                         paused: false
                         zeroTime: 1706371925000
@@ -1547,7 +1580,7 @@ channels:
                     - index: 2
                       label: Show Timer
                       configured: true
-                      mode: *a48
+                      mode: *a49
                       state:
                         paused: false
                         zeroTime: 1706371800000
@@ -1563,13 +1596,13 @@ channels:
                       anchorPartId: null
                   quickLoop: *a29
                   rundowns:
-                    - *a49
+                    - *a50
                   id: OKAgZmZ0Buc99lE_2uPPSKVbMrQ_
                   externalId: 1ZIYVYL1aEkNEJbeGsmRXr5s8wtkyxfPRjNSTxZfcoEI
                   name: Playlist 0
                   activationStatus: rehearsal
             examples:
-              - payload: *a50
+              - payload: *a51
   activePieces:
     description: Topic for active pieces updates
     subscribe:
@@ -1594,20 +1627,20 @@ channels:
                 activePieces:
                   description: Pieces that are currently active (on air)
                   type: array
-                  items: *a51
+                  items: *a52
               required:
                 - event
                 - rundownPlaylistId
                 - activePieces
               additionalProperties: false
               examples:
-                - &a52
+                - &a53
                   event: activePieces
                   rundownPlaylistId: OKAgZmZ0Buc99lE_2uPPSKVbMrQ_
                   activePieces:
                     - *a13
             examples:
-              - payload: *a52
+              - payload: *a53
   segments:
     description: Topic for Segment updates
     subscribe:
@@ -1650,7 +1683,7 @@ channels:
                       name:
                         description: Name of the segment
                         type: string
-                      timing: *a53
+                      timing: *a54
                       publicData:
                         description: Optional arbitrary data
                     required:
@@ -1663,7 +1696,7 @@ channels:
                   - name
                   - timing
                 examples:
-                  - &a54
+                  - &a55
                     identifier: Segment 0 identifier
                     rundownId: y9HauyWkcxQS3XaAOsW40BRLLsI_
                     name: Segment 0
@@ -1679,13 +1712,13 @@ channels:
             - rundownPlaylistId
             - segments
           examples:
-            - &a55
+            - &a56
               event: segments
               rundownPlaylistId: OKAgZmZ0Buc99lE_2uPPSKVbMrQ_
               segments:
-                - *a54
+                - *a55
         examples:
-          - payload: *a55
+          - payload: *a56
   adLibs:
     description: Topic for AdLibs updates
     subscribe:
@@ -1715,7 +1748,7 @@ channels:
                   items:
                     title: AdLibStatus
                     allOf:
-                      - &a60
+                      - &a61
                         title: AdLibBase
                         type: object
                         properties:
@@ -1750,7 +1783,7 @@ channels:
                                 - label
                               additionalProperties: false
                               examples:
-                                - &a56
+                                - &a57
                                   name: pvw
                                   label: Preview
                           tags:
@@ -1770,15 +1803,15 @@ channels:
                           - sourceLayer
                           - actionType
                         examples:
-                          - &a61
+                          - &a62
                             id: C6K_yIMuGFUk8X_L9A9_jRT6aq4_
                             name: Music video clip
                             sourceLayer: Video Clip
-                            actionType: &a57
-                              - *a56
-                            tags: &a58
+                            actionType: &a58
+                              - *a57
+                            tags: &a59
                               - music_video
-                            publicData: &a59
+                            publicData: &a60
                               fileName: MV000123.mxf
                             optionsSchema: '{"$schema":"https://json-schema.org/draft/2020-12/schema","title":"Play
                               Video
@@ -1810,15 +1843,15 @@ channels:
                           - segmentId
                           - partId
                     examples:
-                      - &a62
+                      - &a63
                         segmentId: HsD8_QwE1ZmR5vN3XcK_Ab7y
                         partId: JkL3_OpR6WxT1bF8Vq2_Zy9u
                         id: C6K_yIMuGFUk8X_L9A9_jRT6aq4_
                         name: Music video clip
                         sourceLayer: Video Clip
-                        actionType: *a57
-                        tags: *a58
-                        publicData: *a59
+                        actionType: *a58
+                        tags: *a59
+                        publicData: *a60
                         optionsSchema: '{"$schema":"https://json-schema.org/draft/2020-12/schema","title":"Play
                           Video
                           Clip","type":"object","properties":{"type":"adlib_action_video_clip","label":{"type":"string"},"clipId":{"type":"string"},"vo":{"type":"boolean"},"target":{"$schema":"https://json-schema.org/draft/2020-12/schema","title":"Object
@@ -1842,9 +1875,9 @@ channels:
                   items:
                     title: GlobalAdLibStatus
                     allOf:
-                      - *a60
-                    examples:
                       - *a61
+                    examples:
+                      - *a62
               required:
                 - event
                 - rundownPlaylistId
@@ -1852,15 +1885,15 @@ channels:
                 - globalAdLibs
               additionalProperties: false
               examples:
-                - &a63
+                - &a64
                   event: adLibs
                   rundownPlaylistId: OKAgZmZ0Buc99lE_2uPPSKVbMrQ_
                   adLibs:
-                    - *a62
+                    - *a63
                   globalAdLibs:
-                    - *a61
+                    - *a62
             examples:
-              - payload: *a63
+              - payload: *a64
   packages:
     description: Packages topic for websocket subscriptions. Packages are assets
       that need to be prepared by Sofie Package Manager or third-party systems
@@ -1968,7 +2001,7 @@ channels:
                       - pieceOrAdLibId
                     additionalProperties: false
                     examples:
-                      - &a64
+                      - &a65
                         packageName: MV000123.mxf
                         status: ok
                         rundownId: y9HauyWkcxQS3XaAOsW40BRLLsI_
@@ -1986,7 +2019,7 @@ channels:
                 - event: packages
                   rundownPlaylistId: y9HauyWkcxQS3XaAOsW40BRLLsI_
                   packages:
-                    - *a64
+                    - *a65
   buckets:
     description: Buckets schema for websocket subscriptions
     subscribe:
@@ -2022,7 +2055,7 @@ channels:
                         items:
                           title: BucketAdLibStatus
                           allOf:
-                            - *a60
+                            - *a61
                             - type: object
                               title: BucketAdLibStatus
                               properties:
@@ -2033,14 +2066,14 @@ channels:
                               required:
                                 - externalId
                           examples:
-                            - &a65
+                            - &a66
                               externalId: C6K_yIMuGFUk8X_L9A9_jRT6aq4_
                               id: C6K_yIMuGFUk8X_L9A9_jRT6aq4_
                               name: Music video clip
                               sourceLayer: Video Clip
-                              actionType: *a57
-                              tags: *a58
-                              publicData: *a59
+                              actionType: *a58
+                              tags: *a59
+                              publicData: *a60
                               optionsSchema: '{"$schema":"https://json-schema.org/draft/2020-12/schema","title":"Play
                                 Video
                                 Clip","type":"object","properties":{"type":"adlib_action_video_clip","label":{"type":"string"},"clipId":{"type":"string"},"vo":{"type":"boolean"},"target":{"$schema":"https://json-schema.org/draft/2020-12/schema","title":"Object
@@ -2064,22 +2097,22 @@ channels:
                       - adLibs
                     additionalProperties: false
                     examples:
-                      - &a66
+                      - &a67
                         id: C6K_yIMuGFUk8X_L9A9_jRT6aq4_
                         name: My Bucket
                         adLibs:
-                          - *a65
+                          - *a66
               required:
                 - event
                 - buckets
               additionalProperties: false
               examples:
-                - &a67
+                - &a68
                   event: buckets
                   buckets:
-                    - *a66
+                    - *a67
             examples:
-              - payload: *a67
+              - payload: *a68
   notifications:
     description: Notifications topic for websocket subscriptions.
     subscribe:
@@ -2120,10 +2153,7 @@ channels:
                         type: string
                         title: NotificationSeverity
                         description: Severity level of the notification.
-                        enum:
-                          - warning
-                          - error
-                          - info
+                        enum: *a69
                       message:
                         type: string
                         description: The message of the notification
@@ -2143,7 +2173,7 @@ channels:
                                 type: string
                                 title: NotificationTargetType
                                 description: Possible NotificationTarget types
-                                enum: &a68
+                                enum: &a70
                                   - rundown
                                   - playlist
                                   - partInstance
@@ -2155,7 +2185,7 @@ channels:
                                 type: string
                             additionalProperties: false
                             examples:
-                              - &a69
+                              - &a71
                                 type: rundown
                                 studioId: studio01
                                 rundownId: rd123
@@ -2171,14 +2201,14 @@ channels:
                                 type: string
                                 title: NotificationTargetType
                                 description: Possible NotificationTarget types
-                                enum: *a68
+                                enum: *a70
                               studioId:
                                 type: string
                               playlistId:
                                 type: string
                             additionalProperties: false
                             examples:
-                              - &a70
+                              - &a72
                                 type: playlist
                                 studioId: studio01
                                 playlistId: pl456
@@ -2195,7 +2225,7 @@ channels:
                                 type: string
                                 title: NotificationTargetType
                                 description: Possible NotificationTarget types
-                                enum: *a68
+                                enum: *a70
                               studioId:
                                 type: string
                               rundownId:
@@ -2204,7 +2234,7 @@ channels:
                                 type: string
                             additionalProperties: false
                             examples:
-                              - &a71
+                              - &a73
                                 type: partInstance
                                 studioId: studio01
                                 rundownId: rd123
@@ -2223,7 +2253,7 @@ channels:
                                 type: string
                                 title: NotificationTargetType
                                 description: Possible NotificationTarget types
-                                enum: *a68
+                                enum: *a70
                               studioId:
                                 type: string
                               rundownId:
@@ -2234,7 +2264,7 @@ channels:
                                 type: string
                             additionalProperties: false
                             examples:
-                              - &a72
+                              - &a74
                                 type: pieceInstance
                                 studioId: studio01
                                 rundownId: rd123
@@ -2250,17 +2280,17 @@ channels:
                                 type: string
                                 title: NotificationTargetType
                                 description: Possible NotificationTarget types
-                                enum: *a68
+                                enum: *a70
                             additionalProperties: false
                             examples:
-                              - &a73
+                              - &a75
                                 type: unknown
                         examples:
-                          - *a69
-                          - *a70
                           - *a71
                           - *a72
                           - *a73
+                          - *a74
+                          - *a75
                       created:
                         type: integer
                         format: int64
@@ -2271,11 +2301,11 @@ channels:
                         description: Unix timestamp of last modification
                     additionalProperties: false
                     examples:
-                      - &a74
+                      - &a76
                         _id: notif123
                         severity: error
                         message: disk.space.low
-                        relatedTo: *a72
+                        relatedTo: *a74
                         created: 1694784932
                         modified: 1694784950
               required:
@@ -2283,9 +2313,9 @@ channels:
                 - activeNotifications
               additionalProperties: false
               examples:
-                - &a75
+                - &a77
                   event: notifications
                   activeNotifications:
-                    - *a74
+                    - *a76
             examples:
-              - payload: *a75
+              - payload: *a77

--- a/packages/live-status-gateway-api/src/generated/schema.ts
+++ b/packages/live-status-gateway-api/src/generated/schema.ts
@@ -638,7 +638,7 @@ interface ResolvedPlaylistEvent {
 	 */
 	publicData?: any
 	/**
-	 * Timing information about the playlist, expressed as relative offsets (not wall-clock time)
+	 * Timing information about the playlist using absolute Unix timestamps (ms) and expected duration.
 	 */
 	timing: ResolvedPlaylistTiming
 	/**
@@ -657,29 +657,29 @@ interface ResolvedPlaylistEvent {
 }
 
 /**
- * Timing information about the playlist, expressed as relative offsets (not wall-clock time)
+ * Timing information about the playlist using absolute Unix timestamps (ms) and expected duration.
  */
 interface ResolvedPlaylistTiming {
 	/**
-	 * Whether timing counts forward from a start time or back from an end time
+	 * Whether the playlist is forward-timed from a start time or back-timed from an end time
 	 */
 	type: ResolvedPlaylistTimingType
 	/**
-	 * Optional start offset of the playlist (ms). When present, this is typically 0.
+	 * Unix timestamp (ms) when the playlist actually started playback (first timed part confirmed started). Null until known.
 	 */
-	startMs: number | null
+	startedPlayback: number | null
 	/**
-	 * Expected duration of the playlist (ms)
+	 * Expected duration of the playlist (ms). Null when unknown/unavailable.
 	 */
-	durationMs: number | null
+	expectedDurationMs: number | null
 	/**
-	 * Optional end offset of the playlist (ms) from the beginning of the playlist
+	 * Unix timestamp (ms) when the playlist is expected/projected to end. Null when it cannot be resolved from timing configuration.
 	 */
-	endMs: number | null
+	expectedEnd: number | null
 }
 
 /**
- * Whether timing counts forward from a start time or back from an end time
+ * Whether the playlist is forward-timed from a start time or back-timed from an end time
  */
 enum ResolvedPlaylistTimingType {
 	FORWARD = 'forward',

--- a/packages/live-status-gateway-api/src/generated/schema.ts
+++ b/packages/live-status-gateway-api/src/generated/schema.ts
@@ -874,6 +874,14 @@ interface ResolvedPart {
 	 */
 	rank: number
 	/**
+	 * Whether this part is invalid and should not be taken
+	 */
+	invalid: boolean
+	/**
+	 * Optional explanation for why the part is invalid
+	 */
+	invalidReason?: PartInvalidReason
+	/**
 	 * Set only for the current or next part
 	 */
 	state?: ResolvedPartState
@@ -894,6 +902,33 @@ interface ResolvedPart {
 	 */
 	pieces: ResolvedPiece[]
 	additionalProperties?: Record<string, any>
+}
+
+/**
+ * Optional explanation for why the part is invalid
+ */
+interface PartInvalidReason {
+	/**
+	 * Human-readable message explaining why the part is invalid
+	 */
+	message: string
+	/**
+	 * Severity hint for displaying the invalid reason
+	 */
+	severity?: NotificationSeverity
+	/**
+	 * Optional UI color hint
+	 */
+	color?: string
+}
+
+/**
+ * Severity level of the notification.
+ */
+enum NotificationSeverity {
+	WARNING = 'warning',
+	ERROR = 'error',
+	INFO = 'info',
 }
 
 /**
@@ -1369,15 +1404,6 @@ interface NotificationObj {
 	modified?: number
 }
 
-/**
- * Severity level of the notification.
- */
-enum NotificationSeverity {
-	WARNING = 'warning',
-	ERROR = 'error',
-	INFO = 'info',
-}
-
 interface NotificationTargetRundown {
 	/**
 	 * Possible NotificationTarget types
@@ -1498,6 +1524,8 @@ export {
 	OutputLayer,
 	ResolvedSegmentTiming,
 	ResolvedPart,
+	PartInvalidReason,
+	NotificationSeverity,
 	ResolvedPartState,
 	ResolvedPartTiming,
 	ResolvedPiece,
@@ -1518,7 +1546,6 @@ export {
 	BucketAdLibStatus,
 	NotificationsEvent,
 	NotificationObj,
-	NotificationSeverity,
 	NotificationTargetRundown,
 	NotificationTargetType,
 	NotificationTargetRundownPlaylist,

--- a/packages/live-status-gateway-api/src/generated/schema.ts
+++ b/packages/live-status-gateway-api/src/generated/schema.ts
@@ -882,6 +882,10 @@ interface ResolvedPart {
 	 */
 	floated: boolean
 	/**
+	 * Whether this part is excluded from normal timing calculations
+	 */
+	untimed: boolean
+	/**
 	 * Optional explanation for why the part is invalid
 	 */
 	invalidReason?: PartInvalidReason

--- a/packages/live-status-gateway-api/src/generated/schema.ts
+++ b/packages/live-status-gateway-api/src/generated/schema.ts
@@ -709,7 +709,7 @@ interface ResolvedRundown {
 	/**
 	 * Optional description
 	 */
-	description: string
+	description?: string
 	/**
 	 * Optional arbitrary data
 	 */

--- a/packages/live-status-gateway-api/src/generated/schema.ts
+++ b/packages/live-status-gateway-api/src/generated/schema.ts
@@ -1010,6 +1010,10 @@ interface ResolvedPiece {
 	 */
 	createdByAdLib: boolean
 	/**
+	 * Whether this piece is invalid and should be ignored
+	 */
+	invalid: boolean
+	/**
 	 * Optional arbitrary data
 	 */
 	publicData?: any

--- a/packages/live-status-gateway-api/src/generated/schema.ts
+++ b/packages/live-status-gateway-api/src/generated/schema.ts
@@ -964,13 +964,13 @@ interface ResolvedPartTiming {
 	 */
 	plannedStartedPlayback?: number
 	/**
-	 * Unix timestamp (ms) when the part was reported as started playback
+	 * Unix timestamp (ms) when the part was reported when it actually started playback
 	 */
 	reportedStartedPlayback?: number
 	/**
-	 * Playback offset relative to planned start (ms)
+	 * Milliseconds into the part where playback started when taken (eg via “Play/Set Next from Here”; 0 = from the beginning)
 	 */
-	playOffset?: number
+	playOffsetMs?: number
 	/**
 	 * Unix timestamp (ms) when the part was set as next
 	 */

--- a/packages/live-status-gateway-api/src/generated/schema.ts
+++ b/packages/live-status-gateway-api/src/generated/schema.ts
@@ -822,10 +822,6 @@ interface OutputLayer {
 	 */
 	isPGM: boolean
 	/**
-	 * Output layer type (numeric enum)
-	 */
-	type: number
-	/**
 	 * The set of sourceLayer ids that feed this output layer
 	 */
 	sourceLayerIds: string[]
@@ -881,6 +877,10 @@ interface ResolvedPart {
 	 * Set only for the current or next part
 	 */
 	state?: ResolvedPartState
+	/**
+	 * Whether this part was created by an adlib
+	 */
+	createdByAdLib: boolean
 	/**
 	 * Optional arbitrary data
 	 */
@@ -971,6 +971,10 @@ interface ResolvedPiece {
 	 */
 	outputLayerId: string
 	/**
+	 * Whether this piece was created by an adlib
+	 */
+	createdByAdLib: boolean
+	/**
 	 * Optional arbitrary data
 	 */
 	publicData?: any
@@ -995,15 +999,15 @@ interface ResolvedPieceTiming {
 	/**
 	 * Start offset of the piece (ms) from the beginning of the part
 	 */
-	startMs: number
+	startMs?: number
 	/**
 	 * Resolved duration of the piece (ms)
 	 */
-	durationMs: number
+	durationMs?: number
 	/**
 	 * Preroll duration for the piece (ms)
 	 */
-	prerollMs: number
+	prerollMs?: number
 }
 
 interface ActivePiecesEvent {

--- a/packages/live-status-gateway-api/src/generated/schema.ts
+++ b/packages/live-status-gateway-api/src/generated/schema.ts
@@ -992,7 +992,7 @@ interface ResolvedPiece {
 	/**
 	 * Unique id of the piece instance
 	 */
-	instanceId: string
+	instanceId?: string
 	/**
 	 * Id normally sourced from the ingest system
 	 */

--- a/packages/live-status-gateway-api/src/generated/schema.ts
+++ b/packages/live-status-gateway-api/src/generated/schema.ts
@@ -878,6 +878,10 @@ interface ResolvedPart {
 	 */
 	invalid: boolean
 	/**
+	 * Whether this part is floated and cannot be taken/nexted
+	 */
+	floated: boolean
+	/**
 	 * Optional explanation for why the part is invalid
 	 */
 	invalidReason?: PartInvalidReason

--- a/packages/live-status-gateway-api/src/generated/schema.ts
+++ b/packages/live-status-gateway-api/src/generated/schema.ts
@@ -60,6 +60,7 @@ interface SubscriptionRequestDetails {
 enum SubscriptionName {
 	STUDIO = 'studio',
 	ACTIVE_PLAYLIST = 'activePlaylist',
+	RESOLVED_PLAYLIST = 'resolvedPlaylist',
 	ACTIVE_PIECES = 'activePieces',
 	SEGMENTS = 'segments',
 	AD_LIBS = 'adLibs',
@@ -142,6 +143,7 @@ interface PlaylistStatus {
 	 * Whether this playlist is currently active or in rehearsal
 	 */
 	activationStatus: PlaylistActivationStatus
+	additionalProperties?: Record<string, any>
 }
 
 /**
@@ -598,6 +600,412 @@ interface TimerStatePaused {
 	pauseTime?: number | null
 }
 
+/**
+ * Resolved playlist details, including the base playlist status.
+ */
+interface ResolvedPlaylistEvent {
+	/**
+	 * Unique id of the playlist
+	 */
+	id: string
+	/**
+	 * Id normally sourced from the ingest system
+	 */
+	externalId: string
+	/**
+	 * The user defined playlist name
+	 */
+	name: string
+	/**
+	 * Whether this playlist is currently active or in rehearsal
+	 */
+	activationStatus: PlaylistActivationStatus
+	event: 'resolvedPlaylist'
+	/**
+	 * Instance id of the current part, if any
+	 */
+	currentPartInstanceId: string | null
+	/**
+	 * Instance id of the next part, if any
+	 */
+	nextPartInstanceId: string | null
+	/**
+	 * Blueprint-defined playout state, used to expose arbitrary information about playout
+	 */
+	playoutState?: any
+	/**
+	 * Optional arbitrary data
+	 */
+	publicData?: any
+	/**
+	 * Timing information about the playlist, expressed as relative offsets (not wall-clock time)
+	 */
+	timing: ResolvedPlaylistTiming
+	/**
+	 * Status of the 3 T-timers in the playlist
+	 */
+	tTimers: TTimerStatus[]
+	/**
+	 * Information about the current quickLoop, if any
+	 */
+	quickLoop?: ActivePlaylistQuickLoop | null
+	/**
+	 * The rundowns in the playlist, in rank order
+	 */
+	rundowns: ResolvedRundown[]
+	additionalProperties?: Record<string, any>
+}
+
+/**
+ * Timing information about the playlist, expressed as relative offsets (not wall-clock time)
+ */
+interface ResolvedPlaylistTiming {
+	/**
+	 * Whether timing counts forward from a start time or back from an end time
+	 */
+	type: ResolvedPlaylistTimingType
+	/**
+	 * Optional start offset of the playlist (ms). When present, this is typically 0.
+	 */
+	startMs: number | null
+	/**
+	 * Expected duration of the playlist (ms)
+	 */
+	durationMs: number | null
+	/**
+	 * Optional end offset of the playlist (ms) from the beginning of the playlist
+	 */
+	endMs: number | null
+}
+
+/**
+ * Whether timing counts forward from a start time or back from an end time
+ */
+enum ResolvedPlaylistTimingType {
+	FORWARD = 'forward',
+	BACK = 'back',
+}
+
+/**
+ * A rundown within a resolved playlist
+ */
+interface ResolvedRundown {
+	/**
+	 * Unique id of the rundown
+	 */
+	id: string
+	/**
+	 * Id normally sourced from the ingest system
+	 */
+	externalId: string
+	/**
+	 * User-presentable name of the rundown
+	 */
+	name: string
+	/**
+	 * Rank for ordering
+	 */
+	rank: number
+	/**
+	 * Optional description
+	 */
+	description: string
+	/**
+	 * Optional arbitrary data
+	 */
+	publicData?: any
+	/**
+	 * Segments in this rundown
+	 */
+	segments: ResolvedSegment[]
+}
+
+/**
+ * A segment within a resolved rundown
+ */
+interface ResolvedSegment {
+	/**
+	 * Unique id of the segment
+	 */
+	id: string
+	/**
+	 * Id normally sourced from the ingest system
+	 */
+	externalId: string
+	/**
+	 * User-facing identifier from the source system
+	 */
+	identifier: string
+	/**
+	 * Name of the segment
+	 */
+	name: string
+	/**
+	 * Rank for ordering
+	 */
+	rank: number
+	/**
+	 * Whether the segment is hidden
+	 */
+	isHidden: boolean
+	/**
+	 * Source layers used in this segment
+	 */
+	sourceLayers: SourceLayer[]
+	/**
+	 * Output layers used in this segment
+	 */
+	outputLayers: OutputLayer[]
+	/**
+	 * Optional arbitrary data
+	 */
+	publicData?: any
+	/**
+	 * Timing information about the segment, relative to the start of the segment
+	 */
+	timing: ResolvedSegmentTiming
+	/**
+	 * Parts in this segment
+	 */
+	parts: ResolvedPart[]
+	additionalProperties?: Record<string, any>
+}
+
+/**
+ * Definition of a source layer used in a segment
+ */
+interface SourceLayer {
+	/**
+	 * Unique id of the source layer
+	 */
+	id: string
+	/**
+	 * User-presentable name of the source layer
+	 */
+	name: string
+	/**
+	 * Abbreviation for display
+	 */
+	abbreviation: string
+	/**
+	 * Whether the source layer is hidden in the UI
+	 */
+	isHidden: boolean
+	/**
+	 * Source layer content type (numeric enum)
+	 */
+	type: number
+	/**
+	 * Rank for ordering
+	 */
+	rank: number
+}
+
+/**
+ * Definition of an output layer used in a segment
+ */
+interface OutputLayer {
+	/**
+	 * Unique id of the output layer
+	 */
+	id: string
+	/**
+	 * User-presentable name of the output layer
+	 */
+	name: string
+	/**
+	 * Whether the output layer is flattened
+	 */
+	isFlattened: boolean
+	/**
+	 * Whether PGM treatment should be in effect
+	 */
+	isPGM: boolean
+	/**
+	 * Output layer type (numeric enum)
+	 */
+	type: number
+	/**
+	 * The set of sourceLayer ids that feed this output layer
+	 */
+	sourceLayerIds: string[]
+}
+
+/**
+ * Timing information about the segment, relative to the start of the segment
+ */
+interface ResolvedSegmentTiming {
+	/**
+	 * Start offset of the segment (ms). For segments, this is typically 0.
+	 */
+	startMs: number
+	/**
+	 * End offset of the segment (ms) from the beginning of the segment
+	 */
+	endMs: number
+	/**
+	 * Planned/budget duration for the segment (ms)
+	 */
+	budgetDurationMs: number
+}
+
+/**
+ * A part within a resolved segment
+ */
+interface ResolvedPart {
+	/**
+	 * Unique id of the part
+	 */
+	id: string
+	/**
+	 * User-presentable name of the part
+	 */
+	name: string
+	/**
+	 * If this part will progress to the next automatically
+	 */
+	autoNext?: boolean
+	/**
+	 * Unique id of the part instance
+	 */
+	instanceId: string
+	/**
+	 * Id normally sourced from the ingest system
+	 */
+	externalId: string
+	/**
+	 * Rank for ordering
+	 */
+	rank: number
+	/**
+	 * Set only for the current or next part
+	 */
+	state?: ResolvedPartState
+	/**
+	 * Optional arbitrary data
+	 */
+	publicData?: any
+	/**
+	 * Timing information about the part, relative to the start of the segment
+	 */
+	timing: ResolvedPartTiming
+	/**
+	 * Pieces in this part
+	 */
+	pieces: ResolvedPiece[]
+	additionalProperties?: Record<string, any>
+}
+
+/**
+ * Set only for the current or next part
+ */
+enum ResolvedPartState {
+	CURRENT = 'current',
+	NEXT = 'next',
+}
+
+/**
+ * Timing information about the part, relative to the start of the segment
+ */
+interface ResolvedPartTiming {
+	/**
+	 * Start offset of the part (ms) from the beginning of the segment
+	 */
+	startMs: number
+	/**
+	 * Resolved duration of the part (ms)
+	 */
+	durationMs: number
+	/**
+	 * Unix timestamp (ms) when the part was planned to start playback
+	 */
+	plannedStartedPlayback?: number
+	/**
+	 * Unix timestamp (ms) when the part was reported as started playback
+	 */
+	reportedStartedPlayback?: number
+	/**
+	 * Playback offset relative to planned start (ms)
+	 */
+	playOffset?: number
+	/**
+	 * Unix timestamp (ms) when the part was set as next
+	 */
+	setAsNext?: number
+	/**
+	 * Unix timestamp (ms) when the part was taken
+	 */
+	take?: number
+}
+
+/**
+ * A piece within a resolved part
+ */
+interface ResolvedPiece {
+	/**
+	 * Unique id of the piece
+	 */
+	id: string
+	/**
+	 * Unique id of the piece instance
+	 */
+	instanceId: string
+	/**
+	 * Id normally sourced from the ingest system
+	 */
+	externalId: string
+	/**
+	 * User-facing name of the piece
+	 */
+	name: string
+	/**
+	 * Priority of the piece
+	 */
+	priority: number
+	/**
+	 * Id of the source layer for this piece
+	 */
+	sourceLayerId: string
+	/**
+	 * Id of the output layer for this piece
+	 */
+	outputLayerId: string
+	/**
+	 * Optional arbitrary data
+	 */
+	publicData?: any
+	/**
+	 * Timing information about the piece, relative to the start of the part
+	 */
+	timing: ResolvedPieceTiming
+	/**
+	 * Optional tags attached to this piece
+	 */
+	tags?: string[]
+	/**
+	 * Optional AB playback session assignments for this piece
+	 */
+	abSessions?: AbSessionAssignment[]
+}
+
+/**
+ * Timing information about the piece, relative to the start of the part
+ */
+interface ResolvedPieceTiming {
+	/**
+	 * Start offset of the piece (ms) from the beginning of the part
+	 */
+	startMs: number
+	/**
+	 * Resolved duration of the piece (ms)
+	 */
+	durationMs: number
+	/**
+	 * Preroll duration for the piece (ms)
+	 */
+	prerollMs: number
+}
+
 interface ActivePiecesEvent {
 	event: 'activePieces'
 	/**
@@ -1032,6 +1440,7 @@ export type Slash =
 	| NotificationsEvent
 	| PackagesEvent
 	| PongEvent
+	| ResolvedPlaylistEvent
 	| SegmentsEvent
 	| StudioEvent
 	| SubscriptionStatusError
@@ -1076,6 +1485,19 @@ export {
 	TimerModeTimeOfDay,
 	TimerStateRunning,
 	TimerStatePaused,
+	ResolvedPlaylistEvent,
+	ResolvedPlaylistTiming,
+	ResolvedPlaylistTimingType,
+	ResolvedRundown,
+	ResolvedSegment,
+	SourceLayer,
+	OutputLayer,
+	ResolvedSegmentTiming,
+	ResolvedPart,
+	ResolvedPartState,
+	ResolvedPartTiming,
+	ResolvedPiece,
+	ResolvedPieceTiming,
 	ActivePiecesEvent,
 	SegmentsEvent,
 	Segment,

--- a/packages/live-status-gateway/src/collections/notifications/playlistNotificationsHandler.ts
+++ b/packages/live-status-gateway/src/collections/notifications/playlistNotificationsHandler.ts
@@ -74,6 +74,7 @@ export class PlaylistNotificationsHandler extends PublicationCollection<
 				this.setupSubscription(this._studioId, this._currentPlaylistId)
 			}
 		} else {
+			this.stopSubscription()
 			this.clearAndNotify()
 		}
 	}

--- a/packages/live-status-gateway/src/collections/partInstancesHandler.ts
+++ b/packages/live-status-gateway/src/collections/partInstancesHandler.ts
@@ -145,6 +145,7 @@ export class PartInstancesHandler extends PublicationCollection<
 				this.clearAndNotify()
 			}
 		} else {
+			this.stopSubscription()
 			this.clearAndNotify()
 		}
 	}

--- a/packages/live-status-gateway/src/collections/partInstancesInPlaylistHandler.ts
+++ b/packages/live-status-gateway/src/collections/partInstancesInPlaylistHandler.ts
@@ -17,6 +17,10 @@ export interface PartInstancesInPlaylist {
 const PLAYLIST_KEYS = ['_id', 'activationId', 'rundownIdsInOrder'] as const
 type Playlist = Pick<DBRundownPlaylist, (typeof PLAYLIST_KEYS)[number]>
 
+/**
+ * Maintains part instances for the currently active playlist.
+ * Subscription is re-created when rundown set or activation id changes.
+ */
 export class PartInstancesInPlaylistHandler extends PublicationCollection<
 	PartInstancesInPlaylist,
 	CorelibPubSub.partInstances,

--- a/packages/live-status-gateway/src/collections/partInstancesInPlaylistHandler.ts
+++ b/packages/live-status-gateway/src/collections/partInstancesInPlaylistHandler.ts
@@ -1,0 +1,98 @@
+import { Logger } from 'winston'
+import { CoreHandler } from '../coreHandler.js'
+import { PublicationCollection } from '../publicationCollection.js'
+import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
+import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { RundownId, RundownPlaylistActivationId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { CollectionHandlers } from '../liveStatusServer.js'
+import areElementsShallowEqual from '@sofie-automation/shared-lib/dist/lib/isShallowEqual'
+import throttleToNextTick from '@sofie-automation/shared-lib/dist/lib/throttleToNextTick'
+import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist/RundownPlaylist'
+
+export interface PartInstancesInPlaylist {
+	all: DBPartInstance[]
+}
+
+const PLAYLIST_KEYS = ['_id', 'activationId', 'rundownIdsInOrder'] as const
+type Playlist = Pick<DBRundownPlaylist, (typeof PLAYLIST_KEYS)[number]>
+
+export class PartInstancesInPlaylistHandler extends PublicationCollection<
+	PartInstancesInPlaylist,
+	CorelibPubSub.partInstances,
+	CollectionName.PartInstances
+> {
+	private _currentPlaylist: Playlist | undefined
+	private _rundownIds: RundownId[] = []
+	private _activationId: RundownPlaylistActivationId | undefined
+
+	private _throttledUpdateAndNotify = throttleToNextTick(() => {
+		this.updateAndNotify()
+	})
+
+	constructor(logger: Logger, coreHandler: CoreHandler) {
+		super(CollectionName.PartInstances, CorelibPubSub.partInstances, logger, coreHandler)
+		this._collectionData = {
+			all: [],
+		}
+	}
+
+	init(handlers: CollectionHandlers): void {
+		super.init(handlers)
+		handlers.playlistHandler.subscribe(this.onPlaylistUpdate, PLAYLIST_KEYS)
+	}
+
+	protected changed(): void {
+		this._throttledUpdateAndNotify()
+	}
+
+	private updateCollectionData(): boolean {
+		if (!this._collectionData) return false
+		const collection = this.getCollectionOrFail()
+		const allPartInstances = collection.find(undefined)
+
+		const hasAnythingChanged = !areElementsShallowEqual(this._collectionData.all, allPartInstances)
+		if (hasAnythingChanged) this._collectionData.all = allPartInstances
+
+		return hasAnythingChanged
+	}
+
+	private clearCollectionData() {
+		if (!this._collectionData) return
+		this._collectionData.all = []
+	}
+
+	private onPlaylistUpdate = (data: Playlist | undefined): void => {
+		const prevRundownIds = [...this._rundownIds]
+		const prevActivationId = this._activationId
+
+		this._currentPlaylist = data
+		this._rundownIds = this._currentPlaylist ? this._currentPlaylist.rundownIdsInOrder : []
+		this._activationId = this._currentPlaylist?.activationId
+
+		if (this._currentPlaylist && this._rundownIds.length && this._activationId) {
+			const sameSubscription =
+				areElementsShallowEqual(this._rundownIds, prevRundownIds) && prevActivationId === this._activationId
+			if (!sameSubscription) {
+				this.stopSubscription()
+				this.setupSubscription(this._rundownIds, this._activationId)
+			} else if (this._subscriptionId) {
+				this.updateAndNotify()
+			} else {
+				this.clearAndNotify()
+			}
+		} else {
+			this.clearAndNotify()
+		}
+	}
+
+	private clearAndNotify() {
+		this.clearCollectionData()
+		this.notify(this._collectionData)
+	}
+
+	private updateAndNotify() {
+		const hasAnythingChanged = this.updateCollectionData()
+		if (hasAnythingChanged) this.notify(this._collectionData)
+	}
+}

--- a/packages/live-status-gateway/src/collections/partInstancesInPlaylistHandler.ts
+++ b/packages/live-status-gateway/src/collections/partInstancesInPlaylistHandler.ts
@@ -86,6 +86,7 @@ export class PartInstancesInPlaylistHandler extends PublicationCollection<
 				this.clearAndNotify()
 			}
 		} else {
+			this.stopSubscription()
 			this.clearAndNotify()
 		}
 	}

--- a/packages/live-status-gateway/src/collections/pieceContentStatusesHandler.ts
+++ b/packages/live-status-gateway/src/collections/pieceContentStatusesHandler.ts
@@ -58,6 +58,7 @@ export class PieceContentStatusesHandler extends PublicationCollection<
 				this.setupSubscription(this._currentPlaylistId)
 			}
 		} else {
+			this.stopSubscription()
 			this.clearAndNotify()
 		}
 	}

--- a/packages/live-status-gateway/src/collections/pieceInstancesHandler.ts
+++ b/packages/live-status-gateway/src/collections/pieceInstancesHandler.ts
@@ -241,6 +241,7 @@ export class PieceInstancesHandler extends PublicationCollection<
 				this.clearAndNotify()
 			}
 		} else {
+			this.stopSubscription()
 			this.clearAndNotify()
 		}
 	}

--- a/packages/live-status-gateway/src/collections/pieceInstancesInPlaylistHandler.ts
+++ b/packages/live-status-gateway/src/collections/pieceInstancesInPlaylistHandler.ts
@@ -1,0 +1,82 @@
+import { Logger } from 'winston'
+import { CoreHandler } from '../coreHandler.js'
+import { PublicationCollection } from '../publicationCollection.js'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
+import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist/RundownPlaylist'
+import _ from 'underscore'
+import throttleToNextTick from '@sofie-automation/shared-lib/dist/lib/throttleToNextTick'
+import { CollectionHandlers } from '../liveStatusServer.js'
+import { PieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
+import { PartInstancesInPlaylistHandler } from './partInstancesInPlaylistHandler.js'
+import { PartInstanceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { PartInstancesInPlaylist } from './partInstancesInPlaylistHandler.js'
+
+const PLAYLIST_KEYS = ['rundownIdsInOrder', 'activationId'] as const
+type Playlist = Pick<DBRundownPlaylist, (typeof PLAYLIST_KEYS)[number]>
+
+export class PieceInstancesInPlaylistHandler extends PublicationCollection<
+	PieceInstance[],
+	CorelibPubSub.pieceInstances,
+	CollectionName.PieceInstances
+> {
+	private _currentRundownIds: Playlist['rundownIdsInOrder'] | undefined
+	private _partInstanceIds: PartInstanceId[] = []
+
+	private _throttledUpdateAndNotify = throttleToNextTick(() => {
+		this.updateAndNotify()
+	})
+
+	constructor(logger: Logger, coreHandler: CoreHandler) {
+		super(CollectionName.PieceInstances, CorelibPubSub.pieceInstances, logger, coreHandler)
+		this._collectionData = []
+	}
+
+	init(handlers: CollectionHandlers & { partInstancesInPlaylistHandler: PartInstancesInPlaylistHandler }): void {
+		super.init(handlers)
+		handlers.playlistHandler.subscribe(this.onPlaylistUpdate, PLAYLIST_KEYS)
+		handlers.partInstancesInPlaylistHandler.subscribe(this.onPartInstancesInPlaylistUpdate, ['all'])
+	}
+
+	protected changed(): void {
+		this._throttledUpdateAndNotify()
+	}
+
+	private onPlaylistUpdate = (playlist: Playlist | undefined): void => {
+		this._currentRundownIds = playlist?.rundownIdsInOrder
+		this.maybeResubscribe()
+	}
+
+	private onPartInstancesInPlaylistUpdate = (data: PartInstancesInPlaylist | undefined): void => {
+		this._partInstanceIds = _.compact((data?.all ?? []).map((pi: any) => pi._id)).sort()
+		this.maybeResubscribe()
+	}
+
+	private maybeResubscribe(): void {
+		if (!this._currentRundownIds || this._currentRundownIds.length === 0) {
+			this.stopSubscription()
+			this.clearAndNotify()
+			return
+		}
+		if (!this._partInstanceIds.length) {
+			this.stopSubscription()
+			this.clearAndNotify()
+			return
+		}
+
+		// Always resubscribe when our filter set changes (simple/prototype behavior).
+		this.stopSubscription()
+		this.setupSubscription(this._currentRundownIds, this._partInstanceIds, {})
+	}
+
+	private updateAndNotify(): void {
+		const collection = this.getCollectionOrFail()
+		this._collectionData = collection.find(undefined)
+		this.notify(this._collectionData)
+	}
+
+	private clearAndNotify() {
+		this._collectionData = []
+		this.notify(this._collectionData)
+	}
+}

--- a/packages/live-status-gateway/src/collections/pieceInstancesInPlaylistHandler.ts
+++ b/packages/live-status-gateway/src/collections/pieceInstancesInPlaylistHandler.ts
@@ -12,9 +12,14 @@ import { PartInstancesInPlaylistHandler } from './partInstancesInPlaylistHandler
 import { PartInstanceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { PartInstancesInPlaylist } from './partInstancesInPlaylistHandler.js'
 
+/** Playlist fields needed to scope piece-instances to active playlist context. */
 const PLAYLIST_KEYS = ['rundownIdsInOrder', 'activationId'] as const
 type Playlist = Pick<DBRundownPlaylist, (typeof PLAYLIST_KEYS)[number]>
 
+/**
+ * Publishes piece instances for the active playlist.
+ * Scope is derived from both rundown ids and currently available part-instance ids.
+ */
 export class PieceInstancesInPlaylistHandler extends PublicationCollection<
 	PieceInstance[],
 	CorelibPubSub.pieceInstances,
@@ -43,30 +48,47 @@ export class PieceInstancesInPlaylistHandler extends PublicationCollection<
 	}
 
 	private onPlaylistUpdate = (playlist: Playlist | undefined): void => {
+		const prevRundownIds = this._currentRundownIds
 		this._currentRundownIds = playlist?.rundownIdsInOrder
-		this.maybeResubscribe()
+		this.resubscribe(prevRundownIds, this._partInstanceIds)
 	}
 
 	private onPartInstancesInPlaylistUpdate = (data: PartInstancesInPlaylist | undefined): void => {
+		const prevPartInstanceIds = this._partInstanceIds
 		this._partInstanceIds = _.compact((data?.all ?? []).map((pi: any) => pi._id)).sort()
-		this.maybeResubscribe()
+		this.resubscribe(this._currentRundownIds, prevPartInstanceIds)
 	}
 
-	private maybeResubscribe(): void {
+	private resubscribe(
+		prevRundownIds: Playlist['rundownIdsInOrder'] | undefined,
+		prevPartInstanceIds: PartInstanceId[]
+	): void {
+		// No rundown scope -> nothing should be published.
 		if (!this._currentRundownIds || this._currentRundownIds.length === 0) {
 			this.stopSubscription()
 			this.clearAndNotify()
 			return
 		}
+		// No active/derived part instances -> no matching piece instances can exist.
 		if (!this._partInstanceIds.length) {
 			this.stopSubscription()
 			this.clearAndNotify()
 			return
 		}
 
-		// Always resubscribe when our filter set changes (simple/prototype behavior).
-		this.stopSubscription()
-		this.setupSubscription(this._currentRundownIds, this._partInstanceIds, {})
+		const sameSubscription =
+			_.isEqual(prevRundownIds, this._currentRundownIds) && _.isEqual(prevPartInstanceIds, this._partInstanceIds)
+
+		if (!sameSubscription) {
+			// Subscription arguments changed; recreate the server-side observer with new filters.
+			this.stopSubscription()
+			this.setupSubscription(this._currentRundownIds, this._partInstanceIds, {})
+		} else if (this._subscriptionId) {
+			// Filter scope is unchanged and subscription is alive; just republish latest local snapshot.
+			this.updateAndNotify()
+		} else {
+			this.clearAndNotify()
+		}
 	}
 
 	private updateAndNotify(): void {

--- a/packages/live-status-gateway/src/collections/pieceInstancesInPlaylistHandler.ts
+++ b/packages/live-status-gateway/src/collections/pieceInstancesInPlaylistHandler.ts
@@ -9,7 +9,7 @@ import throttleToNextTick from '@sofie-automation/shared-lib/dist/lib/throttleTo
 import { CollectionHandlers } from '../liveStatusServer.js'
 import { PieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
 import { PartInstancesInPlaylistHandler } from './partInstancesInPlaylistHandler.js'
-import { PartInstanceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { PartInstanceId, RundownPlaylistActivationId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { PartInstancesInPlaylist } from './partInstancesInPlaylistHandler.js'
 
 /** Playlist fields needed to scope piece-instances to active playlist context. */
@@ -26,6 +26,7 @@ export class PieceInstancesInPlaylistHandler extends PublicationCollection<
 	CollectionName.PieceInstances
 > {
 	private _currentRundownIds: Playlist['rundownIdsInOrder'] | undefined
+	private _currentActivationId: RundownPlaylistActivationId | undefined
 	private _partInstanceIds: PartInstanceId[] = []
 
 	private _throttledUpdateAndNotify = throttleToNextTick(() => {
@@ -49,22 +50,40 @@ export class PieceInstancesInPlaylistHandler extends PublicationCollection<
 
 	private onPlaylistUpdate = (playlist: Playlist | undefined): void => {
 		const prevRundownIds = this._currentRundownIds
+		const prevActivationId = this._currentActivationId
+
+		const newActivationId = playlist?.activationId
+		if (newActivationId !== prevActivationId) {
+			// Ensure no stale piece instances from the previous activation leak through
+			this.stopSubscription()
+			this.clearAndNotify()
+		}
+
 		this._currentRundownIds = playlist?.rundownIdsInOrder
-		this.resubscribe(prevRundownIds, this._partInstanceIds)
+		this._currentActivationId = newActivationId
+		this.resubscribe(prevRundownIds, this._partInstanceIds, prevActivationId)
 	}
 
 	private onPartInstancesInPlaylistUpdate = (data: PartInstancesInPlaylist | undefined): void => {
 		const prevPartInstanceIds = this._partInstanceIds
+		const prevActivationId = this._currentActivationId
 		this._partInstanceIds = data?.all?.flatMap((pi: any) => (pi._id ? [pi._id] : [])).sort() ?? []
-		this.resubscribe(this._currentRundownIds, prevPartInstanceIds)
+		this.resubscribe(this._currentRundownIds, prevPartInstanceIds, prevActivationId)
 	}
 
 	private resubscribe(
 		prevRundownIds: Playlist['rundownIdsInOrder'] | undefined,
-		prevPartInstanceIds: PartInstanceId[]
+		prevPartInstanceIds: PartInstanceId[],
+		prevActivationId: RundownPlaylistActivationId | undefined
 	): void {
 		// No rundown scope -> nothing should be published.
 		if (!this._currentRundownIds || this._currentRundownIds.length === 0) {
+			this.stopSubscription()
+			this.clearAndNotify()
+			return
+		}
+		// No active playlist context -> nothing should be published.
+		if (!this._currentActivationId) {
 			this.stopSubscription()
 			this.clearAndNotify()
 			return
@@ -77,7 +96,9 @@ export class PieceInstancesInPlaylistHandler extends PublicationCollection<
 		}
 
 		const sameSubscription =
-			_.isEqual(prevRundownIds, this._currentRundownIds) && _.isEqual(prevPartInstanceIds, this._partInstanceIds)
+			_.isEqual(prevRundownIds, this._currentRundownIds) &&
+			_.isEqual(prevPartInstanceIds, this._partInstanceIds) &&
+			prevActivationId === this._currentActivationId
 
 		if (!sameSubscription) {
 			// Subscription arguments changed; recreate the server-side observer with new filters.

--- a/packages/live-status-gateway/src/collections/pieceInstancesInPlaylistHandler.ts
+++ b/packages/live-status-gateway/src/collections/pieceInstancesInPlaylistHandler.ts
@@ -55,7 +55,7 @@ export class PieceInstancesInPlaylistHandler extends PublicationCollection<
 
 	private onPartInstancesInPlaylistUpdate = (data: PartInstancesInPlaylist | undefined): void => {
 		const prevPartInstanceIds = this._partInstanceIds
-		this._partInstanceIds = _.compact((data?.all ?? []).map((pi: any) => pi._id)).sort()
+		this._partInstanceIds = data?.all?.flatMap((pi: any) => (pi._id ? [pi._id] : [])).sort() ?? []
 		this.resubscribe(this._currentRundownIds, prevPartInstanceIds)
 	}
 

--- a/packages/live-status-gateway/src/collections/piecesInPlaylistHandler.ts
+++ b/packages/live-status-gateway/src/collections/piecesInPlaylistHandler.ts
@@ -7,6 +7,7 @@ import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 import _ from 'underscore'
 import { Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
 import { CollectionHandlers } from '../liveStatusServer.js'
+import throttleToNextTick from '@sofie-automation/shared-lib/dist/lib/throttleToNextTick'
 
 const PLAYLIST_KEYS = ['rundownIdsInOrder'] as const
 type Playlist = Pick<DBRundownPlaylist, (typeof PLAYLIST_KEYS)[number]>
@@ -19,6 +20,10 @@ export class PiecesInPlaylistHandler extends PublicationCollection<
 > {
 	private _currentRundownIds: Playlist['rundownIdsInOrder'] | undefined
 
+	private _throttledUpdateAndNotify = throttleToNextTick(() => {
+		this.updateAndNotify()
+	})
+
 	constructor(logger: Logger, coreHandler: CoreHandler) {
 		super(CollectionName.Pieces, CorelibPubSub.pieces, logger, coreHandler)
 		this._collectionData = []
@@ -30,7 +35,7 @@ export class PiecesInPlaylistHandler extends PublicationCollection<
 	}
 
 	protected changed(): void {
-		this.updateAndNotify()
+		this._throttledUpdateAndNotify()
 	}
 
 	private updateAndNotify() {
@@ -55,6 +60,7 @@ export class PiecesInPlaylistHandler extends PublicationCollection<
 				this.clearAndNotify()
 			}
 		} else {
+			this.stopSubscription()
 			this.clearAndNotify()
 		}
 	}

--- a/packages/live-status-gateway/src/collections/piecesInPlaylistHandler.ts
+++ b/packages/live-status-gateway/src/collections/piecesInPlaylistHandler.ts
@@ -1,0 +1,65 @@
+import { Logger } from 'winston'
+import { CoreHandler } from '../coreHandler.js'
+import { PublicationCollection } from '../publicationCollection.js'
+import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist/RundownPlaylist'
+import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import _ from 'underscore'
+import { Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
+import { CollectionHandlers } from '../liveStatusServer.js'
+
+const PLAYLIST_KEYS = ['rundownIdsInOrder'] as const
+type Playlist = Pick<DBRundownPlaylist, (typeof PLAYLIST_KEYS)[number]>
+
+export class PiecesInPlaylistHandler extends PublicationCollection<
+	Piece[],
+	CorelibPubSub.pieces,
+	CollectionName.Pieces
+> {
+	private _currentRundownIds: Playlist['rundownIdsInOrder'] | undefined
+
+	constructor(logger: Logger, coreHandler: CoreHandler) {
+		super(CollectionName.Pieces, CorelibPubSub.pieces, logger, coreHandler)
+		this._collectionData = []
+	}
+
+	init(handlers: CollectionHandlers): void {
+		super.init(handlers)
+		handlers.playlistHandler.subscribe(this.onPlaylistUpdate, PLAYLIST_KEYS)
+	}
+
+	protected changed(): void {
+		this.updateAndNotify()
+	}
+
+	private updateAndNotify() {
+		const collection = this.getCollectionOrFail()
+		const pieces = collection.find(undefined)
+		this._collectionData = pieces
+		this.notify(this._collectionData)
+	}
+
+	private onPlaylistUpdate = (playlist: Playlist | undefined): void => {
+		const rundownIds = playlist?.rundownIdsInOrder
+		const prevRundownIds = this._currentRundownIds
+		this._currentRundownIds = rundownIds
+
+		if (rundownIds && rundownIds.length) {
+			const sameSubscription = _.isEqual(prevRundownIds, rundownIds) && this._subscriptionId
+			if (!sameSubscription) {
+				this.setupSubscription(rundownIds, null)
+			} else if (this._subscriptionId) {
+				this.updateAndNotify()
+			} else {
+				this.clearAndNotify()
+			}
+		} else {
+			this.clearAndNotify()
+		}
+	}
+
+	private clearAndNotify() {
+		this._collectionData = []
+		this.notify(this._collectionData)
+	}
+}

--- a/packages/live-status-gateway/src/collections/piecesInPlaylistHandler.ts
+++ b/packages/live-status-gateway/src/collections/piecesInPlaylistHandler.ts
@@ -11,6 +11,7 @@ import { CollectionHandlers } from '../liveStatusServer.js'
 const PLAYLIST_KEYS = ['rundownIdsInOrder'] as const
 type Playlist = Pick<DBRundownPlaylist, (typeof PLAYLIST_KEYS)[number]>
 
+/** Publishes all pieces belonging to rundowns in the currently selected playlist. */
 export class PiecesInPlaylistHandler extends PublicationCollection<
 	Piece[],
 	CorelibPubSub.pieces,

--- a/packages/live-status-gateway/src/collections/showStyleBasesHandler.ts
+++ b/packages/live-status-gateway/src/collections/showStyleBasesHandler.ts
@@ -1,0 +1,91 @@
+import { Logger } from 'winston'
+import { CoreHandler } from '../coreHandler.js'
+import { PublicationCollection } from '../publicationCollection.js'
+import { CollectionHandlers } from '../liveStatusServer.js'
+import { DBRundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
+import { DBShowStyleBase, OutputLayers, SourceLayers } from '@sofie-automation/corelib/dist/dataModel/ShowStyleBase'
+import { ShowStyleBaseId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { CollectionName } from '@sofie-automation/corelib/dist/dataModel/Collections'
+import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
+import { applyAndValidateOverrides } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
+import { IOutputLayer, ISourceLayer } from '@sofie-automation/blueprints-integration'
+import { ShowStyleBaseExt } from './showStyleBaseHandler.js'
+import _ from 'underscore'
+
+function buildShowStyleBaseExt(showStyleBase: DBShowStyleBase): ShowStyleBaseExt {
+	const sourceLayers: SourceLayers = applyAndValidateOverrides(showStyleBase.sourceLayersWithOverrides).obj
+	const outputLayers: OutputLayers = applyAndValidateOverrides(showStyleBase.outputLayersWithOverrides).obj
+
+	const sourceLayerNamesById = new Map<string, string>()
+	const outputLayerNamesById = new Map<string, string>()
+
+	for (const [layerId, sourceLayer] of Object.entries<ISourceLayer | undefined>(sourceLayers)) {
+		if (sourceLayer === undefined || sourceLayer === null) continue
+		sourceLayerNamesById.set(layerId, sourceLayer.name)
+	}
+	for (const [layerId, outputLayer] of Object.entries<IOutputLayer | undefined>(outputLayers)) {
+		if (outputLayer === undefined || outputLayer === null) continue
+		outputLayerNamesById.set(layerId, outputLayer.name)
+	}
+
+	return {
+		...showStyleBase,
+		sourceLayerNamesById,
+		outputLayerNamesById,
+		sourceLayers,
+	} as ShowStyleBaseExt
+}
+
+/**
+ * Subscribes to all ShowStyleBases used by rundowns in the active playlist.
+ * This enables mixed-showstyle playlists to resolve each rundown/segment with the correct showstyle.
+ */
+export class ShowStyleBasesHandler extends PublicationCollection<
+	ShowStyleBaseExt[],
+	CorelibPubSub.showStyleBases,
+	CollectionName.ShowStyleBases
+> {
+	private _showStyleBaseIds: ShowStyleBaseId[] = []
+
+	constructor(logger: Logger, coreHandler: CoreHandler) {
+		super(CollectionName.ShowStyleBases, CorelibPubSub.showStyleBases, logger, coreHandler)
+	}
+
+	init(handlers: CollectionHandlers): void {
+		super.init(handlers)
+		handlers.rundownsHandler.subscribe(this.onRundownsUpdate)
+	}
+
+	protected changed(): void {
+		this.updateAndNotify()
+	}
+
+	private updateAndNotify(): void {
+		const collection = this.getCollectionOrFail()
+		const all = collection.find(undefined) as unknown as DBShowStyleBase[]
+
+		const showStyles = all.map(buildShowStyleBaseExt)
+
+		this._collectionData = showStyles
+		this.notify(this._collectionData)
+	}
+
+	private onRundownsUpdate = (rundowns: DBRundown[] | undefined): void => {
+		const ids = Array.from(
+			new Set(
+				(rundowns ?? []).map((rundown) => rundown.showStyleBaseId).filter((id): id is ShowStyleBaseId => !!id)
+			)
+		).sort()
+
+		if (_.isEqual(this._showStyleBaseIds, ids)) return
+		this._showStyleBaseIds = ids
+
+		this.stopSubscription()
+		if (this._showStyleBaseIds.length > 0) {
+			this.setupSubscription(this._showStyleBaseIds)
+		} else {
+			this._collectionData = []
+			this.notify(this._collectionData)
+		}
+	}
+}

--- a/packages/live-status-gateway/src/liveStatusServer.ts
+++ b/packages/live-status-gateway/src/liveStatusServer.ts
@@ -5,7 +5,7 @@ import { StudioHandler } from './collections/studioHandler.js'
 import { ShowStyleBaseHandler } from './collections/showStyleBaseHandler.js'
 import { PlaylistHandler, PlaylistsHandler } from './collections/playlistHandler.js'
 import { RundownHandler } from './collections/rundownHandler.js'
-// import { RundownsHandler } from './collections/rundownsHandler.js'
+import { RundownsHandler } from './collections/rundownsHandler.js'
 import { SegmentHandler } from './collections/segmentHandler.js'
 // import { PartHandler } from './collections/part.js'
 import { PartInstancesHandler } from './collections/partInstancesHandler.js'
@@ -35,6 +35,10 @@ import { NotificationsTopic } from './topics/notificationsTopic.js'
 import { PlaylistNotificationsHandler } from './collections/notifications/playlistNotificationsHandler.js'
 import { RundownNotificationsHandler } from './collections/notifications/rundownNotificationsHandler.js'
 import { wsConnectionsGauge } from './wsMetrics.js'
+import { ResolvedPlaylistTopic } from './topics/resolvedPlaylistTopic.js'
+import { PartInstancesInPlaylistHandler } from './collections/partInstancesInPlaylistHandler.js'
+import { PiecesInPlaylistHandler } from './collections/piecesInPlaylistHandler.js'
+import { PieceInstancesInPlaylistHandler } from './collections/pieceInstancesInPlaylistHandler.js'
 
 export interface CollectionHandlers {
 	studioHandler: StudioHandler
@@ -42,12 +46,16 @@ export interface CollectionHandlers {
 	playlistHandler: PlaylistHandler
 	playlistsHandler: PlaylistsHandler
 	rundownHandler: RundownHandler
+	rundownsHandler: RundownsHandler
 	segmentsHandler: SegmentsHandler
 	segmentHandler: SegmentHandler
 	partsHandler: PartsHandler
 	partHandler: PartHandler
 	partInstancesHandler: PartInstancesHandler
+	partInstancesInPlaylistHandler: PartInstancesInPlaylistHandler
 	pieceInstancesHandler: PieceInstancesHandler
+	piecesInPlaylistHandler: PiecesInPlaylistHandler
+	pieceInstancesInPlaylistHandler: PieceInstancesInPlaylistHandler
 	adLibActionsHandler: AdLibActionsHandler
 	adLibsHandler: AdLibsHandler
 	globalAdLibActionsHandler: GlobalAdLibActionsHandler
@@ -80,13 +88,17 @@ export class LiveStatusServer {
 		const showStyleBaseHandler = new ShowStyleBaseHandler(this._logger, this._coreHandler)
 		const playlistHandler = new PlaylistHandler(this._logger, this._coreHandler)
 		const playlistsHandler = playlistHandler.playlistsHandler
-		const rundownHandler = new RundownHandler(this._logger, this._coreHandler)
+		const rundownsHandler = new RundownsHandler(this._logger, this._coreHandler)
+		const rundownHandler = new RundownHandler(this._logger, this._coreHandler, rundownsHandler)
 		const segmentsHandler = new SegmentsHandler(this._logger, this._coreHandler)
 		const segmentHandler = new SegmentHandler(this._logger, this._coreHandler, segmentsHandler)
 		const partsHandler = new PartsHandler(this._logger, this._coreHandler)
 		const partHandler = new PartHandler(this._logger, this._coreHandler, partsHandler)
 		const partInstancesHandler = new PartInstancesHandler(this._logger, this._coreHandler)
+		const partInstancesInPlaylistHandler = new PartInstancesInPlaylistHandler(this._logger, this._coreHandler)
+		const piecesInPlaylistHandler = new PiecesInPlaylistHandler(this._logger, this._coreHandler)
 		const pieceInstancesHandler = new PieceInstancesHandler(this._logger, this._coreHandler)
+		const pieceInstancesInPlaylistHandler = new PieceInstancesInPlaylistHandler(this._logger, this._coreHandler)
 		const adLibActionsHandler = new AdLibActionsHandler(this._logger, this._coreHandler)
 		const adLibsHandler = new AdLibsHandler(this._logger, this._coreHandler)
 		const globalAdLibActionsHandler = new GlobalAdLibActionsHandler(this._logger, this._coreHandler)
@@ -105,12 +117,16 @@ export class LiveStatusServer {
 			playlistHandler,
 			playlistsHandler,
 			rundownHandler,
+			rundownsHandler,
 			segmentsHandler,
 			segmentHandler,
 			partsHandler,
 			partHandler,
 			partInstancesHandler,
+			partInstancesInPlaylistHandler,
 			pieceInstancesHandler,
+			piecesInPlaylistHandler,
+			pieceInstancesInPlaylistHandler,
 			adLibActionsHandler,
 			adLibsHandler,
 			globalAdLibActionsHandler,
@@ -132,6 +148,7 @@ export class LiveStatusServer {
 		const activePiecesTopic = new ActivePiecesTopic(this._logger, handlers)
 		const activePlaylistTopic = new ActivePlaylistTopic(this._logger, handlers)
 		const segmentsTopic = new SegmentsTopic(this._logger, handlers)
+		const resolvedPlaylistTopic = new ResolvedPlaylistTopic(this._logger, handlers)
 		const adLibsTopic = new AdLibsTopic(this._logger, handlers)
 		const notificationsTopic = new NotificationsTopic(this._logger, handlers)
 		const packageStatusTopic = new PackagesTopic(this._logger, handlers)
@@ -139,6 +156,7 @@ export class LiveStatusServer {
 
 		rootChannel.addTopic(SubscriptionName.STUDIO, studioTopic)
 		rootChannel.addTopic(SubscriptionName.ACTIVE_PLAYLIST, activePlaylistTopic)
+		rootChannel.addTopic(SubscriptionName.RESOLVED_PLAYLIST, resolvedPlaylistTopic)
 		rootChannel.addTopic(SubscriptionName.ACTIVE_PIECES, activePiecesTopic)
 		rootChannel.addTopic(SubscriptionName.SEGMENTS, segmentsTopic)
 		rootChannel.addTopic(SubscriptionName.AD_LIBS, adLibsTopic)

--- a/packages/live-status-gateway/src/liveStatusServer.ts
+++ b/packages/live-status-gateway/src/liveStatusServer.ts
@@ -3,6 +3,7 @@ import { CoreHandler } from './coreHandler.js'
 import { WebSocket, WebSocketServer } from 'ws'
 import { StudioHandler } from './collections/studioHandler.js'
 import { ShowStyleBaseHandler } from './collections/showStyleBaseHandler.js'
+import { ShowStyleBasesHandler } from './collections/showStyleBasesHandler.js'
 import { PlaylistHandler, PlaylistsHandler } from './collections/playlistHandler.js'
 import { RundownHandler } from './collections/rundownHandler.js'
 import { RundownsHandler } from './collections/rundownsHandler.js'
@@ -43,6 +44,7 @@ import { PieceInstancesInPlaylistHandler } from './collections/pieceInstancesInP
 export interface CollectionHandlers {
 	studioHandler: StudioHandler
 	showStyleBaseHandler: ShowStyleBaseHandler
+	showStyleBasesHandler: ShowStyleBasesHandler
 	playlistHandler: PlaylistHandler
 	playlistsHandler: PlaylistsHandler
 	rundownHandler: RundownHandler
@@ -86,6 +88,7 @@ export class LiveStatusServer {
 
 		const studioHandler = new StudioHandler(this._logger, this._coreHandler)
 		const showStyleBaseHandler = new ShowStyleBaseHandler(this._logger, this._coreHandler)
+		const showStyleBasesHandler = new ShowStyleBasesHandler(this._logger, this._coreHandler)
 		const playlistHandler = new PlaylistHandler(this._logger, this._coreHandler)
 		const playlistsHandler = playlistHandler.playlistsHandler
 		const rundownsHandler = new RundownsHandler(this._logger, this._coreHandler)
@@ -114,6 +117,7 @@ export class LiveStatusServer {
 		const handlers: CollectionHandlers = {
 			studioHandler,
 			showStyleBaseHandler,
+			showStyleBasesHandler,
 			playlistHandler,
 			playlistsHandler,
 			rundownHandler,

--- a/packages/live-status-gateway/src/topics/__tests__/utils.ts
+++ b/packages/live-status-gateway/src/topics/__tests__/utils.ts
@@ -77,6 +77,7 @@ export function makeMockHandlers(): CollectionHandlers {
 		playlistHandler: makeMockHandler(),
 		playlistsHandler: makeMockHandler(),
 		rundownHandler: makeMockHandler(),
+		rundownsHandler: makeMockHandler(),
 		segmentHandler: makeMockHandler(),
 		segmentsHandler: makeMockHandler(),
 		showStyleBaseHandler: makeMockHandler(),

--- a/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/quickLoop/toQuickLoopStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/quickLoop/toQuickLoopStatus.ts
@@ -1,0 +1,64 @@
+import type { ActivePlaylistQuickLoop, QuickLoopMarker } from '@sofie-automation/live-status-gateway-api'
+import { QuickLoopMarkerType } from '@sofie-automation/live-status-gateway-api'
+import { QuickLoopMarkerType as CoreQuickLoopMarkerType } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist/RundownPlaylist'
+import type {
+	QuickLoopMarker as CoreQuickLoopMarker,
+	QuickLoopProps,
+} from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist/RundownPlaylist'
+import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
+
+type ToQuickLoopStatusProps = {
+	quickLoop: QuickLoopProps | undefined
+	segmentsById: Record<string, { rundownId?: unknown } | undefined>
+	partsById: Record<string, { rundownId?: unknown; segmentId?: unknown } | undefined>
+}
+
+function toMarker(
+	marker: CoreQuickLoopMarker | undefined,
+	segmentsById: ToQuickLoopStatusProps['segmentsById'],
+	partsById: ToQuickLoopStatusProps['partsById']
+): QuickLoopMarker | undefined {
+	if (!marker) return undefined
+
+	switch (marker.type) {
+		case CoreQuickLoopMarkerType.PLAYLIST:
+			return { markerType: QuickLoopMarkerType.PLAYLIST }
+		case CoreQuickLoopMarkerType.RUNDOWN:
+			return { markerType: QuickLoopMarkerType.RUNDOWN, rundownId: unprotectString(marker.id) }
+		case CoreQuickLoopMarkerType.SEGMENT: {
+			const seg = segmentsById[unprotectString(marker.id)]
+			return {
+				markerType: QuickLoopMarkerType.SEGMENT,
+				rundownId: seg?.rundownId ? unprotectString(seg.rundownId as any) : undefined,
+				segmentId: unprotectString(marker.id),
+			}
+		}
+		case CoreQuickLoopMarkerType.PART: {
+			const part = partsById[unprotectString(marker.id)]
+			return {
+				markerType: QuickLoopMarkerType.PART,
+				rundownId: part?.rundownId ? unprotectString(part.rundownId as any) : undefined,
+				segmentId: part?.segmentId ? unprotectString(part.segmentId as any) : undefined,
+				partId: unprotectString(marker.id),
+			}
+		}
+		default:
+			// If corelib adds a new marker type, just omit it rather than crashing conversion
+			return undefined
+	}
+}
+
+export function toQuickLoopStatus({
+	quickLoop,
+	segmentsById,
+	partsById,
+}: ToQuickLoopStatusProps): ActivePlaylistQuickLoop | null {
+	if (!quickLoop) return null
+
+	return {
+		locked: quickLoop.locked,
+		running: quickLoop.running,
+		start: toMarker(quickLoop.start, segmentsById, partsById),
+		end: toMarker(quickLoop.end, segmentsById, partsById),
+	}
+}

--- a/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/quickLoop/toQuickLoopStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/quickLoop/toQuickLoopStatus.ts
@@ -5,18 +5,21 @@ import type {
 	QuickLoopMarker as CoreQuickLoopMarker,
 	QuickLoopProps,
 } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist/RundownPlaylist'
+import type { Logger } from 'winston'
 import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 
 type ToQuickLoopStatusProps = {
 	quickLoop: QuickLoopProps | undefined
 	segmentsById: Record<string, { rundownId?: unknown } | undefined>
 	partsById: Record<string, { rundownId?: unknown; segmentId?: unknown } | undefined>
+	logger?: Logger
 }
 
 function toMarker(
 	marker: CoreQuickLoopMarker | undefined,
 	segmentsById: ToQuickLoopStatusProps['segmentsById'],
-	partsById: ToQuickLoopStatusProps['partsById']
+	partsById: ToQuickLoopStatusProps['partsById'],
+	logger?: Logger
 ): QuickLoopMarker | undefined {
 	if (!marker) return undefined
 
@@ -44,6 +47,9 @@ function toMarker(
 		}
 		default:
 			// If corelib adds a new marker type, just omit it rather than crashing conversion
+			logger?.warn('Unknown QuickLoop markerType encountered; omitting marker', {
+				markerType: String((marker as any).type),
+			})
 			return undefined
 	}
 }
@@ -52,13 +58,14 @@ export function toQuickLoopStatus({
 	quickLoop,
 	segmentsById,
 	partsById,
+	logger,
 }: ToQuickLoopStatusProps): ActivePlaylistQuickLoop | null {
 	if (!quickLoop) return null
 
 	return {
 		locked: quickLoop.locked,
 		running: quickLoop.running,
-		start: toMarker(quickLoop.start, segmentsById, partsById),
-		end: toMarker(quickLoop.end, segmentsById, partsById),
+		start: toMarker(quickLoop.start, segmentsById, partsById, logger),
+		end: toMarker(quickLoop.end, segmentsById, partsById, logger),
 	}
 }

--- a/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timers/__tests__/toTTimers.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timers/__tests__/toTTimers.spec.ts
@@ -1,0 +1,51 @@
+import { toTTimers } from '../toTTimers.js'
+
+type TimerInput = {
+	index: 1 | 2 | 3
+	label: string
+	mode: any
+	state: any
+	projectedState?: any
+	anchorPartId?: any
+}
+
+function makeTimer(index: 1 | 2 | 3, overrides: Partial<TimerInput> = {}): TimerInput {
+	return {
+		index,
+		label: `Timer ${index}`,
+		mode: null,
+		state: null,
+		...overrides,
+	}
+}
+
+describe('toTTimers', () => {
+	it('returns 3 empty timers for nullish/empty input', () => {
+		expect(toTTimers(undefined)).toMatchObject([{ index: 1 }, { index: 2 }, { index: 3 }])
+		expect(toTTimers(null)).toMatchObject([{ index: 1 }, { index: 2 }, { index: 3 }])
+		expect(toTTimers([])).toMatchObject([{ index: 1 }, { index: 2 }, { index: 3 }])
+	})
+
+	it('does not throw for length 1 or 2 and places by index', () => {
+		expect(() => toTTimers([makeTimer(2)] as any)).not.toThrow()
+		expect(toTTimers([makeTimer(2)] as any).map((t) => t.index)).toEqual([1, 2, 3])
+
+		expect(() => toTTimers([makeTimer(1), makeTimer(3)] as any)).not.toThrow()
+		expect(toTTimers([makeTimer(1), makeTimer(3)] as any).map((t) => t.label)).toEqual(['Timer 1', '', 'Timer 3'])
+	})
+
+	it('is index-aware (out-of-order input lands in correct slots)', () => {
+		const result = toTTimers([makeTimer(3), makeTimer(1)] as any)
+		expect(result.map((t) => t.label)).toEqual(['Timer 1', '', 'Timer 3'])
+	})
+
+	it('uses first timer when duplicate indices occur', () => {
+		const result = toTTimers([makeTimer(2, { label: 'First' }), makeTimer(2, { label: 'Second' })] as any)
+		expect(result[1].label).toBe('First')
+	})
+
+	it('ignores invalid indices', () => {
+		const result = toTTimers([{ ...makeTimer(1), index: 4 } as any, makeTimer(1)] as any)
+		expect(result.map((t) => t.label)).toEqual(['Timer 1', '', ''])
+	})
+})

--- a/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timers/toTTimers.ts
+++ b/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timers/toTTimers.ts
@@ -29,9 +29,18 @@ function toTTimer(timer: RundownTTimer): TTimerStatus {
 
 export function toTTimers(tTimers: RundownTTimer[] | null | undefined): [TTimerStatus, TTimerStatus, TTimerStatus] {
 	// Always return exactly 3 timers
-	if (!tTimers || tTimers.length === 0) {
-		return [emptyTimer(1), emptyTimer(2), emptyTimer(3)]
+	const slots: [TTimerStatus, TTimerStatus, TTimerStatus] = [emptyTimer(1), emptyTimer(2), emptyTimer(3)]
+	if (!tTimers || tTimers.length === 0) return slots
+
+	const filled = new Set<number>()
+
+	for (const timer of tTimers) {
+		const slotIndex = timer.index - 1
+		if (slotIndex < 0 || slotIndex > 2) continue
+		if (filled.has(slotIndex)) continue
+		slots[slotIndex] = toTTimer(timer)
+		filled.add(slotIndex)
 	}
 
-	return [toTTimer(tTimers[0]), toTTimer(tTimers[1]), toTTimer(tTimers[2])]
+	return slots
 }

--- a/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timers/toTTimers.ts
+++ b/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timers/toTTimers.ts
@@ -1,0 +1,37 @@
+import type { TTimerStatus, TTimerIndex } from '@sofie-automation/live-status-gateway-api'
+import type { RundownTTimer } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist/TTimers'
+import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
+
+function emptyTimer(index: number): TTimerStatus {
+	return {
+		index: index as TTimerIndex,
+		label: '',
+		configured: false,
+		mode: null,
+		state: null,
+		projected: null,
+		anchorPartId: null,
+	}
+}
+
+function toTTimer(timer: RundownTTimer): TTimerStatus {
+	const { index, label, mode, state, projectedState, anchorPartId } = timer
+	return {
+		index: index as TTimerIndex,
+		label,
+		configured: !!(mode && state),
+		mode: mode as TTimerStatus['mode'],
+		state: state as TTimerStatus['state'],
+		projected: projectedState ? (projectedState as NonNullable<TTimerStatus['projected']>) : null,
+		anchorPartId: anchorPartId ? unprotectString(anchorPartId) : null,
+	}
+}
+
+export function toTTimers(tTimers: RundownTTimer[] | null | undefined): [TTimerStatus, TTimerStatus, TTimerStatus] {
+	// Always return exactly 3 timers
+	if (!tTimers || tTimers.length === 0) {
+		return [emptyTimer(1), emptyTimer(2), emptyTimer(3)]
+	}
+
+	return [toTTimer(tTimers[0]), toTTimer(tTimers[1]), toTTimer(tTimers[2])]
+}

--- a/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timers/toTTimers.ts
+++ b/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timers/toTTimers.ts
@@ -1,5 +1,8 @@
 import type { TTimerStatus, TTimerIndex } from '@sofie-automation/live-status-gateway-api'
-import type { RundownTTimer } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist/TTimers'
+import {
+	type RundownTTimer,
+	isRundownTTimerIndex,
+} from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist/TTimers'
 import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 
 function emptyTimer(index: number): TTimerStatus {
@@ -35,6 +38,7 @@ export function toTTimers(tTimers: RundownTTimer[] | null | undefined): [TTimerS
 	const filled = new Set<number>()
 
 	for (const timer of tTimers) {
+		if (!isRundownTTimerIndex(timer.index)) continue
 		const slotIndex = timer.index - 1
 		if (slotIndex < 0 || slotIndex > 2) continue
 		if (filled.has(slotIndex)) continue

--- a/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timing/toActivePlaylistTiming.ts
+++ b/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timing/toActivePlaylistTiming.ts
@@ -1,0 +1,39 @@
+import { literal } from '@sofie-automation/shared-lib/dist/lib/lib'
+import { PlaylistTimingType } from '@sofie-automation/blueprints-integration'
+import type { ActivePlaylistEvent } from '@sofie-automation/live-status-gateway-api'
+import type { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist/RundownPlaylist'
+
+import { translatePlaylistTimingType } from './translatePlaylistTimingType.js'
+
+/**
+ * Properties required to convert playlist timing into API timing.
+ *
+ * @typedef {object} ToActivePlaylistTimingProps
+ */
+type ToActivePlaylistTimingProps = {
+	startedPlaybackState: DBRundownPlaylist['startedPlayback']
+	timingState: DBRundownPlaylist['timing']
+}
+
+/**
+ * Converts internal playlist timing fields into API `ActivePlaylistEvent.timing`.
+ *
+ * @param {ToActivePlaylistTimingProps} props Playlist timing source fields.
+ * @returns {ActivePlaylistEvent['timing']} Converted timing payload.
+ */
+export function toActivePlaylistTiming({
+	startedPlaybackState,
+	timingState,
+}: ToActivePlaylistTimingProps): ActivePlaylistEvent['timing'] {
+	const timingMode = translatePlaylistTimingType(timingState.type)
+	const expectedStart = timingState.type !== PlaylistTimingType.None ? timingState.expectedStart : undefined
+	const expectedEnd = timingState.type !== PlaylistTimingType.None ? timingState.expectedEnd : undefined
+
+	return literal<ActivePlaylistEvent['timing']>({
+		timingMode,
+		startedPlayback: startedPlaybackState,
+		expectedDurationMs: timingState.expectedDuration,
+		expectedStart,
+		expectedEnd,
+	})
+}

--- a/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timing/toActivePlaylistTiming.ts
+++ b/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timing/toActivePlaylistTiming.ts
@@ -27,7 +27,10 @@ export function toActivePlaylistTiming({
 }: ToActivePlaylistTimingProps): ActivePlaylistEvent['timing'] {
 	const timingMode = translatePlaylistTimingType(timingState.type)
 	const expectedStart = timingState.type !== PlaylistTimingType.None ? timingState.expectedStart : undefined
-	const expectedEnd = timingState.type !== PlaylistTimingType.None && 'expectedEnd' in timingState ? timingState.expectedEnd : undefined
+	const expectedEnd =
+		timingState.type !== PlaylistTimingType.None && 'expectedEnd' in timingState
+			? timingState.expectedEnd
+			: undefined
 
 	return literal<ActivePlaylistEvent['timing']>({
 		timingMode,

--- a/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timing/toActivePlaylistTiming.ts
+++ b/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timing/toActivePlaylistTiming.ts
@@ -27,7 +27,7 @@ export function toActivePlaylistTiming({
 }: ToActivePlaylistTimingProps): ActivePlaylistEvent['timing'] {
 	const timingMode = translatePlaylistTimingType(timingState.type)
 	const expectedStart = timingState.type !== PlaylistTimingType.None ? timingState.expectedStart : undefined
-	const expectedEnd = timingState.type !== PlaylistTimingType.None ? timingState.expectedEnd : undefined
+	const expectedEnd = timingState.type !== PlaylistTimingType.None && 'expectedEnd' in timingState ? timingState.expectedEnd : undefined
 
 	return literal<ActivePlaylistEvent['timing']>({
 		timingMode,

--- a/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timing/translatePlaylistTimingType.ts
+++ b/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timing/translatePlaylistTimingType.ts
@@ -1,0 +1,18 @@
+import { PlaylistTimingType } from '@sofie-automation/blueprints-integration'
+import { ActivePlaylistTimingMode } from '@sofie-automation/live-status-gateway-api'
+import { assertNever } from '@sofie-automation/shared-lib/dist/lib/lib'
+
+export function translatePlaylistTimingType(type: PlaylistTimingType): ActivePlaylistTimingMode {
+	switch (type) {
+		case PlaylistTimingType.None:
+			return ActivePlaylistTimingMode.NONE
+		case PlaylistTimingType.BackTime:
+			return ActivePlaylistTimingMode.BACK_MINUS_TIME
+		case PlaylistTimingType.ForwardTime:
+			return ActivePlaylistTimingMode.FORWARD_MINUS_TIME
+		default:
+			assertNever(type)
+			// Cast and return the value anyway, so that the application works
+			return type as any as ActivePlaylistTimingMode
+	}
+}

--- a/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timing/translatePlaylistTimingType.ts
+++ b/packages/live-status-gateway/src/topics/helpers/activePlaylistConversion/timing/translatePlaylistTimingType.ts
@@ -10,6 +10,8 @@ export function translatePlaylistTimingType(type: PlaylistTimingType): ActivePla
 			return ActivePlaylistTimingMode.BACK_MINUS_TIME
 		case PlaylistTimingType.ForwardTime:
 			return ActivePlaylistTimingMode.FORWARD_MINUS_TIME
+		case PlaylistTimingType.Duration:
+			return ActivePlaylistTimingMode.DURATION
 		default:
 			assertNever(type)
 			// Cast and return the value anyway, so that the application works

--- a/packages/live-status-gateway/src/topics/helpers/notification/toNotificationStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/notification/toNotificationStatus.ts
@@ -16,7 +16,7 @@ export function toNotificationStatus(dbNotification: DBNotificationObj): Notific
 	})
 }
 
-function toNotificationSeverity(severity: NoteSeverity): NotificationSeverity {
+export function toNotificationSeverity(severity: NoteSeverity): NotificationSeverity {
 	switch (severity) {
 		case NoteSeverity.WARNING:
 			return NotificationSeverity.WARNING

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/conversionContext.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/conversionContext.spec.ts
@@ -1,0 +1,96 @@
+import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import {
+	createResolvedPlaylistConversionContext,
+	findCurrentPartInstance,
+	findNextPartInstance,
+	getOrderedPartsInRundown,
+	getOrderedSegmentsInRundown,
+} from '../context/conversionContext.js'
+import {
+	makePart,
+	makePartInstance,
+	makePieceInstance,
+	makePlaylist,
+	makeRundown,
+	makeSegment,
+	makeTestShowStyleBaseExt,
+} from './resolvedPlaylistConversionTestUtils.js'
+
+describe('conversionContext', () => {
+	it('builds sorted lookup context and current/next pointers', () => {
+		const currentId = protectString('current_pi')
+		const nextId = protectString('next_pi')
+		const playlist = makePlaylist({
+			currentPartInfo: { partInstanceId: currentId },
+			nextPartInfo: { partInstanceId: nextId },
+		})
+		const ctx = createResolvedPlaylistConversionContext({
+			playlistState: playlist,
+			rundownsState: [makeRundown('rundown0')],
+			showStyleBaseExtState: makeTestShowStyleBaseExt(),
+			segmentsState: [makeSegment('segment1', 'rundown0', 2), makeSegment('segment0', 'rundown0', 1)],
+			partsState: [makePart('part1', 'rundown0', 'segment0', 2), makePart('part0', 'rundown0', 'segment0', 1)],
+			partInstancesInPlaylistState: [
+				makePartInstance('next_pi', 'part1', 'segment0', 'rundown0'),
+				makePartInstance('current_pi', 'part0', 'segment0', 'rundown0'),
+			],
+			piecesInPlaylistState: [makePieceInstance('pi0').piece],
+			pieceInstancesInPlaylistState: [makePieceInstance('pi0')],
+		})
+
+		expect(getOrderedSegmentsInRundown(ctx, 'rundown0').map((s) => String(s._id))).toEqual(['segment0', 'segment1'])
+		expect(getOrderedPartsInRundown(ctx, 'rundown0').map((p) => String(p._id))).toEqual(['part0', 'part1'])
+		expect(String(ctx.currentPartInstance?._id)).toBe('current_pi')
+		expect(String(ctx.nextPartInstance?._id)).toBe('next_pi')
+		expect(ctx.orderedRundownIds).toEqual(['rundown0', 'rundown1'])
+	})
+
+	it('query adapters filter data correctly', () => {
+		const ctx = createResolvedPlaylistConversionContext({
+			playlistState: makePlaylist(),
+			rundownsState: [makeRundown('rundown0')],
+			showStyleBaseExtState: makeTestShowStyleBaseExt(),
+			segmentsState: [makeSegment('segment0', 'rundown0', 0)],
+			partsState: [makePart('part0', 'rundown0', 'segment0', 0)],
+			partInstancesInPlaylistState: [makePartInstance('pi0', 'part0', 'segment0', 'rundown0')],
+			piecesInPlaylistState: [makePieceInstance('x').piece],
+			pieceInstancesInPlaylistState: [makePieceInstance('x')],
+		})
+
+		expect(String(ctx.accessors.segmentsFindOne({ _id: protectString('segment0') } as any, {} as any)?._id)).toBe(
+			'segment0'
+		)
+		expect(
+			ctx.accessors.getActivePartInstances({ _id: protectString('playlist0') } as any, {
+				_id: protectString('pi0'),
+			}).length
+		).toBe(1)
+		expect(ctx.accessors.piecesFind({ _id: protectString('piece_x') } as any).length).toBe(1)
+		expect(ctx.accessors.pieceInstancesFind({ _id: protectString('x') } as any).length).toBe(1)
+	})
+
+	it('throws when required playlist/showStyle is missing', () => {
+		expect(() =>
+			createResolvedPlaylistConversionContext({
+				playlistState: undefined,
+				rundownsState: [],
+				showStyleBaseExtState: makeTestShowStyleBaseExt(),
+				segmentsState: [],
+				partsState: [],
+				partInstancesInPlaylistState: [],
+				piecesInPlaylistState: [],
+				pieceInstancesInPlaylistState: [],
+			})
+		).toThrow('Missing playlist or showStyleBaseExt')
+	})
+
+	it('findCurrentPartInstance/findNextPartInstance return undefined when ids are absent', () => {
+		const playlist = makePlaylist()
+		expect(
+			findCurrentPartInstance(playlist, [makePartInstance('pi0', 'part0', 'segment0', 'rundown0')])
+		).toBeUndefined()
+		expect(
+			findNextPartInstance(playlist, [makePartInstance('pi1', 'part1', 'segment0', 'rundown0')])
+		).toBeUndefined()
+	})
+})

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/conversionContext.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/conversionContext.spec.ts
@@ -45,6 +45,76 @@ describe('conversionContext', () => {
 		expect(ctx.orderedRundownIds).toEqual(['rundown0', 'rundown1'])
 	})
 
+	it('orders parts by segment order, then by part rank', () => {
+		const ctx = createResolvedPlaylistConversionContext({
+			playlistState: makePlaylist(),
+			rundownsState: [makeRundown('rundown0')],
+			showStyleBaseExtState: makeTestShowStyleBaseExt(),
+			segmentsState: [makeSegment('segment1', 'rundown0', 2), makeSegment('segment0', 'rundown0', 1)],
+			partsState: [
+				// Deliberately interleave segments and ranks:
+				// - segment0 should still come first overall (because segment order)
+				// - within each segment, sort by part rank
+				makePart('partA', 'rundown0', 'segment0', 20),
+				makePart('partC', 'rundown0', 'segment1', 2),
+				makePart('partB', 'rundown0', 'segment0', 10),
+				makePart('partD', 'rundown0', 'segment1', 1),
+			],
+			partInstancesInPlaylistState: [],
+			piecesInPlaylistState: [],
+			pieceInstancesInPlaylistState: [],
+		})
+
+		expect(getOrderedPartsInRundown(ctx, 'rundown0').map((p) => String(p._id))).toEqual([
+			'partB',
+			'partA',
+			'partD',
+			'partC',
+		])
+	})
+
+	it('maps rundowns to their own showStyleBaseId', () => {
+		const playlist = makePlaylist()
+		const rundown0 = makeRundown('rundown0')
+		const rundown1 = makeRundown('rundown1')
+		rundown0.showStyleBaseId = protectString('showStyleBaseA')
+		rundown1.showStyleBaseId = protectString('showStyleBaseB')
+
+		const ctx = createResolvedPlaylistConversionContext({
+			playlistState: playlist,
+			rundownsState: [rundown0, rundown1],
+			showStyleBaseExtState: makeTestShowStyleBaseExt(),
+			segmentsState: [],
+			partsState: [],
+			partInstancesInPlaylistState: [],
+			piecesInPlaylistState: [],
+			pieceInstancesInPlaylistState: [],
+		})
+
+		expect(String(ctx.rundownsToShowStyles.get(protectString('rundown0')))).toBe('showStyleBaseA')
+		expect(String(ctx.rundownsToShowStyles.get(protectString('rundown1')))).toBe('showStyleBaseB')
+	})
+
+	it('omits missing rundowns from rundownsToShowStyles', () => {
+		const playlist = makePlaylist()
+		const rundown0 = makeRundown('rundown0')
+		rundown0.showStyleBaseId = protectString('showStyleBaseA')
+
+		const ctx = createResolvedPlaylistConversionContext({
+			playlistState: playlist,
+			rundownsState: [rundown0],
+			showStyleBaseExtState: makeTestShowStyleBaseExt(),
+			segmentsState: [],
+			partsState: [],
+			partInstancesInPlaylistState: [],
+			piecesInPlaylistState: [],
+			pieceInstancesInPlaylistState: [],
+		})
+
+		expect(String(ctx.rundownsToShowStyles.get(protectString('rundown0')))).toBe('showStyleBaseA')
+		expect(ctx.rundownsToShowStyles.has(protectString('rundown1'))).toBe(false)
+	})
+
 	it('query adapters filter data correctly', () => {
 		const ctx = createResolvedPlaylistConversionContext({
 			playlistState: makePlaylist(),
@@ -67,6 +137,31 @@ describe('conversionContext', () => {
 		).toBe(1)
 		expect(ctx.accessors.piecesFind({ _id: protectString('piece_x') } as any).length).toBe(1)
 		expect(ctx.accessors.pieceInstancesFind({ _id: protectString('x') } as any).length).toBe(1)
+	})
+
+	it('getActivePartInstances omits reset part instances', () => {
+		const resetInstance = makePartInstance('pi_reset', 'part0', 'segment0', 'rundown0')
+		resetInstance.reset = true
+
+		const ctx = createResolvedPlaylistConversionContext({
+			playlistState: makePlaylist(),
+			rundownsState: [makeRundown('rundown0')],
+			showStyleBaseExtState: makeTestShowStyleBaseExt(),
+			segmentsState: [makeSegment('segment0', 'rundown0', 0)],
+			partsState: [makePart('part0', 'rundown0', 'segment0', 0)],
+			partInstancesInPlaylistState: [makePartInstance('pi0', 'part0', 'segment0', 'rundown0'), resetInstance],
+			piecesInPlaylistState: [],
+			pieceInstancesInPlaylistState: [],
+		})
+
+		expect(
+			ctx.accessors.getActivePartInstances({ _id: protectString('playlist0') } as any).map((p) => String(p._id))
+		).toEqual(['pi0'])
+		expect(
+			ctx.accessors.getActivePartInstances({ _id: protectString('playlist0') } as any, {
+				_id: protectString('pi_reset'),
+			}).length
+		).toBe(0)
 	})
 
 	it('throws when required playlist/showStyle is missing', () => {

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/resolvedPlaylistConversionTestUtils.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/resolvedPlaylistConversionTestUtils.ts
@@ -1,0 +1,132 @@
+import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import { PlaylistTimingType } from '@sofie-automation/blueprints-integration'
+import { ShowStyleBaseExt } from '../../../../collections/showStyleBaseHandler.js'
+import { QuickLoopMarkerType } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist/RundownPlaylist'
+
+export function makeTestShowStyleBaseExt(): ShowStyleBaseExt {
+	return {
+		_id: protectString('showStyleBase0'),
+		sourceLayerNamesById: new Map([
+			['sl1', 'Source Layer 1'],
+			['sl2', 'Source Layer 2'],
+		]),
+		outputLayerNamesById: new Map([
+			['ol1', 'Output Layer 1'],
+			['ol2', 'Output Layer 2'],
+		]),
+	} as unknown as ShowStyleBaseExt
+}
+
+export function makePlaylist(overrides: Partial<any> = {}): any {
+	return {
+		_id: protectString('playlist0'),
+		externalId: 'ext_playlist_0',
+		activationId: undefined,
+		rehearsal: false,
+		name: 'Playlist 0',
+		rundownIdsInOrder: [protectString('rundown0'), protectString('rundown1')],
+		quickLoop: null,
+		currentPartInfo: null,
+		nextPartInfo: null,
+		publicData: { playlistPublic: true },
+		publicPlayoutPersistentState: { playout: true },
+		timing: { type: PlaylistTimingType.None, expectedDuration: 10000 },
+		tTimers: [],
+		...overrides,
+	}
+}
+
+export function makeRundown(id: string, rank = 0): any {
+	return {
+		_id: protectString(id),
+		externalId: `ext_${id}`,
+		name: `Rundown ${id}`,
+		description: `Description ${id}`,
+		publicData: { rank },
+	}
+}
+
+export function makeSegment(id: string, rundownId: string, rank: number): any {
+	return {
+		_id: protectString(id),
+		externalId: `ext_${id}`,
+		identifier: `ident_${id}`,
+		name: `Segment ${id}`,
+		_rank: rank,
+		rundownId: protectString(rundownId),
+		segmentTiming: { budgetDuration: 3000 },
+	}
+}
+
+export function makePart(id: string, rundownId: string, segmentId: string, rank: number): any {
+	return {
+		_id: protectString(id),
+		externalId: `ext_${id}`,
+		title: `Part ${id}`,
+		_rank: rank,
+		rundownId: protectString(rundownId),
+		segmentId: protectString(segmentId),
+		autoNext: true,
+	}
+}
+
+export function makePartInstance(id: string, partId: string, segmentId: string, rundownId: string): any {
+	return {
+		_id: protectString(id),
+		rundownId: protectString(rundownId),
+		segmentId: protectString(segmentId),
+		part: {
+			_id: protectString(partId),
+			externalId: `ext_${partId}`,
+			title: `Part ${partId}`,
+			_rank: 1,
+			autoNext: false,
+			publicData: { fromPart: true },
+		},
+		timings: {
+			plannedStartedPlayback: 10,
+			reportedStartedPlayback: 11,
+			playOffset: 12,
+			setAsNext: 13,
+			take: 14,
+		},
+	}
+}
+
+export function makePieceInstance(id: string): any {
+	return {
+		_id: protectString(id),
+		priority: 9,
+		dynamicallyInserted: true,
+		resolvedEndCap: 1500,
+		piece: {
+			_id: protectString(`piece_${id}`),
+			externalId: `ext_piece_${id}`,
+			name: `Piece ${id}`,
+			sourceLayerId: 'sl1',
+			outputLayerId: 'ol1',
+			publicData: { piecePublic: true },
+			enable: {
+				start: 100,
+				duration: 200,
+			},
+			tags: ['tag1'],
+			abSessions: [
+				{
+					poolName: 'poolA',
+					sessionName: 'sessionA',
+					playerId: 'playerA',
+				},
+			],
+		},
+	}
+}
+
+export function makeQuickLoop(): any {
+	return {
+		locked: false,
+		running: true,
+		start: { type: QuickLoopMarkerType.PLAYLIST },
+		end: { type: QuickLoopMarkerType.RUNDOWN, id: protectString('rundown0') },
+	}
+}

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/resolvedPlaylistConversionTestUtils.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/resolvedPlaylistConversionTestUtils.ts
@@ -39,6 +39,8 @@ export function makePlaylist(overrides: Partial<any> = {}): any {
 export function makeRundown(id: string, rank = 0): any {
 	return {
 		_id: protectString(id),
+		showStyleBaseId: protectString('showStyleBase0'),
+		showStyleVariantId: protectString('showStyleVariant0'),
 		externalId: `ext_${id}`,
 		name: `Rundown ${id}`,
 		description: `Description ${id}`,

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/serializeResolvedSegment.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/serializeResolvedSegment.spec.ts
@@ -1,0 +1,47 @@
+import { serializePart, serializePiece, serializeSegmentExtended } from '../segments/serializeResolvedSegment.js'
+
+describe('serializeResolvedSegment helpers', () => {
+	it('serializePiece omits outputLayer and keeps transport-safe fields', () => {
+		const result = serializePiece({
+			renderedInPoint: 1,
+			renderedDuration: 2,
+			instance: { _id: 'inst0' },
+			outputLayer: { circular: true },
+		})
+
+		expect(result).toEqual({
+			renderedInPoint: 1,
+			renderedDuration: 2,
+			instance: { _id: 'inst0' },
+		})
+	})
+
+	it('serializePart serializes nested pieces', () => {
+		const result = serializePart({
+			partId: 'part0',
+			instance: { _id: 'pi0' },
+			renderedDuration: 2000,
+			startsAt: 1000,
+			willProbablyAutoNext: false,
+			pieces: [{ instance: { _id: 'piece0' } }],
+		})
+		expect(result.pieces).toEqual([
+			{ renderedInPoint: undefined, renderedDuration: undefined, instance: { _id: 'piece0' } },
+		])
+	})
+
+	it('serializeSegmentExtended strips cyclic refs from layers', () => {
+		const result = serializeSegmentExtended({
+			_id: 'segment0',
+			outputLayers: {
+				ol1: { _id: 'ol1', sourceLayers: [{ _id: 'sl1' }] },
+			},
+			sourceLayers: {
+				sl1: { _id: 'sl1', pieces: [{ _id: 'pieceA' }, { instance: { _id: 'pieceB' } }] },
+			},
+		})
+
+		expect(result.outputLayers.ol1.sourceLayers).toEqual([])
+		expect(result.sourceLayers.sl1.pieces).toEqual(['pieceA', 'pieceB'])
+	})
+})

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPartStatus.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPartStatus.spec.ts
@@ -1,5 +1,6 @@
 import { protectString } from '@sofie-automation/corelib/dist/protectedString'
 import { ResolvedPartState } from '@sofie-automation/live-status-gateway-api'
+import { NoteSeverity } from '@sofie-automation/blueprints-integration'
 import { toResolvedPartStatus } from '../parts/toResolvedPartStatus.js'
 import {
 	makePartInstance,
@@ -32,6 +33,15 @@ describe('toResolvedPartStatus', () => {
 			instance: {
 				...makePartInstance('current_pi', 'part0', 'segment0', 'rundown0'),
 				orphaned: 'adlib-part',
+				part: {
+					...makePartInstance('current_pi', 'part0', 'segment0', 'rundown0').part,
+					invalid: true,
+					invalidReason: {
+						message: { key: 'Invalid {{foo}}', args: { foo: 'bar' }, namespaces: ['blueprint_test'] },
+						severity: NoteSeverity.WARNING,
+						color: '#ff0000',
+					},
+				},
 			},
 			startsAt: 1000,
 			renderedDuration: 2000,
@@ -43,6 +53,12 @@ describe('toResolvedPartStatus', () => {
 		expect(result.createdByAdLib).toBe(true)
 		expect(result.id).toBe('part0')
 		expect(result.instanceId).toBe('current_pi')
+		expect(result.invalid).toBe(true)
+		expect(result.invalidReason).toMatchObject({
+			message: 'Invalid bar',
+			severity: 'warning',
+			color: '#ff0000',
+		})
 		expect(result.timing).toMatchObject({
 			startMs: 1000,
 			durationMs: 2000,
@@ -77,6 +93,8 @@ describe('toResolvedPartStatus', () => {
 
 		const result = toResolvedPartStatus(ctx, partExtended)
 		expect(result.state).toBe(ResolvedPartState.NEXT)
+		expect(result.invalid).toBe(false)
+		expect(result.invalidReason).toBeUndefined()
 		expect(result.timing.startMs).toBe(0)
 		expect(result.timing.durationMs).toBe(0)
 		expect(result.pieces).toEqual([])

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPartStatus.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPartStatus.spec.ts
@@ -37,6 +37,7 @@ describe('toResolvedPartStatus', () => {
 					...makePartInstance('current_pi', 'part0', 'segment0', 'rundown0').part,
 					invalid: true,
 					floated: true,
+					untimed: true,
 					invalidReason: {
 						message: { key: 'Invalid {{foo}}', args: { foo: 'bar' }, namespaces: ['blueprint_test'] },
 						severity: NoteSeverity.WARNING,
@@ -56,6 +57,7 @@ describe('toResolvedPartStatus', () => {
 		expect(result.instanceId).toBe('current_pi')
 		expect(result.invalid).toBe(true)
 		expect(result.floated).toBe(true)
+		expect(result.untimed).toBe(true)
 		expect(result.invalidReason).toMatchObject({
 			message: 'Invalid bar',
 			severity: 'warning',
@@ -97,6 +99,7 @@ describe('toResolvedPartStatus', () => {
 		expect(result.state).toBe(ResolvedPartState.NEXT)
 		expect(result.invalid).toBe(false)
 		expect(result.floated).toBe(false)
+		expect(result.untimed).toBe(false)
 		expect(result.invalidReason).toBeUndefined()
 		expect(result.timing.startMs).toBe(0)
 		expect(result.timing.durationMs).toBe(0)

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPartStatus.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPartStatus.spec.ts
@@ -1,0 +1,84 @@
+import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import { ResolvedPartState } from '@sofie-automation/live-status-gateway-api'
+import { toResolvedPartStatus } from '../parts/toResolvedPartStatus.js'
+import {
+	makePartInstance,
+	makePieceInstance,
+	makePlaylist,
+	makeRundown,
+	makeSegment,
+	makeTestShowStyleBaseExt,
+} from './resolvedPlaylistConversionTestUtils.js'
+import { createResolvedPlaylistConversionContext } from '../context/conversionContext.js'
+
+describe('toResolvedPartStatus', () => {
+	it('maps current part state and nested pieces', () => {
+		const currentPartInstanceId = protectString('current_pi')
+		const ctx = createResolvedPlaylistConversionContext({
+			playlistState: makePlaylist({
+				currentPartInfo: { partInstanceId: currentPartInstanceId },
+			}),
+			rundownsState: [makeRundown('rundown0')],
+			showStyleBaseExtState: makeTestShowStyleBaseExt(),
+			segmentsState: [makeSegment('segment0', 'rundown0', 0)],
+			partsState: [],
+			partInstancesInPlaylistState: [makePartInstance('current_pi', 'part0', 'segment0', 'rundown0')],
+			piecesInPlaylistState: [],
+			pieceInstancesInPlaylistState: [],
+		})
+
+		const partExtended = {
+			partId: protectString('part0'),
+			instance: {
+				...makePartInstance('current_pi', 'part0', 'segment0', 'rundown0'),
+				orphaned: 'adlib-part',
+			},
+			startsAt: 1000,
+			renderedDuration: 2000,
+			pieces: [{ instance: makePieceInstance('piece0') }],
+		} as any
+
+		const result = toResolvedPartStatus(ctx, partExtended)
+		expect(result.state).toBe(ResolvedPartState.CURRENT)
+		expect(result.createdByAdLib).toBe(true)
+		expect(result.id).toBe('part0')
+		expect(result.instanceId).toBe('current_pi')
+		expect(result.timing).toMatchObject({
+			startMs: 1000,
+			durationMs: 2000,
+			plannedStartedPlayback: 10,
+			reportedStartedPlayback: 11,
+			playOffset: 12,
+			setAsNext: 13,
+			take: 14,
+		})
+		expect(result.pieces).toHaveLength(1)
+	})
+
+	it('maps next part state and default timing fallbacks', () => {
+		const nextPartInstanceId = protectString('next_pi')
+		const ctx = createResolvedPlaylistConversionContext({
+			playlistState: makePlaylist({
+				nextPartInfo: { partInstanceId: nextPartInstanceId },
+			}),
+			rundownsState: [makeRundown('rundown0')],
+			showStyleBaseExtState: makeTestShowStyleBaseExt(),
+			segmentsState: [makeSegment('segment0', 'rundown0', 0)],
+			partsState: [],
+			partInstancesInPlaylistState: [makePartInstance('next_pi', 'part1', 'segment0', 'rundown0')],
+			piecesInPlaylistState: [],
+			pieceInstancesInPlaylistState: [],
+		})
+
+		const partExtended = {
+			partId: protectString('part1'),
+			instance: makePartInstance('next_pi', 'part1', 'segment0', 'rundown0'),
+		} as any
+
+		const result = toResolvedPartStatus(ctx, partExtended)
+		expect(result.state).toBe(ResolvedPartState.NEXT)
+		expect(result.timing.startMs).toBe(0)
+		expect(result.timing.durationMs).toBe(0)
+		expect(result.pieces).toEqual([])
+	})
+})

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPartStatus.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPartStatus.spec.ts
@@ -36,6 +36,7 @@ describe('toResolvedPartStatus', () => {
 				part: {
 					...makePartInstance('current_pi', 'part0', 'segment0', 'rundown0').part,
 					invalid: true,
+					floated: true,
 					invalidReason: {
 						message: { key: 'Invalid {{foo}}', args: { foo: 'bar' }, namespaces: ['blueprint_test'] },
 						severity: NoteSeverity.WARNING,
@@ -54,6 +55,7 @@ describe('toResolvedPartStatus', () => {
 		expect(result.id).toBe('part0')
 		expect(result.instanceId).toBe('current_pi')
 		expect(result.invalid).toBe(true)
+		expect(result.floated).toBe(true)
 		expect(result.invalidReason).toMatchObject({
 			message: 'Invalid bar',
 			severity: 'warning',
@@ -94,6 +96,7 @@ describe('toResolvedPartStatus', () => {
 		const result = toResolvedPartStatus(ctx, partExtended)
 		expect(result.state).toBe(ResolvedPartState.NEXT)
 		expect(result.invalid).toBe(false)
+		expect(result.floated).toBe(false)
 		expect(result.invalidReason).toBeUndefined()
 		expect(result.timing.startMs).toBe(0)
 		expect(result.timing.durationMs).toBe(0)

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPartStatus.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPartStatus.spec.ts
@@ -68,7 +68,7 @@ describe('toResolvedPartStatus', () => {
 			durationMs: 2000,
 			plannedStartedPlayback: 10,
 			reportedStartedPlayback: 11,
-			playOffset: 12,
+			playOffsetMs: 12,
 			setAsNext: 13,
 			take: 14,
 		})

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPieceStatus.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPieceStatus.spec.ts
@@ -19,6 +19,7 @@ describe('toResolvedPieceStatus', () => {
 			priority: 9,
 			sourceLayerId: 'sl1',
 			outputLayerId: 'ol1',
+			invalid: false,
 			tags: ['tag1'],
 			timing: {
 				startMs: 345,

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPieceStatus.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPieceStatus.spec.ts
@@ -1,0 +1,68 @@
+import { toResolvedPieceStatus } from '../pieces/toResolvedPieceStatus.js'
+import { makePieceInstance } from './resolvedPlaylistConversionTestUtils.js'
+
+describe('toResolvedPieceStatus', () => {
+	it('maps rendered timings and basic fields', () => {
+		const pieceExtended = {
+			renderedInPoint: 345,
+			renderedDuration: 678,
+			instance: makePieceInstance('inst0'),
+		} as any
+
+		const result = toResolvedPieceStatus(pieceExtended)
+		expect(result).toMatchObject({
+			id: 'piece_inst0',
+			instanceId: 'inst0',
+			createdByAdLib: true,
+			externalId: 'ext_piece_inst0',
+			name: 'Piece inst0',
+			priority: 9,
+			sourceLayerId: 'sl1',
+			outputLayerId: 'ol1',
+			tags: ['tag1'],
+			timing: {
+				startMs: 345,
+				durationMs: 678,
+				prerollMs: undefined,
+			},
+			abSessions: [{ poolName: 'poolA', sessionName: 'sessionA', playerId: 'playerA' }],
+		})
+	})
+
+	it('falls back to computed duration from userDuration or resolvedEndCap', () => {
+		const pieceWithUserDuration = {
+			instance: {
+				...makePieceInstance('inst1'),
+				userDuration: { endRelativeToPart: 500 },
+			},
+		} as any
+		const first = toResolvedPieceStatus(pieceWithUserDuration)
+		expect(first.timing.startMs).toBe(100)
+		expect(first.timing.durationMs).toBe(400)
+
+		const pieceWithResolvedEndCap = {
+			instance: {
+				...makePieceInstance('inst2'),
+				userDuration: undefined,
+				resolvedEndCap: 350,
+			},
+		} as any
+		const second = toResolvedPieceStatus(pieceWithResolvedEndCap)
+		expect(second.timing.durationMs).toBe(250)
+	})
+
+	it('filters invalid abSessions entries', () => {
+		const pieceExtended = {
+			instance: {
+				...makePieceInstance('inst3'),
+				piece: {
+					...makePieceInstance('inst3').piece,
+					abSessions: [{ poolName: 'ok', sessionName: 'ok', playerId: 'p0' }, { poolName: 'bad' }],
+				},
+			},
+		} as any
+
+		const result = toResolvedPieceStatus(pieceExtended)
+		expect(result.abSessions).toEqual([{ poolName: 'ok', sessionName: 'ok', playerId: 'p0' }])
+	})
+})

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPlaylistStatus.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPlaylistStatus.spec.ts
@@ -1,0 +1,85 @@
+import { PlaylistTimingType } from '@sofie-automation/blueprints-integration'
+import { PlaylistActivationStatus, ResolvedPlaylistTimingType } from '@sofie-automation/live-status-gateway-api'
+import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import { toResolvedPlaylistStatus } from '../events/toResolvedPlaylistStatus.js'
+import {
+	makePart,
+	makePartInstance,
+	makePieceInstance,
+	makePlaylist,
+	makeQuickLoop,
+	makeRundown,
+	makeSegment,
+	makeTestShowStyleBaseExt,
+} from './resolvedPlaylistConversionTestUtils.js'
+
+jest.mock('../rundowns/toResolvedRundownStatus.js', () => ({
+	toResolvedRundownStatus: jest.fn((_ctx, rundownId) => ({ id: rundownId })),
+}))
+
+describe('toResolvedPlaylistStatus', () => {
+	it('returns empty payload when playlist or showStyle is missing', () => {
+		const result = toResolvedPlaylistStatus({
+			playlistState: undefined,
+			rundownsState: [],
+			showStyleBaseExtState: undefined,
+			segmentsState: [],
+			partsState: [],
+			partInstancesInPlaylistState: [],
+			piecesInPlaylistState: [],
+			pieceInstancesInPlaylistState: [],
+		})
+
+		expect(result).toMatchObject({
+			event: 'resolvedPlaylist',
+			id: '',
+			externalId: '',
+			name: '',
+			activationStatus: PlaylistActivationStatus.DEACTIVATED,
+			rundowns: [],
+			timing: {
+				type: ResolvedPlaylistTimingType.FORWARD,
+				startMs: null,
+				durationMs: null,
+				endMs: null,
+			},
+		})
+	})
+
+	it('assembles full payload and maps activation/timing/quickLoop', () => {
+		const playlist = makePlaylist({
+			activationId: protectString('activation0'),
+			rehearsal: true,
+			quickLoop: makeQuickLoop(),
+			currentPartInfo: { partInstanceId: protectString('current_pi') },
+			nextPartInfo: { partInstanceId: protectString('next_pi') },
+			timing: { type: PlaylistTimingType.BackTime, expectedDuration: 15000 },
+		})
+
+		const result = toResolvedPlaylistStatus({
+			playlistState: playlist,
+			rundownsState: [makeRundown('rundown0'), makeRundown('rundown1')],
+			showStyleBaseExtState: makeTestShowStyleBaseExt(),
+			segmentsState: [makeSegment('segment0', 'rundown0', 0)],
+			partsState: [makePart('part0', 'rundown0', 'segment0', 0)],
+			partInstancesInPlaylistState: [
+				makePartInstance('current_pi', 'part0', 'segment0', 'rundown0'),
+				makePartInstance('next_pi', 'part0', 'segment0', 'rundown0'),
+			],
+			piecesInPlaylistState: [makePieceInstance('piece0').piece],
+			pieceInstancesInPlaylistState: [makePieceInstance('piece0')],
+		})
+
+		expect(result.activationStatus).toBe(PlaylistActivationStatus.REHEARSAL)
+		expect(result.currentPartInstanceId).toBe('current_pi')
+		expect(result.nextPartInstanceId).toBe('next_pi')
+		expect(result.timing).toMatchObject({
+			type: ResolvedPlaylistTimingType.BACK,
+			startMs: 0,
+			durationMs: 15000,
+			endMs: 15000,
+		})
+		expect(result.quickLoop).toBeDefined()
+		expect(result.rundowns).toEqual([{ id: 'rundown0' }, { id: 'rundown1' }])
+	})
+})

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPlaylistStatus.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPlaylistStatus.spec.ts
@@ -39,9 +39,9 @@ describe('toResolvedPlaylistStatus', () => {
 			rundowns: [],
 			timing: {
 				type: ResolvedPlaylistTimingType.FORWARD,
-				startMs: null,
-				durationMs: null,
-				endMs: null,
+				startedPlayback: null,
+				expectedDurationMs: null,
+				expectedEnd: null,
 			},
 		})
 	})
@@ -53,7 +53,8 @@ describe('toResolvedPlaylistStatus', () => {
 			quickLoop: makeQuickLoop(),
 			currentPartInfo: { partInstanceId: protectString('current_pi') },
 			nextPartInfo: { partInstanceId: protectString('next_pi') },
-			timing: { type: PlaylistTimingType.BackTime, expectedDuration: 15000 },
+			startedPlayback: 1706371806000,
+			timing: { type: PlaylistTimingType.BackTime, expectedDuration: 15000, expectedEnd: 1706371821000 },
 		})
 
 		const result = toResolvedPlaylistStatus({
@@ -75,9 +76,9 @@ describe('toResolvedPlaylistStatus', () => {
 		expect(result.nextPartInstanceId).toBe('next_pi')
 		expect(result.timing).toMatchObject({
 			type: ResolvedPlaylistTimingType.BACK,
-			startMs: 0,
-			durationMs: 15000,
-			endMs: 15000,
+			startedPlayback: 1706371806000,
+			expectedDurationMs: 15000,
+			expectedEnd: 1706371821000,
 		})
 		expect(result.quickLoop).toBeDefined()
 		expect(result.rundowns).toEqual([{ id: 'rundown0' }, { id: 'rundown1' }])

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPlaylistStatus.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedPlaylistStatus.spec.ts
@@ -82,4 +82,39 @@ describe('toResolvedPlaylistStatus', () => {
 		expect(result.quickLoop).toBeDefined()
 		expect(result.rundowns).toEqual([{ id: 'rundown0' }, { id: 'rundown1' }])
 	})
+
+	it('warns and omits quickLoop markers with unknown markerType', () => {
+		const unknownMarkerType = 'unknownMarkerType'
+		const mockLogger = { warn: jest.fn() } as any
+
+		const playlist = makePlaylist({
+			quickLoop: {
+				locked: false,
+				running: true,
+				start: { type: unknownMarkerType },
+				end: { type: 'rundown', id: protectString('rundown0') },
+			} as any,
+		})
+
+		const result = toResolvedPlaylistStatus({
+			playlistState: playlist,
+			rundownsState: [makeRundown('rundown0'), makeRundown('rundown1')],
+			showStyleBaseExtState: makeTestShowStyleBaseExt(),
+			segmentsState: [],
+			partsState: [],
+			partInstancesInPlaylistState: [],
+			piecesInPlaylistState: [],
+			pieceInstancesInPlaylistState: [],
+			logger: mockLogger,
+		})
+
+		expect(result.quickLoop?.start).toBeUndefined()
+		expect(result.quickLoop?.end).toMatchObject({ markerType: 'rundown', rundownId: 'rundown0' })
+
+		expect(mockLogger.warn).toHaveBeenCalledTimes(1)
+		expect(mockLogger.warn).toHaveBeenCalledWith(
+			'Unknown QuickLoop markerType encountered; omitting marker',
+			expect.objectContaining({ markerType: unknownMarkerType })
+		)
+	})
 })

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedRundownStatus.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedRundownStatus.spec.ts
@@ -1,0 +1,57 @@
+import { toResolvedRundownStatus } from '../rundowns/toResolvedRundownStatus.js'
+import {
+	makePart,
+	makePartInstance,
+	makePlaylist,
+	makeRundown,
+	makeSegment,
+	makeTestShowStyleBaseExt,
+} from './resolvedPlaylistConversionTestUtils.js'
+import { createResolvedPlaylistConversionContext } from '../context/conversionContext.js'
+
+jest.mock('../segments/toResolvedSegmentStatus.js', () => ({
+	toResolvedSegmentStatus: jest.fn((_ctx, segment) => ({ id: String(segment._id) })),
+}))
+
+describe('toResolvedRundownStatus', () => {
+	it('maps rundown fields and ordered segments', () => {
+		const ctx = createResolvedPlaylistConversionContext({
+			playlistState: makePlaylist(),
+			rundownsState: [makeRundown('rundown0')],
+			showStyleBaseExtState: makeTestShowStyleBaseExt(),
+			segmentsState: [makeSegment('segment1', 'rundown0', 2), makeSegment('segment0', 'rundown0', 1)],
+			partsState: [makePart('part0', 'rundown0', 'segment0', 0)],
+			partInstancesInPlaylistState: [makePartInstance('pi0', 'part0', 'segment0', 'rundown0')],
+			piecesInPlaylistState: [],
+			pieceInstancesInPlaylistState: [],
+		})
+
+		const result = toResolvedRundownStatus(ctx, 'rundown0')
+		expect(result).toMatchObject({
+			id: 'rundown0',
+			externalId: 'ext_rundown0',
+			name: 'Rundown rundown0',
+			rank: 0,
+			description: 'Description rundown0',
+		})
+		expect(result.segments).toEqual([{ id: 'segment0' }, { id: 'segment1' }])
+	})
+
+	it('returns empty defaults when rundown is missing', () => {
+		const ctx = createResolvedPlaylistConversionContext({
+			playlistState: makePlaylist(),
+			rundownsState: [],
+			showStyleBaseExtState: makeTestShowStyleBaseExt(),
+			segmentsState: [],
+			partsState: [],
+			partInstancesInPlaylistState: [],
+			piecesInPlaylistState: [],
+			pieceInstancesInPlaylistState: [],
+		})
+
+		const result = toResolvedRundownStatus(ctx, 'missing')
+		expect(result.externalId).toBe('')
+		expect(result.segments).toEqual([])
+		expect(result.rank).toBe(0)
+	})
+})

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedRundownStatus.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedRundownStatus.spec.ts
@@ -39,7 +39,7 @@ describe('toResolvedRundownStatus', () => {
 
 	it('returns empty defaults when rundown is missing', () => {
 		const ctx = createResolvedPlaylistConversionContext({
-			playlistState: makePlaylist(),
+			playlistState: makePlaylist({ rundownIdsInOrder: ['rundown0'] }),
 			rundownsState: [],
 			showStyleBaseExtState: makeTestShowStyleBaseExt(),
 			segmentsState: [],
@@ -49,9 +49,24 @@ describe('toResolvedRundownStatus', () => {
 			pieceInstancesInPlaylistState: [],
 		})
 
-		const result = toResolvedRundownStatus(ctx, 'missing')
+		const result = toResolvedRundownStatus(ctx, 'rundown0')
 		expect(result.externalId).toBe('')
 		expect(result.segments).toEqual([])
 		expect(result.rank).toBe(0)
+	})
+
+	it('throws when rundownId is not in orderedRundownIds', () => {
+		const ctx = createResolvedPlaylistConversionContext({
+			playlistState: makePlaylist({ rundownIdsInOrder: ['rundown0'] }),
+			rundownsState: [makeRundown('rundown0')],
+			showStyleBaseExtState: makeTestShowStyleBaseExt(),
+			segmentsState: [],
+			partsState: [],
+			partInstancesInPlaylistState: [],
+			piecesInPlaylistState: [],
+			pieceInstancesInPlaylistState: [],
+		})
+
+		expect(() => toResolvedRundownStatus(ctx, 'missing')).toThrow(/orderedRundownIds/)
 	})
 })

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedSegmentStatus.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedSegmentStatus.spec.ts
@@ -1,0 +1,68 @@
+import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import { getResolvedSegment } from '@sofie-automation/corelib/dist/playout/stateCacheResolver'
+import { toResolvedSegmentStatus } from '../segments/toResolvedSegmentStatus.js'
+import {
+	makePart,
+	makePartInstance,
+	makePieceInstance,
+	makePlaylist,
+	makeRundown,
+	makeSegment,
+	makeTestShowStyleBaseExt,
+} from './resolvedPlaylistConversionTestUtils.js'
+import { createResolvedPlaylistConversionContext } from '../context/conversionContext.js'
+
+jest.mock('@sofie-automation/corelib/dist/playout/stateCacheResolver', () => ({
+	getResolvedSegment: jest.fn(),
+}))
+
+describe('toResolvedSegmentStatus', () => {
+	it('maps resolved segment to API shape and sorts layers', () => {
+		;(getResolvedSegment as jest.Mock).mockReturnValue({
+			segmentExtended: {
+				sourceLayers: {
+					sl2: { _rank: 2, name: 'SL2', abbreviation: 'S2', isHidden: true, type: 3 },
+					sl1: { _rank: 1, name: 'SL1', abbreviation: 'S1', isHidden: false, type: 2 },
+				},
+				outputLayers: {
+					ol2: { name: 'Output B', isFlattened: true, isPGM: false, sourceLayers: [{ _id: 'sl2' }] },
+					ol1: { name: 'Output A', isFlattened: false, isPGM: true, sourceLayers: [{ _id: 'sl1' }] },
+				},
+			},
+			parts: [
+				{
+					partId: protectString('part0'),
+					instance: makePartInstance('pi0', 'part0', 'segment0', 'rundown0'),
+					pieces: [{ instance: makePieceInstance('piece0') }],
+				},
+			],
+		})
+
+		const segment = makeSegment('segment0', 'rundown0', 1)
+		const rundown = makeRundown('rundown0')
+		const ctx = createResolvedPlaylistConversionContext({
+			playlistState: makePlaylist(),
+			rundownsState: [rundown],
+			showStyleBaseExtState: makeTestShowStyleBaseExt(),
+			segmentsState: [segment],
+			partsState: [makePart('part0', 'rundown0', 'segment0', 1)],
+			partInstancesInPlaylistState: [makePartInstance('pi0', 'part0', 'segment0', 'rundown0')],
+			piecesInPlaylistState: [makePieceInstance('piece0').piece],
+			pieceInstancesInPlaylistState: [makePieceInstance('piece0')],
+		})
+
+		const result = toResolvedSegmentStatus(ctx, segment, rundown)
+		expect(result).toMatchObject({
+			id: 'segment0',
+			externalId: 'ext_segment0',
+			identifier: 'ident_segment0',
+			name: 'Segment segment0',
+			rank: 1,
+			isHidden: false,
+			timing: { startMs: 0, endMs: 3000, budgetDurationMs: 3000 },
+		})
+		expect(result.sourceLayers.map((s) => s.id)).toEqual(['sl1', 'sl2'])
+		expect(result.outputLayers.map((s) => s.id)).toEqual(['ol1', 'ol2'])
+		expect(result.parts).toHaveLength(1)
+	})
+})

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedSegmentStatus.spec.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/__tests__/toResolvedSegmentStatus.spec.ts
@@ -65,4 +65,54 @@ describe('toResolvedSegmentStatus', () => {
 		expect(result.outputLayers.map((s) => s.id)).toEqual(['ol1', 'ol2'])
 		expect(result.parts).toHaveLength(1)
 	})
+
+	it('resolves per-rundown showStyleBaseExt in mixed-showstyle playlists', () => {
+		const showStyleBaseExtA = makeTestShowStyleBaseExt()
+		const showStyleBaseExtB = {
+			...makeTestShowStyleBaseExt(),
+			_id: protectString('showStyleBaseB'),
+			sourceLayerNamesById: new Map([['sourceLayerX', 'SourceLayerX_fromShowStyleB']]),
+			outputLayerNamesById: new Map([['outputLayerX', 'OutputLayerX_fromShowStyleB']]),
+		}
+
+		;(getResolvedSegment as jest.Mock).mockReturnValue({
+			segmentExtended: {
+				sourceLayers: {
+					sourceLayerX: { _rank: 1 },
+				},
+				outputLayers: {
+					outputLayerX: { sourceLayers: [{ _id: 'sourceLayerX' }] },
+				},
+			},
+			parts: [],
+		})
+
+		const rundown0 = makeRundown('rundown0')
+		const rundown1 = makeRundown('rundown1')
+		rundown0.showStyleBaseId = showStyleBaseExtA._id
+		rundown1.showStyleBaseId = showStyleBaseExtB._id
+
+		const segment = makeSegment('segment1', 'rundown1', 1)
+		const ctx = createResolvedPlaylistConversionContext({
+			playlistState: makePlaylist(),
+			rundownsState: [rundown0, rundown1],
+			// Fallback showstyle:
+			showStyleBaseExtState: showStyleBaseExtA,
+			showStyleBaseExtsByIdState: new Map([
+				[showStyleBaseExtA._id, showStyleBaseExtA],
+				[showStyleBaseExtB._id, showStyleBaseExtB],
+			]),
+			segmentsState: [segment],
+			partsState: [],
+			partInstancesInPlaylistState: [],
+			piecesInPlaylistState: [],
+			pieceInstancesInPlaylistState: [],
+		})
+
+		const result = toResolvedSegmentStatus(ctx, segment, rundown1)
+
+		expect(getResolvedSegment).toHaveBeenCalledWith(expect.objectContaining({ showStyleBase: showStyleBaseExtB }))
+		expect(result.sourceLayers).toMatchObject([{ id: 'sourceLayerX', name: 'SourceLayerX_fromShowStyleB' }])
+		expect(result.outputLayers).toMatchObject([{ id: 'outputLayerX', name: 'OutputLayerX_fromShowStyleB' }])
+	})
 })

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/context/conversionContext.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/context/conversionContext.ts
@@ -38,6 +38,10 @@ export type ResolvedPlaylistConversionContext = Readonly<{
 	accessors: ReturnType<typeof createQueryAdapters>
 }>
 
+/**
+ * Creates a normalized lookup context used by all resolved-playlist converters.
+ * This keeps conversion functions deterministic and avoids repeated map/filter work.
+ */
 export function createResolvedPlaylistConversionContext(
 	props: ToResolvedPlaylistStatusProps
 ): ResolvedPlaylistConversionContext {
@@ -100,16 +104,19 @@ function groupByRundownId<T extends { rundownId: unknown }>(items: T[]): Map<str
 	return map
 }
 
+/** Returns segments in rundown order so API consumers get stable ranks. */
 export function getOrderedSegmentsInRundown(ctx: ResolvedPlaylistConversionContext, rundownId: string): DBSegment[] {
 	const list = ctx.segmentsByRundownId.get(String(rundownId)) ?? []
 	return list.slice().sort((a, b) => a._rank - b._rank)
 }
 
+/** Returns parts in rundown order for state resolver and API output parity. */
 export function getOrderedPartsInRundown(ctx: ResolvedPlaylistConversionContext, rundownId: string): DBPart[] {
 	const list = ctx.partsByRundownId.get(String(rundownId)) ?? []
 	return list.slice().sort((a, b) => a._rank - b._rank)
 }
 
+/** Finds the current part instance referenced by playlist state. */
 export function findCurrentPartInstance(
 	playlist: DBRundownPlaylist,
 	partInstancesInPlaylistState: PartInstance[]
@@ -117,6 +124,7 @@ export function findCurrentPartInstance(
 	return partInstancesInPlaylistState.find((pi) => pi._id === playlist.currentPartInfo?.partInstanceId)
 }
 
+/** Finds the next part instance referenced by playlist state. */
 export function findNextPartInstance(
 	playlist: DBRundownPlaylist,
 	partInstancesInPlaylistState: PartInstance[]
@@ -137,6 +145,7 @@ function createQueryAdapters({
 	piecesInPlaylistState: Piece[]
 	pieceInstancesInPlaylistState: PieceInstance[]
 }): StateCacheResolverDataAccess {
+	// Adapter surface expected by `getResolvedSegment`
 	return {
 		segmentsFindOne: (selector, _options): DBSegment | undefined => {
 			const segmentId: DBSegment['_id'] | undefined =

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/context/conversionContext.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/context/conversionContext.ts
@@ -55,9 +55,12 @@ export function createResolvedPlaylistConversionContext(
 
 	const orderedRundownIds = (playlist.rundownIdsInOrder ?? []).map((r) => unprotectString(r))
 	const rundownsById = new Map<string, DBRundown>((props.rundownsState ?? []).map((r) => [unprotectString(r._id), r]))
-	const rundownsToShowStyles = new Map<RundownId, ShowStyleBaseId>(
-		(playlist.rundownIdsInOrder ?? []).map((r) => [r, showStyleBaseExt._id])
-	)
+	const rundownsToShowStyles = new Map<RundownId, ShowStyleBaseId>()
+	for (const rundownId of playlist.rundownIdsInOrder ?? []) {
+		const rundown = rundownsById.get(unprotectString(rundownId))
+		if (!rundown) continue
+		rundownsToShowStyles.set(rundownId, rundown.showStyleBaseId)
+	}
 
 	const segmentsByRundownId = groupByRundownId(props.segmentsState)
 	const partsByRundownId = groupByRundownId(props.partsState)
@@ -106,8 +109,30 @@ export function getOrderedSegmentsInRundown(ctx: ResolvedPlaylistConversionConte
 
 /** Returns parts in rundown order for state resolver and API output parity. */
 export function getOrderedPartsInRundown(ctx: ResolvedPlaylistConversionContext, rundownId: string): DBPart[] {
-	const list = ctx.partsByRundownId.get(String(rundownId)) ?? []
-	return list.slice().sort((a, b) => a._rank - b._rank)
+	const normalizedRundownId = String(rundownId)
+
+	const partsInRundown = ctx.partsByRundownId.get(normalizedRundownId) ?? []
+	if (partsInRundown.length === 0) return []
+
+	// Part._rank is only meaningful within a segment, so we must preserve segment order.
+	const partsBySegmentId = new Map<string, DBPart[]>()
+	for (const part of partsInRundown) {
+		const segmentId = String(part.segmentId)
+		const list = partsBySegmentId.get(segmentId) ?? []
+		list.push(part)
+		partsBySegmentId.set(segmentId, list)
+	}
+
+	const orderedSegments = getOrderedSegmentsInRundown(ctx, normalizedRundownId)
+	const orderedParts: DBPart[] = []
+	for (const segment of orderedSegments) {
+		const segmentParts = partsBySegmentId.get(String(segment._id))
+		if (!segmentParts?.length) continue
+		segmentParts.sort((a, b) => a._rank - b._rank)
+		orderedParts.push(...segmentParts)
+	}
+
+	return orderedParts
 }
 
 /** Finds the current part instance referenced by playlist state. */
@@ -162,9 +187,8 @@ function createQueryAdapters({
 			}
 		},
 		getActivePartInstances: (_playlistPick: Pick<DBRundownPlaylist, '_id'>, selector?: unknown) => {
-			return selector
-				? mongoWhereFilter(partInstancesInPlaylistState, selector as never)
-				: partInstancesInPlaylistState
+			const mergedSelector = selector ? { ...(selector as any), reset: { $ne: true } } : { reset: { $ne: true } }
+			return mongoWhereFilter(partInstancesInPlaylistState, mergedSelector as never)
 		},
 		piecesFind: (selector) => {
 			if (!selector) return piecesInPlaylistState

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/context/conversionContext.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/context/conversionContext.ts
@@ -8,6 +8,7 @@ import type { PartInstance } from '@sofie-automation/corelib/dist/dataModel/Part
 import type { Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
 import type { PieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
 import type { StateCacheResolverDataAccess } from '@sofie-automation/corelib/dist/playout/stateCacheResolverTypes'
+import { RundownId, ShowStyleBaseId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { ShowStyleBaseExt } from '../../../../collections/showStyleBaseHandler.js'
 
 export type ToResolvedPlaylistStatusProps = {
@@ -26,7 +27,7 @@ export type ResolvedPlaylistConversionContext = Readonly<{
 	rundownsById: Map<string, DBRundown>
 	showStyleBaseExt: ShowStyleBaseExt
 
-	rundownsToShowStyles: Map<string, ShowStyleBaseExt['_id']>
+	rundownsToShowStyles: ReadonlyMap<RundownId, ShowStyleBaseId>
 	orderedRundownIds: string[]
 
 	segmentsByRundownId: Map<string, DBSegment[]>
@@ -52,17 +53,10 @@ export function createResolvedPlaylistConversionContext(
 		throw new Error('Missing playlist or showStyleBaseExt')
 	}
 
-	const orderedRundownIds = (playlist.rundownIdsInOrder ?? []).map(
-		(r: DBRundownPlaylist['rundownIdsInOrder'][number]) => unprotectString(r)
-	)
-	const rundownsById = new Map<string, DBRundown>(
-		(props.rundownsState ?? []).map((r: DBRundown) => [unprotectString(r._id), r])
-	)
-	const rundownsToShowStyles = new Map<string, ShowStyleBaseExt['_id']>(
-		(playlist.rundownIdsInOrder ?? []).map((r: DBRundownPlaylist['rundownIdsInOrder'][number]) => [
-			String(r),
-			showStyleBaseExt._id,
-		])
+	const orderedRundownIds = (playlist.rundownIdsInOrder ?? []).map((r) => unprotectString(r))
+	const rundownsById = new Map<string, DBRundown>((props.rundownsState ?? []).map((r) => [unprotectString(r._id), r]))
+	const rundownsToShowStyles = new Map<RundownId, ShowStyleBaseId>(
+		(playlist.rundownIdsInOrder ?? []).map((r) => [r, showStyleBaseExt._id])
 	)
 
 	const segmentsByRundownId = groupByRundownId(props.segmentsState)

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/context/conversionContext.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/context/conversionContext.ts
@@ -1,0 +1,177 @@
+import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
+import { mongoWhereFilter } from '@sofie-automation/corelib/dist/mongo'
+import type { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist/RundownPlaylist'
+import type { DBRundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
+import type { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
+import type { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
+import type { PartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
+import type { Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
+import type { PieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
+import type { StateCacheResolverDataAccess } from '@sofie-automation/corelib/dist/playout/stateCacheResolverTypes'
+import { ShowStyleBaseExt } from '../../../../collections/showStyleBaseHandler.js'
+
+export type ToResolvedPlaylistStatusProps = {
+	playlistState: DBRundownPlaylist | undefined
+	rundownsState: DBRundown[]
+	showStyleBaseExtState: ShowStyleBaseExt | undefined
+	segmentsState: DBSegment[]
+	partsState: DBPart[]
+	partInstancesInPlaylistState: PartInstance[]
+	piecesInPlaylistState: Piece[]
+	pieceInstancesInPlaylistState: PieceInstance[]
+}
+
+export type ResolvedPlaylistConversionContext = Readonly<{
+	playlist: DBRundownPlaylist
+	rundownsById: Map<string, DBRundown>
+	showStyleBaseExt: ShowStyleBaseExt
+
+	rundownsToShowStyles: Map<string, ShowStyleBaseExt['_id']>
+	orderedRundownIds: string[]
+
+	segmentsByRundownId: Map<string, DBSegment[]>
+	partsByRundownId: Map<string, DBPart[]>
+
+	currentPartInstance: PartInstance | undefined
+	nextPartInstance: PartInstance | undefined
+
+	accessors: ReturnType<typeof createQueryAdapters>
+}>
+
+export function createResolvedPlaylistConversionContext(
+	props: ToResolvedPlaylistStatusProps
+): ResolvedPlaylistConversionContext {
+	const playlist = props.playlistState
+	const showStyleBaseExt = props.showStyleBaseExtState
+
+	if (!playlist || !showStyleBaseExt) {
+		throw new Error('Missing playlist or showStyleBaseExt')
+	}
+
+	const orderedRundownIds = (playlist.rundownIdsInOrder ?? []).map(
+		(r: DBRundownPlaylist['rundownIdsInOrder'][number]) => unprotectString(r)
+	)
+	const rundownsById = new Map<string, DBRundown>(
+		(props.rundownsState ?? []).map((r: DBRundown) => [unprotectString(r._id), r])
+	)
+	const rundownsToShowStyles = new Map<string, ShowStyleBaseExt['_id']>(
+		(playlist.rundownIdsInOrder ?? []).map((r: DBRundownPlaylist['rundownIdsInOrder'][number]) => [
+			String(r),
+			showStyleBaseExt._id,
+		])
+	)
+
+	const segmentsByRundownId = groupByRundownId(props.segmentsState)
+	const partsByRundownId = groupByRundownId(props.partsState)
+
+	const currentPartInstance = findCurrentPartInstance(playlist, props.partInstancesInPlaylistState)
+	const nextPartInstance = findNextPartInstance(playlist, props.partInstancesInPlaylistState)
+
+	const accessors = createQueryAdapters({
+		segmentsState: props.segmentsState,
+		partsState: props.partsState,
+		partInstancesInPlaylistState: props.partInstancesInPlaylistState,
+		piecesInPlaylistState: props.piecesInPlaylistState,
+		pieceInstancesInPlaylistState: props.pieceInstancesInPlaylistState,
+	})
+
+	return {
+		playlist,
+		rundownsById,
+		showStyleBaseExt,
+		rundownsToShowStyles,
+		orderedRundownIds,
+		segmentsByRundownId,
+		partsByRundownId,
+		currentPartInstance,
+		nextPartInstance,
+		accessors,
+	}
+}
+
+function groupByRundownId<T extends { rundownId: unknown }>(items: T[]): Map<string, T[]> {
+	const map = new Map<string, T[]>()
+	for (const item of items ?? []) {
+		const rundownId = String(item.rundownId)
+		const list = map.get(rundownId) ?? ([] as T[])
+		list.push(item)
+		map.set(rundownId, list)
+	}
+	return map
+}
+
+export function getOrderedSegmentsInRundown(ctx: ResolvedPlaylistConversionContext, rundownId: string): DBSegment[] {
+	const list = ctx.segmentsByRundownId.get(String(rundownId)) ?? []
+	return list.slice().sort((a, b) => a._rank - b._rank)
+}
+
+export function getOrderedPartsInRundown(ctx: ResolvedPlaylistConversionContext, rundownId: string): DBPart[] {
+	const list = ctx.partsByRundownId.get(String(rundownId)) ?? []
+	return list.slice().sort((a, b) => a._rank - b._rank)
+}
+
+export function findCurrentPartInstance(
+	playlist: DBRundownPlaylist,
+	partInstancesInPlaylistState: PartInstance[]
+): PartInstance | undefined {
+	return partInstancesInPlaylistState.find((pi) => pi._id === playlist.currentPartInfo?.partInstanceId)
+}
+
+export function findNextPartInstance(
+	playlist: DBRundownPlaylist,
+	partInstancesInPlaylistState: PartInstance[]
+): PartInstance | undefined {
+	return partInstancesInPlaylistState.find((pi) => pi._id === playlist.nextPartInfo?.partInstanceId)
+}
+
+function createQueryAdapters({
+	segmentsState,
+	partsState,
+	partInstancesInPlaylistState,
+	piecesInPlaylistState,
+	pieceInstancesInPlaylistState,
+}: {
+	segmentsState: DBSegment[]
+	partsState: DBPart[]
+	partInstancesInPlaylistState: PartInstance[]
+	piecesInPlaylistState: Piece[]
+	pieceInstancesInPlaylistState: PieceInstance[]
+}): StateCacheResolverDataAccess {
+	return {
+		segmentsFindOne: (selector, _options): DBSegment | undefined => {
+			const segmentId: DBSegment['_id'] | undefined =
+				typeof selector === 'object' && selector !== null && '_id' in selector
+					? (selector._id as DBSegment['_id'] | undefined)
+					: (selector as DBSegment['_id'])
+			if (!segmentId) return undefined
+			const normalizedSelectorId = unprotectString(segmentId)
+			return segmentsState.find((s) => unprotectString(s._id) === normalizedSelectorId)
+		},
+		getSegmentsAndPartsSync: (playlistPick, segmentsQuery, partsQuery) => {
+			const rundownIds = new Set(playlistPick.rundownIdsInOrder ?? [])
+			const segmentsInRundowns = segmentsState.filter((s) => rundownIds.has(s.rundownId))
+			const partsInRundowns = partsState.filter((p) => rundownIds.has(p.rundownId))
+			return {
+				segments: segmentsQuery
+					? mongoWhereFilter(segmentsInRundowns, segmentsQuery as never)
+					: segmentsInRundowns,
+				parts: partsQuery ? mongoWhereFilter(partsInRundowns, partsQuery as never) : partsInRundowns,
+			}
+		},
+		getActivePartInstances: (_playlistPick: Pick<DBRundownPlaylist, '_id'>, selector?: unknown) => {
+			return selector
+				? mongoWhereFilter(partInstancesInPlaylistState, selector as never)
+				: partInstancesInPlaylistState
+		},
+		piecesFind: (selector) => {
+			if (!selector) return piecesInPlaylistState
+			if (typeof selector === 'string') return piecesInPlaylistState.filter((p) => p._id === selector)
+			return mongoWhereFilter(piecesInPlaylistState, selector as never)
+		},
+		pieceInstancesFind: (selector) => {
+			if (!selector) return pieceInstancesInPlaylistState
+			if (typeof selector === 'string') return pieceInstancesInPlaylistState.filter((pi) => pi._id === selector)
+			return mongoWhereFilter(pieceInstancesInPlaylistState, selector as never)
+		},
+	}
+}

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/context/conversionContext.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/context/conversionContext.ts
@@ -167,13 +167,13 @@ function createQueryAdapters({
 	// Adapter surface expected by `getResolvedSegment`
 	return {
 		segmentsFindOne: (selector, _options): DBSegment | undefined => {
-			const segmentId: DBSegment['_id'] | undefined =
-				typeof selector === 'object' && selector !== null && '_id' in selector
-					? (selector._id as DBSegment['_id'] | undefined)
-					: (selector as DBSegment['_id'])
-			if (!segmentId) return undefined
-			const normalizedSelectorId = unprotectString(segmentId)
-			return segmentsState.find((s) => unprotectString(s._id) === normalizedSelectorId)
+			if (!selector) return undefined
+			if (typeof selector === 'string') {
+				const normalizedSelectorId = unprotectString(selector as any)
+				return segmentsState.find((s) => unprotectString(s._id) === normalizedSelectorId)
+			}
+
+			return mongoWhereFilter(segmentsState, selector as never)[0]
 		},
 		getSegmentsAndPartsSync: (playlistPick, segmentsQuery, partsQuery) => {
 			const rundownIds = new Set(playlistPick.rundownIdsInOrder ?? [])

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/context/conversionContext.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/context/conversionContext.ts
@@ -36,6 +36,7 @@ export type ToResolvedPlaylistStatusProps = {
 	playlistState: PlaylistState | undefined
 	rundownsState: DBRundown[]
 	showStyleBaseExtState: ShowStyleBaseExt | undefined
+	showStyleBaseExtsByIdState?: ReadonlyMap<ShowStyleBaseId, ShowStyleBaseExt>
 	segmentsState: DBSegment[]
 	partsState: DBPart[]
 	partInstancesInPlaylistState: PartInstance[]
@@ -49,6 +50,7 @@ export type ResolvedPlaylistConversionContext = Readonly<{
 	showStyleBaseExt: ShowStyleBaseExt
 
 	rundownsToShowStyles: ReadonlyMap<RundownId, ShowStyleBaseId>
+	rundownsToShowStyleBaseExt: ReadonlyMap<RundownId, ShowStyleBaseExt>
 	orderedRundownIds: string[]
 
 	segmentsByRundownId: Map<string, DBSegment[]>
@@ -77,10 +79,13 @@ export function createResolvedPlaylistConversionContext(
 	const orderedRundownIds = (playlist.rundownIdsInOrder ?? []).map((r) => unprotectString(r))
 	const rundownsById = new Map<string, DBRundown>((props.rundownsState ?? []).map((r) => [unprotectString(r._id), r]))
 	const rundownsToShowStyles = new Map<RundownId, ShowStyleBaseId>()
+	const rundownsToShowStyleBaseExt = new Map<RundownId, ShowStyleBaseExt>()
 	for (const rundownId of playlist.rundownIdsInOrder ?? []) {
 		const rundown = rundownsById.get(unprotectString(rundownId))
 		if (!rundown) continue
 		rundownsToShowStyles.set(rundownId, rundown.showStyleBaseId)
+		const showStyle = props.showStyleBaseExtsByIdState?.get(rundown.showStyleBaseId)
+		if (showStyle) rundownsToShowStyleBaseExt.set(rundownId, showStyle)
 	}
 
 	const segmentsByRundownId = groupByRundownId(props.segmentsState)
@@ -102,6 +107,7 @@ export function createResolvedPlaylistConversionContext(
 		rundownsById,
 		showStyleBaseExt,
 		rundownsToShowStyles,
+		rundownsToShowStyleBaseExt,
 		orderedRundownIds,
 		segmentsByRundownId,
 		partsByRundownId,

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/context/conversionContext.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/context/conversionContext.ts
@@ -29,6 +29,7 @@ type PlaylistState = Pick<
 	| 'publicData'
 	| 'publicPlayoutPersistentState'
 	| 'timing'
+	| 'startedPlayback'
 	| 'tTimers'
 >
 

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/context/conversionContext.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/context/conversionContext.ts
@@ -11,8 +11,29 @@ import type { StateCacheResolverDataAccess } from '@sofie-automation/corelib/dis
 import { RundownId, ShowStyleBaseId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { ShowStyleBaseExt } from '../../../../collections/showStyleBaseHandler.js'
 
+type PlaylistState = Pick<
+	DBRundownPlaylist,
+	| '_id'
+	| 'studioId'
+	| 'created'
+	| 'modified'
+	| 'externalId'
+	| 'activationId'
+	| 'rehearsal'
+	| 'name'
+	| 'rundownIdsInOrder'
+	| 'quickLoop'
+	| 'currentPartInfo'
+	| 'nextPartInfo'
+	| 'previousPartInfo'
+	| 'publicData'
+	| 'publicPlayoutPersistentState'
+	| 'timing'
+	| 'tTimers'
+>
+
 export type ToResolvedPlaylistStatusProps = {
-	playlistState: DBRundownPlaylist | undefined
+	playlistState: PlaylistState | undefined
 	rundownsState: DBRundown[]
 	showStyleBaseExtState: ShowStyleBaseExt | undefined
 	segmentsState: DBSegment[]
@@ -23,7 +44,7 @@ export type ToResolvedPlaylistStatusProps = {
 }
 
 export type ResolvedPlaylistConversionContext = Readonly<{
-	playlist: DBRundownPlaylist
+	playlist: PlaylistState
 	rundownsById: Map<string, DBRundown>
 	showStyleBaseExt: ShowStyleBaseExt
 
@@ -137,7 +158,7 @@ export function getOrderedPartsInRundown(ctx: ResolvedPlaylistConversionContext,
 
 /** Finds the current part instance referenced by playlist state. */
 export function findCurrentPartInstance(
-	playlist: DBRundownPlaylist,
+	playlist: PlaylistState,
 	partInstancesInPlaylistState: PartInstance[]
 ): PartInstance | undefined {
 	return partInstancesInPlaylistState.find((pi) => pi._id === playlist.currentPartInfo?.partInstanceId)
@@ -145,7 +166,7 @@ export function findCurrentPartInstance(
 
 /** Finds the next part instance referenced by playlist state. */
 export function findNextPartInstance(
-	playlist: DBRundownPlaylist,
+	playlist: PlaylistState,
 	partInstancesInPlaylistState: PartInstance[]
 ): PartInstance | undefined {
 	return partInstancesInPlaylistState.find((pi) => pi._id === playlist.nextPartInfo?.partInstanceId)

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/events/toResolvedPlaylistStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/events/toResolvedPlaylistStatus.ts
@@ -32,8 +32,6 @@ export function toResolvedPlaylistStatus({
 			activationStatus: PlaylistActivationStatus.DEACTIVATED,
 			currentPartInstanceId: null,
 			nextPartInstanceId: null,
-			playoutState: {},
-			publicData: {},
 			timing: {
 				type: ResolvedPlaylistTimingType.FORWARD,
 				startMs: null,
@@ -88,6 +86,9 @@ export function toResolvedPlaylistStatus({
 			? ResolvedPlaylistTimingType.BACK
 			: ResolvedPlaylistTimingType.FORWARD
 
+	const playoutState = ctx.playlist.publicPlayoutPersistentState
+	const publicData = ctx.playlist.publicData
+
 	return literal<ResolvedPlaylistEvent>({
 		event: 'resolvedPlaylist' as const,
 		id: unprotectString(ctx.playlist._id),
@@ -96,8 +97,8 @@ export function toResolvedPlaylistStatus({
 		activationStatus,
 		currentPartInstanceId,
 		nextPartInstanceId,
-		playoutState: ctx.playlist.publicPlayoutPersistentState,
-		publicData: ctx.playlist.publicData,
+		...(playoutState !== undefined ? { playoutState } : {}),
+		...(publicData !== undefined ? { publicData } : {}),
 		timing: {
 			type: timingType,
 			startMs: 0,

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/events/toResolvedPlaylistStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/events/toResolvedPlaylistStatus.ts
@@ -1,0 +1,114 @@
+import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
+import { literal } from '@sofie-automation/shared-lib/dist/lib/lib'
+import {
+	PlaylistActivationStatus,
+	ResolvedPlaylistTimingType,
+	type ResolvedPlaylistEvent,
+} from '@sofie-automation/live-status-gateway-api'
+import { createResolvedPlaylistConversionContext, ToResolvedPlaylistStatusProps } from '../context/conversionContext.js'
+import { toResolvedRundownStatus } from '../rundowns/toResolvedRundownStatus.js'
+import { toTTimers } from '../../activePlaylistConversion/timers/toTTimers.js'
+import { toQuickLoopStatus } from '../../activePlaylistConversion/quickLoop/toQuickLoopStatus.js'
+import { PlaylistTimingType } from '@sofie-automation/blueprints-integration'
+
+export function toResolvedPlaylistStatus({
+	playlistState,
+	rundownsState,
+	showStyleBaseExtState,
+	segmentsState,
+	partsState,
+	partInstancesInPlaylistState,
+	piecesInPlaylistState,
+	pieceInstancesInPlaylistState,
+}: ToResolvedPlaylistStatusProps): ResolvedPlaylistEvent {
+	// default value
+	if (!playlistState || !showStyleBaseExtState) {
+		return literal<ResolvedPlaylistEvent>({
+			event: 'resolvedPlaylist' as const,
+			id: '',
+			externalId: '',
+			name: '',
+			activationStatus: PlaylistActivationStatus.DEACTIVATED,
+			currentPartInstanceId: null,
+			nextPartInstanceId: null,
+			playoutState: {},
+			publicData: {},
+			timing: {
+				type: ResolvedPlaylistTimingType.FORWARD,
+				startMs: null,
+				durationMs: null,
+				endMs: null,
+			},
+			tTimers: toTTimers(null),
+			quickLoop: null,
+			rundowns: [],
+		})
+	}
+
+	const ctx = createResolvedPlaylistConversionContext({
+		playlistState,
+		rundownsState,
+		showStyleBaseExtState,
+		segmentsState,
+		partsState,
+		partInstancesInPlaylistState,
+		piecesInPlaylistState,
+		pieceInstancesInPlaylistState,
+	})
+
+	let activationStatus: PlaylistActivationStatus =
+		ctx.playlist.activationId === undefined
+			? PlaylistActivationStatus.DEACTIVATED
+			: PlaylistActivationStatus.ACTIVATED
+	if (ctx.playlist.activationId && ctx.playlist.rehearsal) activationStatus = PlaylistActivationStatus.REHEARSAL
+
+	const currentPartInstanceId = ctx.playlist.currentPartInfo?.partInstanceId
+		? unprotectString(ctx.playlist.currentPartInfo.partInstanceId)
+		: null
+	const nextPartInstanceId = ctx.playlist.nextPartInfo?.partInstanceId
+		? unprotectString(ctx.playlist.nextPartInfo.partInstanceId)
+		: null
+
+	const segmentsById = Object.fromEntries(
+		(segmentsState ?? []).map((s) => [unprotectString(s._id), { rundownId: s.rundownId }])
+	) as Record<string, { rundownId?: (typeof segmentsState)[number]['rundownId'] } | undefined>
+	const partsById = Object.fromEntries(
+		(partsState ?? []).map((p) => [unprotectString(p._id), { rundownId: p.rundownId, segmentId: p.segmentId }])
+	) as Record<
+		string,
+		| { rundownId?: (typeof partsState)[number]['rundownId']; segmentId?: (typeof partsState)[number]['segmentId'] }
+		| undefined
+	>
+
+	const timingState = ctx.playlist.timing
+	const durationMs: number | null = timingState?.expectedDuration ?? null
+	const timingType =
+		timingState?.type === PlaylistTimingType.BackTime
+			? ResolvedPlaylistTimingType.BACK
+			: ResolvedPlaylistTimingType.FORWARD
+
+	return literal<ResolvedPlaylistEvent>({
+		event: 'resolvedPlaylist' as const,
+		id: unprotectString(ctx.playlist._id),
+		externalId: ctx.playlist.externalId,
+		name: ctx.playlist.name,
+		activationStatus,
+		currentPartInstanceId,
+		nextPartInstanceId,
+		playoutState: ctx.playlist.publicPlayoutPersistentState,
+		publicData: ctx.playlist.publicData,
+		timing: {
+			type: timingType,
+			startMs: 0,
+			durationMs,
+			endMs: durationMs,
+		},
+		tTimers: toTTimers(ctx.playlist.tTimers ?? null),
+		quickLoop: toQuickLoopStatus({
+			quickLoop: ctx.playlist.quickLoop,
+			segmentsById,
+			partsById,
+		}),
+		rundowns: ctx.orderedRundownIds.map((rundownId) => toResolvedRundownStatus(ctx, rundownId)),
+	})
+}

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/events/toResolvedPlaylistStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/events/toResolvedPlaylistStatus.ts
@@ -11,6 +11,7 @@ import { toTTimers } from '../../activePlaylistConversion/timers/toTTimers.js'
 import { toQuickLoopStatus } from '../../activePlaylistConversion/quickLoop/toQuickLoopStatus.js'
 import { PlaylistTimingType } from '@sofie-automation/blueprints-integration'
 
+/** Converts playlist-scoped collection snapshots into the `resolvedPlaylist` websocket event shape. */
 export function toResolvedPlaylistStatus({
 	playlistState,
 	rundownsState,
@@ -21,7 +22,7 @@ export function toResolvedPlaylistStatus({
 	piecesInPlaylistState,
 	pieceInstancesInPlaylistState,
 }: ToResolvedPlaylistStatusProps): ResolvedPlaylistEvent {
-	// default value
+	// Keep payload shape stable before all dependencies are available.
 	if (!playlistState || !showStyleBaseExtState) {
 		return literal<ResolvedPlaylistEvent>({
 			event: 'resolvedPlaylist' as const,

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/events/toResolvedPlaylistStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/events/toResolvedPlaylistStatus.ts
@@ -1,3 +1,4 @@
+import type { Logger } from 'winston'
 import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 import { literal } from '@sofie-automation/shared-lib/dist/lib/lib'
 import {
@@ -21,7 +22,8 @@ export function toResolvedPlaylistStatus({
 	partInstancesInPlaylistState,
 	piecesInPlaylistState,
 	pieceInstancesInPlaylistState,
-}: ToResolvedPlaylistStatusProps): ResolvedPlaylistEvent {
+	logger,
+}: ToResolvedPlaylistStatusProps & { logger?: Logger }): ResolvedPlaylistEvent {
 	// Keep payload shape stable before all dependencies are available.
 	if (!playlistState || !showStyleBaseExtState) {
 		return literal<ResolvedPlaylistEvent>({
@@ -110,6 +112,7 @@ export function toResolvedPlaylistStatus({
 			quickLoop: ctx.playlist.quickLoop,
 			segmentsById,
 			partsById,
+			logger,
 		}),
 		rundowns: ctx.orderedRundownIds.map((rundownId) => toResolvedRundownStatus(ctx, rundownId)),
 	})

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/events/toResolvedPlaylistStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/events/toResolvedPlaylistStatus.ts
@@ -11,6 +11,7 @@ import { toResolvedRundownStatus } from '../rundowns/toResolvedRundownStatus.js'
 import { toTTimers } from '../../activePlaylistConversion/timers/toTTimers.js'
 import { toQuickLoopStatus } from '../../activePlaylistConversion/quickLoop/toQuickLoopStatus.js'
 import { PlaylistTimingType } from '@sofie-automation/blueprints-integration'
+import { PlaylistTiming } from '@sofie-automation/corelib/dist/playout/rundownTiming'
 
 /** Converts playlist-scoped collection snapshots into the `resolvedPlaylist` websocket event shape. */
 export function toResolvedPlaylistStatus({
@@ -36,9 +37,9 @@ export function toResolvedPlaylistStatus({
 			nextPartInstanceId: null,
 			timing: {
 				type: ResolvedPlaylistTimingType.FORWARD,
-				startMs: null,
-				durationMs: null,
-				endMs: null,
+				startedPlayback: null,
+				expectedDurationMs: null,
+				expectedEnd: null,
 			},
 			tTimers: toTTimers(null),
 			quickLoop: null,
@@ -82,11 +83,14 @@ export function toResolvedPlaylistStatus({
 	>
 
 	const timingState = ctx.playlist.timing
-	const durationMs: number | null = timingState?.expectedDuration ?? null
+	const expectedDurationMs: number | null = timingState?.expectedDuration ?? null
 	const timingType =
 		timingState?.type === PlaylistTimingType.BackTime
 			? ResolvedPlaylistTimingType.BACK
 			: ResolvedPlaylistTimingType.FORWARD
+	const expectedEnd: number | null = timingState
+		? (PlaylistTiming.getExpectedEnd(timingState, ctx.playlist.startedPlayback) ?? null)
+		: null
 
 	const playoutState = ctx.playlist.publicPlayoutPersistentState
 	const publicData = ctx.playlist.publicData
@@ -103,9 +107,9 @@ export function toResolvedPlaylistStatus({
 		...(publicData !== undefined ? { publicData } : {}),
 		timing: {
 			type: timingType,
-			startMs: 0,
-			durationMs,
-			endMs: durationMs,
+			startedPlayback: ctx.playlist.startedPlayback ?? null,
+			expectedDurationMs,
+			expectedEnd,
 		},
 		tTimers: toTTimers(ctx.playlist.tTimers ?? null),
 		quickLoop: toQuickLoopStatus({

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/parts/toResolvedPartStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/parts/toResolvedPartStatus.ts
@@ -4,6 +4,7 @@ import { ResolvedPlaylistConversionContext } from '../context/conversionContext.
 import type { PartExtended } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { ResolvedPart, ResolvedPartState } from '@sofie-automation/live-status-gateway-api'
 
+/** Converts a resolved `PartExtended` model into the gateway API `ResolvedPart` shape. */
 export function toResolvedPartStatus(ctx: ResolvedPlaylistConversionContext, partExtended: PartExtended): ResolvedPart {
 	const part = partExtended
 	const instance = part.instance

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/parts/toResolvedPartStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/parts/toResolvedPartStatus.ts
@@ -36,6 +36,7 @@ export function toResolvedPartStatus(ctx: ResolvedPlaylistConversionContext, par
 		rank: basePart._rank ?? 0,
 		autoNext: !!basePart.autoNext,
 		invalid: !!basePart.invalid,
+		floated: !!basePart.floated,
 		invalidReason: basePart.invalidReason ? toApiPartInvalidReason(basePart.invalidReason) : undefined,
 		state,
 		publicData: basePart.publicData,

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/parts/toResolvedPartStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/parts/toResolvedPartStatus.ts
@@ -37,6 +37,7 @@ export function toResolvedPartStatus(ctx: ResolvedPlaylistConversionContext, par
 		autoNext: !!basePart.autoNext,
 		invalid: !!basePart.invalid,
 		floated: !!basePart.floated,
+		untimed: !!basePart.untimed,
 		invalidReason: basePart.invalidReason ? toApiPartInvalidReason(basePart.invalidReason) : undefined,
 		state,
 		publicData: basePart.publicData,

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/parts/toResolvedPartStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/parts/toResolvedPartStatus.ts
@@ -2,7 +2,10 @@ import { toResolvedPieceStatus } from '../pieces/toResolvedPieceStatus.js'
 import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 import { ResolvedPlaylistConversionContext } from '../context/conversionContext.js'
 import type { PartExtended } from '@sofie-automation/corelib/dist/dataModel/Part'
-import { ResolvedPart, ResolvedPartState } from '@sofie-automation/live-status-gateway-api'
+import type { PartInvalidReason as CorePartInvalidReason } from '@sofie-automation/corelib/dist/dataModel/Part'
+import { PartInvalidReason, ResolvedPart, ResolvedPartState } from '@sofie-automation/live-status-gateway-api'
+import { interpollateTranslation } from '@sofie-automation/corelib/dist/TranslatableMessage'
+import { toNotificationSeverity } from '../../notification/toNotificationStatus.js'
 
 /** Converts a resolved `PartExtended` model into the gateway API `ResolvedPart` shape. */
 export function toResolvedPartStatus(ctx: ResolvedPlaylistConversionContext, partExtended: PartExtended): ResolvedPart {
@@ -32,6 +35,8 @@ export function toResolvedPartStatus(ctx: ResolvedPlaylistConversionContext, par
 		name: basePart.title ?? '',
 		rank: basePart._rank ?? 0,
 		autoNext: !!basePart.autoNext,
+		invalid: !!basePart.invalid,
+		invalidReason: basePart.invalidReason ? toApiPartInvalidReason(basePart.invalidReason) : undefined,
 		state,
 		publicData: basePart.publicData,
 		timing: {
@@ -44,5 +49,15 @@ export function toResolvedPartStatus(ctx: ResolvedPlaylistConversionContext, par
 			take: timings.take ?? 0,
 		},
 		pieces: part.pieces?.map((piece) => toResolvedPieceStatus(piece)) ?? [],
+	}
+}
+
+function toApiPartInvalidReason(invalidReason: CorePartInvalidReason): PartInvalidReason {
+	const msg = invalidReason.message
+
+	return {
+		message: interpollateTranslation(msg.key, msg.args ?? {}),
+		severity: invalidReason.severity ? toNotificationSeverity(invalidReason.severity) : undefined,
+		color: invalidReason.color,
 	}
 }

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/parts/toResolvedPartStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/parts/toResolvedPartStatus.ts
@@ -1,0 +1,47 @@
+import { toResolvedPieceStatus } from '../pieces/toResolvedPieceStatus.js'
+import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
+import { ResolvedPlaylistConversionContext } from '../context/conversionContext.js'
+import type { PartExtended } from '@sofie-automation/corelib/dist/dataModel/Part'
+import { ResolvedPart, ResolvedPartState } from '@sofie-automation/live-status-gateway-api'
+
+export function toResolvedPartStatus(ctx: ResolvedPlaylistConversionContext, partExtended: PartExtended): ResolvedPart {
+	const part = partExtended
+	const instance = part.instance
+	const basePart = instance?.part ?? {}
+
+	const instanceId = instance?._id ? unprotectString(instance._id) : ''
+	let state: ResolvedPartState | undefined
+	if (ctx.playlist.currentPartInfo?.partInstanceId && instance?._id === ctx.playlist.currentPartInfo.partInstanceId) {
+		state = ResolvedPartState.CURRENT
+	} else if (
+		ctx.playlist.nextPartInfo?.partInstanceId &&
+		instance?._id === ctx.playlist.nextPartInfo.partInstanceId
+	) {
+		state = ResolvedPartState.NEXT
+	}
+
+	const timings = instance?.timings ?? {}
+	const createdByAdLib = instance?.orphaned === 'adlib-part'
+
+	return {
+		id: unprotectString(part.partId ?? basePart._id),
+		instanceId,
+		createdByAdLib: createdByAdLib,
+		externalId: basePart.externalId ?? '',
+		name: basePart.title ?? '',
+		rank: basePart._rank ?? 0,
+		autoNext: !!basePart.autoNext,
+		state,
+		publicData: basePart.publicData,
+		timing: {
+			startMs: part.startsAt ?? 0,
+			durationMs: part.renderedDuration ?? 0,
+			plannedStartedPlayback: timings.plannedStartedPlayback ?? 0,
+			reportedStartedPlayback: timings.reportedStartedPlayback ?? 0,
+			playOffset: timings.playOffset ?? 0,
+			setAsNext: timings.setAsNext ?? 0,
+			take: timings.take ?? 0,
+		},
+		pieces: part.pieces?.map((piece) => toResolvedPieceStatus(piece)) ?? [],
+	}
+}

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/parts/toResolvedPartStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/parts/toResolvedPartStatus.ts
@@ -46,7 +46,7 @@ export function toResolvedPartStatus(ctx: ResolvedPlaylistConversionContext, par
 			durationMs: part.renderedDuration ?? 0,
 			plannedStartedPlayback: timings.plannedStartedPlayback ?? 0,
 			reportedStartedPlayback: timings.reportedStartedPlayback ?? 0,
-			playOffset: timings.playOffset ?? 0,
+			playOffsetMs: timings.playOffset ?? undefined,
 			setAsNext: timings.setAsNext ?? 0,
 			take: timings.take ?? 0,
 		},

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/pieces/toResolvedPieceStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/pieces/toResolvedPieceStatus.ts
@@ -1,0 +1,73 @@
+import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
+import type { PieceExtended } from '@sofie-automation/corelib/dist/dataModel/Piece'
+import type { AbSessionAssignment, ResolvedPiece } from '@sofie-automation/live-status-gateway-api'
+
+export function toResolvedPieceStatus(pieceExtended: PieceExtended): ResolvedPiece {
+	const piece = pieceExtended
+	const instance = piece.instance
+	const basePiece = instance?.piece ?? {}
+	const startMs = getStartMs(piece, basePiece)
+	const durationMs = getDurationMs(piece, instance, startMs, basePiece)
+	const createdByAdLib = !!instance?.dynamicallyInserted
+	const abSessions = toAbSessions(basePiece)
+
+	return {
+		id: unprotectString(basePiece._id),
+		instanceId: unprotectString(instance?._id),
+		createdByAdLib,
+		externalId: basePiece.externalId ?? '',
+		name: basePiece.name ?? '',
+		priority: instance?.priority ?? 0,
+		sourceLayerId: basePiece.sourceLayerId ?? '',
+		outputLayerId: basePiece.outputLayerId ?? '',
+		publicData: basePiece.publicData,
+		timing: {
+			startMs,
+			durationMs,
+			prerollMs: basePiece.prerollDuration,
+		},
+		tags: basePiece.tags ? [...basePiece.tags] : [],
+		abSessions,
+	}
+}
+
+function getStartMs(
+	piece: PieceExtended,
+	basePiece: NonNullable<PieceExtended['instance']>['piece'] | Record<string, never>
+) {
+	if (typeof piece.renderedInPoint === 'number') return piece.renderedInPoint
+	if (typeof basePiece?.enable?.start === 'number') return basePiece.enable.start
+	return undefined
+}
+
+function getDurationMs(
+	piece: PieceExtended,
+	instance: PieceExtended['instance'],
+	startMs: number | undefined,
+	basePiece: NonNullable<PieceExtended['instance']>['piece'] | Record<string, never>
+) {
+	if (typeof piece.renderedDuration === 'number') return piece.renderedDuration
+
+	const durationFromEnable = typeof basePiece?.enable?.duration === 'number' ? basePiece.enable.duration : undefined
+	const durationFromUserDuration =
+		typeof instance?.userDuration?.endRelativeToPart === 'number' && typeof startMs === 'number'
+			? Math.max(0, instance.userDuration.endRelativeToPart - startMs)
+			: undefined
+	const durationFromResolvedEndCap =
+		typeof instance?.resolvedEndCap === 'number' && typeof startMs === 'number'
+			? Math.max(0, instance.resolvedEndCap - startMs)
+			: undefined
+
+	return durationFromUserDuration ?? durationFromResolvedEndCap ?? durationFromEnable
+}
+
+function toAbSessions(basePiece: NonNullable<PieceExtended['instance']>['piece'] | Record<string, never>) {
+	if (!Array.isArray(basePiece.abSessions)) return undefined
+
+	return basePiece.abSessions
+		.filter(
+			(s): s is AbSessionAssignment =>
+				!!s && typeof s.poolName === 'string' && typeof s.sessionName === 'string' && 'playerId' in s
+		)
+		.map((s) => ({ poolName: s.poolName, sessionName: s.sessionName, playerId: s.playerId }))
+}

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/pieces/toResolvedPieceStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/pieces/toResolvedPieceStatus.ts
@@ -2,6 +2,7 @@ import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protected
 import type { PieceExtended } from '@sofie-automation/corelib/dist/dataModel/Piece'
 import type { AbSessionAssignment, ResolvedPiece } from '@sofie-automation/live-status-gateway-api'
 
+/** Converts a resolved `PieceExtended` model into the gateway API `ResolvedPiece` shape. */
 export function toResolvedPieceStatus(pieceExtended: PieceExtended): ResolvedPiece {
 	const piece = pieceExtended
 	const instance = piece.instance
@@ -31,6 +32,7 @@ export function toResolvedPieceStatus(pieceExtended: PieceExtended): ResolvedPie
 	}
 }
 
+/** Resolves piece start offset from rendered data or blueprint timing metadata. */
 function getStartMs(
 	piece: PieceExtended,
 	basePiece: NonNullable<PieceExtended['instance']>['piece'] | Record<string, never>
@@ -40,6 +42,7 @@ function getStartMs(
 	return undefined
 }
 
+/** Resolves duration using runtime render first, then fallback timing metadata. */
 function getDurationMs(
 	piece: PieceExtended,
 	instance: PieceExtended['instance'],
@@ -61,6 +64,7 @@ function getDurationMs(
 	return durationFromUserDuration ?? durationFromResolvedEndCap ?? durationFromEnable
 }
 
+/** Normalizes ad-lib AB sessions to a strict API-safe shape. */
 function toAbSessions(basePiece: NonNullable<PieceExtended['instance']>['piece'] | Record<string, never>) {
 	if (!Array.isArray(basePiece.abSessions)) return undefined
 

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/pieces/toResolvedPieceStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/pieces/toResolvedPieceStatus.ts
@@ -21,6 +21,7 @@ export function toResolvedPieceStatus(pieceExtended: PieceExtended): ResolvedPie
 		priority: instance?.priority ?? 0,
 		sourceLayerId: basePiece.sourceLayerId ?? '',
 		outputLayerId: basePiece.outputLayerId ?? '',
+		invalid: !!basePiece.invalid,
 		publicData: basePiece.publicData,
 		timing: {
 			startMs,

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/pieces/toResolvedPieceStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/pieces/toResolvedPieceStatus.ts
@@ -14,7 +14,7 @@ export function toResolvedPieceStatus(pieceExtended: PieceExtended): ResolvedPie
 
 	return {
 		id: unprotectString(basePiece._id),
-		instanceId: unprotectString(instance?._id),
+		instanceId: instance?._id ? unprotectString(instance._id) : undefined,
 		createdByAdLib,
 		externalId: basePiece.externalId ?? '',
 		name: basePiece.name ?? '',

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/rundowns/toResolvedRundownStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/rundowns/toResolvedRundownStatus.ts
@@ -1,0 +1,19 @@
+import { ResolvedPlaylistConversionContext, getOrderedSegmentsInRundown } from '../context/conversionContext.js'
+import { toResolvedSegmentStatus } from '../segments/toResolvedSegmentStatus.js'
+import type { ResolvedRundown } from '@sofie-automation/live-status-gateway-api'
+
+export function toResolvedRundownStatus(ctx: ResolvedPlaylistConversionContext, rundownId: string): ResolvedRundown {
+	const rundown = ctx.rundownsById.get(String(rundownId))
+	const orderedSegments = getOrderedSegmentsInRundown(ctx, rundownId)
+	const rank = Math.max(0, ctx.orderedRundownIds.indexOf(String(rundownId)))
+
+	return {
+		id: rundownId,
+		externalId: rundown?.externalId ?? '',
+		name: rundown?.name ?? '',
+		rank,
+		description: rundown?.description ?? '',
+		publicData: rundown?.publicData,
+		segments: rundown ? orderedSegments.map((segment) => toResolvedSegmentStatus(ctx, segment, rundown)) : [],
+	}
+}

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/rundowns/toResolvedRundownStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/rundowns/toResolvedRundownStatus.ts
@@ -2,6 +2,7 @@ import { ResolvedPlaylistConversionContext, getOrderedSegmentsInRundown } from '
 import { toResolvedSegmentStatus } from '../segments/toResolvedSegmentStatus.js'
 import type { ResolvedRundown } from '@sofie-automation/live-status-gateway-api'
 
+/** Converts a rundown id into a fully expanded `ResolvedRundown` payload. */
 export function toResolvedRundownStatus(ctx: ResolvedPlaylistConversionContext, rundownId: string): ResolvedRundown {
 	const rundown = ctx.rundownsById.get(String(rundownId))
 	const orderedSegments = getOrderedSegmentsInRundown(ctx, rundownId)

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/rundowns/toResolvedRundownStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/rundowns/toResolvedRundownStatus.ts
@@ -4,9 +4,14 @@ import type { ResolvedRundown } from '@sofie-automation/live-status-gateway-api'
 
 /** Converts a rundown id into a fully expanded `ResolvedRundown` payload. */
 export function toResolvedRundownStatus(ctx: ResolvedPlaylistConversionContext, rundownId: string): ResolvedRundown {
-	const rundown = ctx.rundownsById.get(String(rundownId))
+	const rundownRank = ctx.orderedRundownIds.indexOf(rundownId)
+	if (rundownRank === -1) {
+		throw new Error(`Rundown "${rundownId}" is not in orderedRundownIds`)
+	}
+
+	const rundown = ctx.rundownsById.get(rundownId)
 	const orderedSegments = getOrderedSegmentsInRundown(ctx, rundownId)
-	const rank = Math.max(0, ctx.orderedRundownIds.indexOf(String(rundownId)))
+	const rank = rundownRank
 
 	return {
 		id: rundownId,

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/segments/serializeResolvedSegment.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/segments/serializeResolvedSegment.ts
@@ -1,9 +1,9 @@
+/** Serializes `PieceExtended` into a JSON-safe shape without circular references. */
 export function serializePiece(pieceExtended: unknown): any {
 	const piece = pieceExtended as any
 	// `PieceExtended` contains references to `outputLayers/sourceLayers` which then contains pieces again -> circular.
 	// We omit `outputLayer` and keep the values used by consumers.
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const { outputLayer, ...rest } = piece ?? {}
+	const { outputLayer: _outputLayer, ...rest } = piece ?? {}
 	return {
 		renderedInPoint: rest.renderedInPoint,
 		renderedDuration: rest.renderedDuration,
@@ -11,6 +11,7 @@ export function serializePiece(pieceExtended: unknown): any {
 	}
 }
 
+/** Serializes `PartExtended` and nested pieces for deterministic debug logging/testing. */
 export function serializePart(partExtended: unknown): any {
 	const part = partExtended as any
 	return {
@@ -23,6 +24,7 @@ export function serializePart(partExtended: unknown): any {
 	}
 }
 
+/** Serializes `SegmentExtended` while pruning cyclical layer/piece references. */
 export function serializeSegmentExtended(segmentExtended: unknown): any {
 	const segment = segmentExtended as any
 	if (!segment) return segment
@@ -32,7 +34,6 @@ export function serializeSegmentExtended(segmentExtended: unknown): any {
 	for (const [layerId, layer] of Object.entries<any>(outputLayers ?? {})) {
 		safeOutputLayers[layerId] = {
 			...layer,
-			// Avoid cycles: layers contain pieces, and pieces can reference layers.
 			sourceLayers: [],
 		}
 	}
@@ -41,7 +42,6 @@ export function serializeSegmentExtended(segmentExtended: unknown): any {
 	for (const [layerId, layer] of Object.entries<any>(sourceLayers ?? {})) {
 		safeSourceLayers[layerId] = {
 			...layer,
-			// Replace pieces with ids to avoid deep circular references.
 			pieces: (layer.pieces ?? []).map((p: any) => p?.instance?._id ?? p?._id),
 		}
 	}

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/segments/serializeResolvedSegment.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/segments/serializeResolvedSegment.ts
@@ -1,0 +1,54 @@
+export function serializePiece(pieceExtended: unknown): any {
+	const piece = pieceExtended as any
+	// `PieceExtended` contains references to `outputLayers/sourceLayers` which then contains pieces again -> circular.
+	// We omit `outputLayer` and keep the values used by consumers.
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const { outputLayer, ...rest } = piece ?? {}
+	return {
+		renderedInPoint: rest.renderedInPoint,
+		renderedDuration: rest.renderedDuration,
+		instance: rest.instance,
+	}
+}
+
+export function serializePart(partExtended: unknown): any {
+	const part = partExtended as any
+	return {
+		partId: part.partId,
+		instance: part.instance,
+		renderedDuration: part.renderedDuration,
+		startsAt: part.startsAt,
+		willProbablyAutoNext: part.willProbablyAutoNext,
+		pieces: part.pieces?.map(serializePiece) ?? [],
+	}
+}
+
+export function serializeSegmentExtended(segmentExtended: unknown): any {
+	const segment = segmentExtended as any
+	if (!segment) return segment
+	const { outputLayers, sourceLayers, ...rest } = segment
+
+	const safeOutputLayers: Record<string, any> = {}
+	for (const [layerId, layer] of Object.entries<any>(outputLayers ?? {})) {
+		safeOutputLayers[layerId] = {
+			...layer,
+			// Avoid cycles: layers contain pieces, and pieces can reference layers.
+			sourceLayers: [],
+		}
+	}
+
+	const safeSourceLayers: Record<string, any> = {}
+	for (const [layerId, layer] of Object.entries<any>(sourceLayers ?? {})) {
+		safeSourceLayers[layerId] = {
+			...layer,
+			// Replace pieces with ids to avoid deep circular references.
+			pieces: (layer.pieces ?? []).map((p: any) => p?.instance?._id ?? p?._id),
+		}
+	}
+
+	return {
+		...rest,
+		outputLayers: safeOutputLayers,
+		sourceLayers: safeSourceLayers,
+	}
+}

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/segments/serializeResolvedSegment.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/segments/serializeResolvedSegment.ts
@@ -13,13 +13,13 @@ export function serializePiece(pieceExtended: unknown): any {
 
 /** Serializes `PartExtended` and nested pieces for deterministic debug logging/testing. */
 export function serializePart(partExtended: unknown): any {
-	const part = partExtended as any
+	const part = (partExtended as any) ?? {}
 	return {
-		partId: part.partId,
-		instance: part.instance,
-		renderedDuration: part.renderedDuration,
-		startsAt: part.startsAt,
-		willProbablyAutoNext: part.willProbablyAutoNext,
+		partId: part?.partId,
+		instance: part?.instance,
+		renderedDuration: part?.renderedDuration,
+		startsAt: part?.startsAt,
+		willProbablyAutoNext: part?.willProbablyAutoNext,
 		pieces: part.pieces?.map(serializePiece) ?? [],
 	}
 }

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/segments/toResolvedSegmentStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/segments/toResolvedSegmentStatus.ts
@@ -74,6 +74,7 @@ export function toResolvedSegmentStatus(
 	}
 }
 
+/** Limits "receive on rundown end" evaluation to segments in the same rundown. */
 function getSegmentsToReceiveOnRundownEndFromSet(
 	ctx: ResolvedPlaylistConversionContext,
 	segment: DBSegment
@@ -82,6 +83,7 @@ function getSegmentsToReceiveOnRundownEndFromSet(
 	return new Set(segmentsInThisRundown.map((s) => s._id))
 }
 
+/** Maps source layers from resolved segment output to API shape sorted by rank. */
 function toSourceLayers(ctx: ResolvedPlaylistConversionContext, segmentExtended: SegmentExtended): SourceLayer[] {
 	return Object.entries<NameableSourceLayer>(segmentExtended?.sourceLayers ?? {})
 		.map(([id, layer]) => ({
@@ -95,6 +97,7 @@ function toSourceLayers(ctx: ResolvedPlaylistConversionContext, segmentExtended:
 		.sort((a, b) => a.rank - b.rank)
 }
 
+/** Maps output layers from resolved segment output to API shape sorted by name. */
 function toOutputLayers(ctx: ResolvedPlaylistConversionContext, segmentExtended: SegmentExtended): OutputLayer[] {
 	return Object.entries<NameableOutputLayer>(segmentExtended?.outputLayers ?? {})
 		.map(([id, layer]) =>

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/segments/toResolvedSegmentStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/segments/toResolvedSegmentStatus.ts
@@ -7,21 +7,6 @@ import type { DBSegment, SegmentExtended } from '@sofie-automation/corelib/dist/
 import type { ResolvedSegment, SourceLayer, OutputLayer } from '@sofie-automation/live-status-gateway-api'
 import { literal } from '@sofie-automation/server-core-integration'
 
-type NameableSourceLayer = {
-	name?: string
-	abbreviation?: string
-	isHidden?: boolean
-	type?: number
-	_rank?: number
-}
-
-type NameableOutputLayer = {
-	name?: string
-	isFlattened?: boolean
-	isPGM?: boolean
-	sourceLayers?: Array<{ _id?: string }>
-}
-
 export function toResolvedSegmentStatus(
 	ctx: ResolvedPlaylistConversionContext,
 	segment: DBSegment,
@@ -35,7 +20,7 @@ export function toResolvedSegmentStatus(
 		segment,
 		segmentsToReceiveOnRundownEndFromSet: getSegmentsToReceiveOnRundownEndFromSet(ctx, segment),
 		rundownsToReceiveOnShowStyleEndFrom: [],
-		rundownsToShowStyles: ctx.rundownsToShowStyles as any,
+		rundownsToShowStyles: ctx.rundownsToShowStyles,
 		orderedAllPartIds: getOrderedPartsInRundown(ctx, unprotectString(segment.rundownId)).map((p) => p._id),
 		currentPartInstance: ctx.currentPartInstance,
 		nextPartInstance: ctx.nextPartInstance,
@@ -85,7 +70,10 @@ function getSegmentsToReceiveOnRundownEndFromSet(
 
 /** Maps source layers from resolved segment output to API shape sorted by rank. */
 function toSourceLayers(ctx: ResolvedPlaylistConversionContext, segmentExtended: SegmentExtended): SourceLayer[] {
-	return Object.entries<NameableSourceLayer>(segmentExtended?.sourceLayers ?? {})
+	type SourceLayerExtended = NonNullable<SegmentExtended['sourceLayers']>[string]
+	if (!segmentExtended.sourceLayers) return []
+
+	return Object.entries<SourceLayerExtended>(segmentExtended.sourceLayers)
 		.map(([id, layer]) => ({
 			id,
 			name: layer?.name ?? ctx.showStyleBaseExt?.sourceLayerNamesById?.get?.(id) ?? '',
@@ -99,7 +87,10 @@ function toSourceLayers(ctx: ResolvedPlaylistConversionContext, segmentExtended:
 
 /** Maps output layers from resolved segment output to API shape sorted by name. */
 function toOutputLayers(ctx: ResolvedPlaylistConversionContext, segmentExtended: SegmentExtended): OutputLayer[] {
-	return Object.entries<NameableOutputLayer>(segmentExtended?.outputLayers ?? {})
+	type OutputLayerExtended = NonNullable<SegmentExtended['outputLayers']>[string]
+	if (!segmentExtended.outputLayers) return []
+
+	return Object.entries<OutputLayerExtended>(segmentExtended.outputLayers)
 		.map(([id, layer]) =>
 			literal<OutputLayer>({
 				id,

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/segments/toResolvedSegmentStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/segments/toResolvedSegmentStatus.ts
@@ -1,0 +1,112 @@
+import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
+import { getResolvedSegment } from '@sofie-automation/corelib/dist/playout/stateCacheResolver'
+import { ResolvedPlaylistConversionContext, getOrderedPartsInRundown } from '../context/conversionContext.js'
+import { toResolvedPartStatus } from '../parts/toResolvedPartStatus.js'
+import type { Rundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
+import type { DBSegment, SegmentExtended } from '@sofie-automation/corelib/dist/dataModel/Segment'
+import type { ResolvedSegment, SourceLayer, OutputLayer } from '@sofie-automation/live-status-gateway-api'
+import { literal } from '@sofie-automation/server-core-integration'
+
+type NameableSourceLayer = {
+	name?: string
+	abbreviation?: string
+	isHidden?: boolean
+	type?: number
+	_rank?: number
+}
+
+type NameableOutputLayer = {
+	name?: string
+	isFlattened?: boolean
+	isPGM?: boolean
+	sourceLayers?: Array<{ _id?: string }>
+}
+
+export function toResolvedSegmentStatus(
+	ctx: ResolvedPlaylistConversionContext,
+	segment: DBSegment,
+	rundown: Rundown
+): ResolvedSegment {
+	const resolvedSegment = getResolvedSegment({
+		showStyleBase: ctx.showStyleBaseExt,
+		studio: undefined,
+		playlist: ctx.playlist,
+		rundown,
+		segment,
+		segmentsToReceiveOnRundownEndFromSet: getSegmentsToReceiveOnRundownEndFromSet(ctx, segment),
+		rundownsToReceiveOnShowStyleEndFrom: [],
+		rundownsToShowStyles: ctx.rundownsToShowStyles as any,
+		orderedAllPartIds: getOrderedPartsInRundown(ctx, unprotectString(segment.rundownId)).map((p) => p._id),
+		currentPartInstance: ctx.currentPartInstance,
+		nextPartInstance: ctx.nextPartInstance,
+		accessors: ctx.accessors,
+		options: {
+			getCurrentTime: () => Date.now(),
+			invalidateAfter: (_timeoutMs: number) => {},
+			includeDisabledPieces: false,
+			showHiddenSourceLayers: false,
+			defaultDisplayDuration: 0,
+		},
+	})
+
+	const segmentExtended = resolvedSegment.segmentExtended
+	const sourceLayers = toSourceLayers(ctx, segmentExtended)
+	const outputLayers = toOutputLayers(ctx, segmentExtended)
+
+	const budgetDurationMs = segment?.segmentTiming?.budgetDuration ?? 0
+
+	return {
+		id: unprotectString(segment._id),
+		externalId: segment.externalId,
+		identifier: segment.identifier ?? '',
+		name: segment.name ?? '',
+		rank: segment._rank,
+		isHidden: segment.isHidden ?? false,
+		sourceLayers,
+		outputLayers,
+		publicData: segment.publicData,
+		timing: {
+			startMs: 0,
+			endMs: budgetDurationMs,
+			budgetDurationMs,
+		},
+		parts: (resolvedSegment.parts ?? []).map((part) => toResolvedPartStatus(ctx, part)),
+	}
+}
+
+function getSegmentsToReceiveOnRundownEndFromSet(
+	ctx: ResolvedPlaylistConversionContext,
+	segment: DBSegment
+): Set<DBSegment['_id']> {
+	const segmentsInThisRundown = ctx.segmentsByRundownId.get(String(segment.rundownId)) ?? []
+	return new Set(segmentsInThisRundown.map((s) => s._id))
+}
+
+function toSourceLayers(ctx: ResolvedPlaylistConversionContext, segmentExtended: SegmentExtended): SourceLayer[] {
+	return Object.entries<NameableSourceLayer>(segmentExtended?.sourceLayers ?? {})
+		.map(([id, layer]) => ({
+			id,
+			name: layer?.name ?? ctx.showStyleBaseExt?.sourceLayerNamesById?.get?.(id) ?? '',
+			abbreviation: layer?.abbreviation ?? '',
+			isHidden: layer?.isHidden ?? false,
+			type: layer?.type ?? 0,
+			rank: layer?._rank ?? 0,
+		}))
+		.sort((a, b) => a.rank - b.rank)
+}
+
+function toOutputLayers(ctx: ResolvedPlaylistConversionContext, segmentExtended: SegmentExtended): OutputLayer[] {
+	return Object.entries<NameableOutputLayer>(segmentExtended?.outputLayers ?? {})
+		.map(([id, layer]) =>
+			literal<OutputLayer>({
+				id,
+				name: layer?.name ?? ctx.showStyleBaseExt?.outputLayerNamesById?.get?.(id) ?? '',
+				isFlattened: layer?.isFlattened ?? false,
+				isPGM: layer?.isPGM ?? false,
+				sourceLayerIds: (layer?.sourceLayers ?? [])
+					.map((sl) => sl?._id)
+					.filter((slId): slId is string => !!slId),
+			})
+		)
+		.sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+}

--- a/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/segments/toResolvedSegmentStatus.ts
+++ b/packages/live-status-gateway/src/topics/helpers/resolvedPlaylistConversion/segments/toResolvedSegmentStatus.ts
@@ -12,8 +12,10 @@ export function toResolvedSegmentStatus(
 	segment: DBSegment,
 	rundown: Rundown
 ): ResolvedSegment {
+	const segmentShowStyleBaseExt = ctx.rundownsToShowStyleBaseExt.get(segment.rundownId) ?? ctx.showStyleBaseExt
+
 	const resolvedSegment = getResolvedSegment({
-		showStyleBase: ctx.showStyleBaseExt,
+		showStyleBase: segmentShowStyleBaseExt,
 		studio: undefined,
 		playlist: ctx.playlist,
 		rundown,
@@ -35,8 +37,8 @@ export function toResolvedSegmentStatus(
 	})
 
 	const segmentExtended = resolvedSegment.segmentExtended
-	const sourceLayers = toSourceLayers(ctx, segmentExtended)
-	const outputLayers = toOutputLayers(ctx, segmentExtended)
+	const sourceLayers = toSourceLayers(segmentShowStyleBaseExt, segmentExtended)
+	const outputLayers = toOutputLayers(segmentShowStyleBaseExt, segmentExtended)
 
 	const budgetDurationMs = segment?.segmentTiming?.budgetDuration ?? 0
 
@@ -69,14 +71,17 @@ function getSegmentsToReceiveOnRundownEndFromSet(
 }
 
 /** Maps source layers from resolved segment output to API shape sorted by rank. */
-function toSourceLayers(ctx: ResolvedPlaylistConversionContext, segmentExtended: SegmentExtended): SourceLayer[] {
+function toSourceLayers(
+	showStyleBaseExt: ResolvedPlaylistConversionContext['showStyleBaseExt'],
+	segmentExtended: SegmentExtended
+): SourceLayer[] {
 	type SourceLayerExtended = NonNullable<SegmentExtended['sourceLayers']>[string]
 	if (!segmentExtended.sourceLayers) return []
 
 	return Object.entries<SourceLayerExtended>(segmentExtended.sourceLayers)
 		.map(([id, layer]) => ({
 			id,
-			name: layer?.name ?? ctx.showStyleBaseExt?.sourceLayerNamesById?.get?.(id) ?? '',
+			name: layer?.name ?? showStyleBaseExt?.sourceLayerNamesById?.get?.(id) ?? '',
 			abbreviation: layer?.abbreviation ?? '',
 			isHidden: layer?.isHidden ?? false,
 			type: layer?.type ?? 0,
@@ -86,7 +91,10 @@ function toSourceLayers(ctx: ResolvedPlaylistConversionContext, segmentExtended:
 }
 
 /** Maps output layers from resolved segment output to API shape sorted by name. */
-function toOutputLayers(ctx: ResolvedPlaylistConversionContext, segmentExtended: SegmentExtended): OutputLayer[] {
+function toOutputLayers(
+	showStyleBaseExt: ResolvedPlaylistConversionContext['showStyleBaseExt'],
+	segmentExtended: SegmentExtended
+): OutputLayer[] {
 	type OutputLayerExtended = NonNullable<SegmentExtended['outputLayers']>[string]
 	if (!segmentExtended.outputLayers) return []
 
@@ -94,7 +102,7 @@ function toOutputLayers(ctx: ResolvedPlaylistConversionContext, segmentExtended:
 		.map(([id, layer]) =>
 			literal<OutputLayer>({
 				id,
-				name: layer?.name ?? ctx.showStyleBaseExt?.outputLayerNamesById?.get?.(id) ?? '',
+				name: layer?.name ?? showStyleBaseExt?.outputLayerNamesById?.get?.(id) ?? '',
 				isFlattened: layer?.isFlattened ?? false,
 				isPGM: layer?.isPGM ?? false,
 				sourceLayerIds: (layer?.sourceLayers ?? [])

--- a/packages/live-status-gateway/src/topics/resolvedPlaylistTopic.ts
+++ b/packages/live-status-gateway/src/topics/resolvedPlaylistTopic.ts
@@ -1,0 +1,125 @@
+import { Logger } from 'winston'
+import { WebSocket } from 'ws'
+import { WebSocketTopicBase, WebSocketTopic } from '../wsHandler.js'
+import { CollectionHandlers } from '../liveStatusServer.js'
+import { toResolvedPlaylistStatus } from './helpers/resolvedPlaylistConversion/events/toResolvedPlaylistStatus.js'
+import type { ToResolvedPlaylistStatusProps } from './helpers/resolvedPlaylistConversion/context/conversionContext.js'
+import { PieceInstance } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
+import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
+import { DBPartInstance, PartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
+import { Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
+import { DBRundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
+import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist/RundownPlaylist'
+import { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
+import type { PartInstancesInPlaylist } from '../collections/partInstancesInPlaylistHandler.js'
+import { ShowStyleBaseExt } from '../collections/showStyleBaseHandler.js'
+
+const THROTTLE_PERIOD_MS = 100
+
+const PLAYLIST_KEYS = [
+	'_id',
+	'externalId',
+	'activationId',
+	'rehearsal',
+	'name',
+	'rundownIdsInOrder',
+	'quickLoop',
+	'currentPartInfo',
+	'nextPartInfo',
+	'publicData',
+	'publicPlayoutPersistentState',
+	'timing',
+	'tTimers',
+] as const
+type PlaylistState = Pick<DBRundownPlaylist, (typeof PLAYLIST_KEYS)[number]>
+
+export class ResolvedPlaylistTopic extends WebSocketTopicBase implements WebSocketTopic {
+	private _playlist: PlaylistState | undefined
+	private _rundowns: DBRundown[] = []
+	private _segments: DBSegment[] = []
+	private _parts: DBPart[] = []
+	private _partInstancesInPlaylist: DBPartInstance[] = []
+	private _showStyleBaseExt: ShowStyleBaseExt | undefined
+	private _piecesInPlaylist: Piece[] = []
+	private _pieceInstancesInPlaylist: PieceInstance[] = []
+
+	constructor(logger: Logger, handlers: CollectionHandlers) {
+		super('resolvedPlaylist', logger, THROTTLE_PERIOD_MS)
+
+		handlers.playlistHandler.subscribe(this.onPlaylistUpdate, PLAYLIST_KEYS)
+		handlers.rundownsHandler.subscribe(this.onRundownsUpdate)
+		handlers.showStyleBaseHandler.subscribe(this.onShowStyleBaseUpdate)
+		handlers.segmentsHandler.subscribe(this.onSegmentsUpdate)
+		handlers.partsHandler.subscribe(this.onPartsUpdate)
+		handlers.partInstancesInPlaylistHandler.subscribe(this.onPartInstancesInPlaylistUpdate, ['all'])
+		handlers.piecesInPlaylistHandler.subscribe(this.onPiecesInPlaylistUpdate)
+		handlers.pieceInstancesInPlaylistHandler.subscribe(this.onPieceInstancesInPlaylistUpdate)
+	}
+
+	sendStatus(subscribers: Iterable<WebSocket>): void {
+		const message = toResolvedPlaylistStatus({
+			playlistState: this._playlist as ToResolvedPlaylistStatusProps['playlistState'],
+			rundownsState: this._rundowns,
+			showStyleBaseExtState: this._showStyleBaseExt,
+			segmentsState: this._segments,
+			partsState: this._parts,
+			partInstancesInPlaylistState: this._partInstancesInPlaylist as PartInstance[],
+			piecesInPlaylistState: this._piecesInPlaylist,
+			pieceInstancesInPlaylistState: this._pieceInstancesInPlaylist,
+		})
+
+		this.sendMessage(subscribers, message)
+	}
+
+	private onPlaylistUpdate = (playlist: PlaylistState | undefined): void => {
+		this.logUpdateReceived('playlist', `rundownPlaylistId ${playlist?._id}`)
+		this._playlist = playlist
+		this.throttledSendStatusToAll()
+	}
+
+	private onRundownsUpdate = (rundowns: ToResolvedPlaylistStatusProps['rundownsState'] | undefined): void => {
+		this.logUpdateReceived('rundowns', `${rundowns?.length ?? 0} rundowns`)
+		this._rundowns = rundowns ?? []
+		this.throttledSendStatusToAll()
+	}
+
+	private onShowStyleBaseUpdate = (showStyleBase: ToResolvedPlaylistStatusProps['showStyleBaseExtState']): void => {
+		this.logUpdateReceived('showStyleBase')
+		this._showStyleBaseExt = showStyleBase
+		this.throttledSendStatusToAll()
+	}
+
+	private onSegmentsUpdate = (segments: ToResolvedPlaylistStatusProps['segmentsState'] | undefined): void => {
+		this.logUpdateReceived('segments')
+		this._segments = segments ?? []
+		this.throttledSendStatusToAll()
+	}
+
+	private onPartsUpdate = (parts: ToResolvedPlaylistStatusProps['partsState'] | undefined): void => {
+		this.logUpdateReceived('parts', `${parts?.length ?? 0} parts`)
+		this._parts = parts ?? []
+		this.throttledSendStatusToAll()
+	}
+
+	private onPartInstancesInPlaylistUpdate = (data: Pick<PartInstancesInPlaylist, 'all'> | undefined): void => {
+		this.logUpdateReceived('partInstancesInPlaylist')
+		this._partInstancesInPlaylist = data?.all ?? []
+		this.throttledSendStatusToAll()
+	}
+
+	private onPiecesInPlaylistUpdate = (
+		pieces: ToResolvedPlaylistStatusProps['piecesInPlaylistState'] | undefined
+	): void => {
+		this.logUpdateReceived('piecesInPlaylist', `${pieces?.length ?? 0} pieces`)
+		this._piecesInPlaylist = pieces ?? []
+		this.throttledSendStatusToAll()
+	}
+
+	private onPieceInstancesInPlaylistUpdate = (
+		pieceInstances: ToResolvedPlaylistStatusProps['pieceInstancesInPlaylistState'] | undefined
+	): void => {
+		this.logUpdateReceived('pieceInstancesInPlaylist', `${pieceInstances?.length ?? 0} pieceInstances`)
+		this._pieceInstancesInPlaylist = pieceInstances ?? []
+		this.throttledSendStatusToAll()
+	}
+}

--- a/packages/live-status-gateway/src/topics/resolvedPlaylistTopic.ts
+++ b/packages/live-status-gateway/src/topics/resolvedPlaylistTopic.ts
@@ -33,6 +33,10 @@ const PLAYLIST_KEYS = [
 ] as const
 type PlaylistState = Pick<DBRundownPlaylist, (typeof PLAYLIST_KEYS)[number]>
 
+/**
+ * Aggregates playlist-scoped collections and publishes the `resolvedPlaylist` topic.
+ * Data is cached locally and merged into a single event on every source update.
+ */
 export class ResolvedPlaylistTopic extends WebSocketTopicBase implements WebSocketTopic {
 	private _playlist: PlaylistState | undefined
 	private _rundowns: DBRundown[] = []
@@ -56,6 +60,7 @@ export class ResolvedPlaylistTopic extends WebSocketTopicBase implements WebSock
 		handlers.pieceInstancesInPlaylistHandler.subscribe(this.onPieceInstancesInPlaylistUpdate)
 	}
 
+	/** Builds and publishes the current resolved playlist snapshot to all subscribers. */
 	sendStatus(subscribers: Iterable<WebSocket>): void {
 		const message = toResolvedPlaylistStatus({
 			playlistState: this._playlist as ToResolvedPlaylistStatusProps['playlistState'],

--- a/packages/live-status-gateway/src/topics/resolvedPlaylistTopic.ts
+++ b/packages/live-status-gateway/src/topics/resolvedPlaylistTopic.ts
@@ -18,6 +18,9 @@ const THROTTLE_PERIOD_MS = 100
 
 const PLAYLIST_KEYS = [
 	'_id',
+	'studioId',
+	'created',
+	'modified',
 	'externalId',
 	'activationId',
 	'rehearsal',
@@ -26,6 +29,7 @@ const PLAYLIST_KEYS = [
 	'quickLoop',
 	'currentPartInfo',
 	'nextPartInfo',
+	'previousPartInfo',
 	'publicData',
 	'publicPlayoutPersistentState',
 	'timing',
@@ -62,8 +66,10 @@ export class ResolvedPlaylistTopic extends WebSocketTopicBase implements WebSock
 
 	/** Builds and publishes the current resolved playlist snapshot to all subscribers. */
 	sendStatus(subscribers: Iterable<WebSocket>): void {
+		if (!this._playlist || !this._showStyleBaseExt) return
+
 		const message = toResolvedPlaylistStatus({
-			playlistState: this._playlist as ToResolvedPlaylistStatusProps['playlistState'],
+			playlistState: this._playlist,
 			rundownsState: this._rundowns,
 			showStyleBaseExtState: this._showStyleBaseExt,
 			segmentsState: this._segments,

--- a/packages/live-status-gateway/src/topics/resolvedPlaylistTopic.ts
+++ b/packages/live-status-gateway/src/topics/resolvedPlaylistTopic.ts
@@ -13,6 +13,7 @@ import { DBRundownPlaylist } from '@sofie-automation/corelib/dist/dataModel/Rund
 import { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
 import type { PartInstancesInPlaylist } from '../collections/partInstancesInPlaylistHandler.js'
 import { ShowStyleBaseExt } from '../collections/showStyleBaseHandler.js'
+import { ShowStyleBaseId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 
 const THROTTLE_PERIOD_MS = 100
 
@@ -48,6 +49,7 @@ export class ResolvedPlaylistTopic extends WebSocketTopicBase implements WebSock
 	private _parts: DBPart[] = []
 	private _partInstancesInPlaylist: DBPartInstance[] = []
 	private _showStyleBaseExt: ShowStyleBaseExt | undefined
+	private _showStyleBaseExtsById: ReadonlyMap<ShowStyleBaseId, ShowStyleBaseExt> = new Map()
 	private _piecesInPlaylist: Piece[] = []
 	private _pieceInstancesInPlaylist: PieceInstance[] = []
 
@@ -57,6 +59,7 @@ export class ResolvedPlaylistTopic extends WebSocketTopicBase implements WebSock
 		handlers.playlistHandler.subscribe(this.onPlaylistUpdate, PLAYLIST_KEYS)
 		handlers.rundownsHandler.subscribe(this.onRundownsUpdate)
 		handlers.showStyleBaseHandler.subscribe(this.onShowStyleBaseUpdate)
+		handlers.showStyleBasesHandler.subscribe(this.onShowStyleBasesUpdate)
 		handlers.segmentsHandler.subscribe(this.onSegmentsUpdate)
 		handlers.partsHandler.subscribe(this.onPartsUpdate)
 		handlers.partInstancesInPlaylistHandler.subscribe(this.onPartInstancesInPlaylistUpdate, ['all'])
@@ -72,6 +75,7 @@ export class ResolvedPlaylistTopic extends WebSocketTopicBase implements WebSock
 			playlistState: this._playlist,
 			rundownsState: this._rundowns,
 			showStyleBaseExtState: this._showStyleBaseExt,
+			showStyleBaseExtsByIdState: this._showStyleBaseExtsById,
 			segmentsState: this._segments,
 			partsState: this._parts,
 			partInstancesInPlaylistState: this._partInstancesInPlaylist as PartInstance[],
@@ -98,6 +102,12 @@ export class ResolvedPlaylistTopic extends WebSocketTopicBase implements WebSock
 	private onShowStyleBaseUpdate = (showStyleBase: ToResolvedPlaylistStatusProps['showStyleBaseExtState']): void => {
 		this.logUpdateReceived('showStyleBase')
 		this._showStyleBaseExt = showStyleBase
+		this.throttledSendStatusToAll()
+	}
+
+	private onShowStyleBasesUpdate = (showStyleBases: ShowStyleBaseExt[] | undefined): void => {
+		this.logUpdateReceived('showStyleBases', `${showStyleBases?.length ?? 0} showStyleBases`)
+		this._showStyleBaseExtsById = new Map((showStyleBases ?? []).map((showStyle) => [showStyle._id, showStyle]))
 		this.throttledSendStatusToAll()
 	}
 

--- a/packages/live-status-gateway/src/topics/resolvedPlaylistTopic.ts
+++ b/packages/live-status-gateway/src/topics/resolvedPlaylistTopic.ts
@@ -77,6 +77,7 @@ export class ResolvedPlaylistTopic extends WebSocketTopicBase implements WebSock
 			partInstancesInPlaylistState: this._partInstancesInPlaylist as PartInstance[],
 			piecesInPlaylistState: this._piecesInPlaylist,
 			pieceInstancesInPlaylistState: this._pieceInstancesInPlaylist,
+			logger: this._logger,
 		})
 
 		this.sendMessage(subscribers, message)

--- a/packages/openapi/src/generated/openapi.yaml
+++ b/packages/openapi/src/generated/openapi.yaml
@@ -5386,7 +5386,7 @@ paths:
             type: string
       responses:
         '200':
-          description: Bucket successfuly removed.
+          description: Bucket successfully removed.
           content:
             application/json:
               schema:
@@ -5506,7 +5506,7 @@ paths:
             type: string
       responses:
         '200':
-          description: Bucket Adlibs successfuly removed.
+          description: Bucket Adlibs successfully removed.
           content:
             application/json:
               schema:
@@ -5560,7 +5560,7 @@ paths:
             type: string
       responses:
         '200':
-          description: Bucket Adlib successfuly removed.
+          description: Bucket Adlib successfully removed.
           content:
             application/json:
               schema:


### PR DESCRIPTION
## About the Contributor

This pull request is posted on behalf of the BBC and CBC.

## Type of Contribution

This is a Feature

## Current Behavior

The Live Status Gateway primarily exposes:

- `activePlaylist`: current/next context and playlist-level timing state for the active playlist
- `activePieces`: only currently active (on-air) pieces

There was no single subscription that provided a resolved, playlist-scoped hierarchy of **all rundowns → segments → parts → pieces**, and some part/piece validity metadata was not exposed in the resolved structures.

## New Behavior

Adds a new websocket subscription/topic, **`resolvedPlaylist`**, that publishes the fully resolved active playlist aligned with the webui.

Key changes include:

- **`resolvedPlaylist` topic**: includes playlist-level fields and a full resolved structure: **rundowns → segments → parts → pieces**, with `publicData` surfaced through the hierarchy.
- **Expose additional part validity/timing flags**:
  - `ResolvedPart.floated`
  - `ResolvedPart.untimed`
  - `ResolvedPart.invalidReason`
- **Piece validity**:
  - `ResolvedPiece.invalid`

## Testing

- [x] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

- Live Status Gateway websocket server topics and collections
- Live Status Gateway API schemas and generated output
- Schema/type generation tooling

## Time Frame

This Feature is critical for us, please review and merge it as soon as possible.

## Status

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments) has been added / updated.