### PR TITLE
Feat/sofie 449 duration based timing mode

### DIFF
--- a/packages/blueprints-integration/src/documents/playlistTiming.ts
+++ b/packages/blueprints-integration/src/documents/playlistTiming.ts
@@ -4,6 +4,7 @@ export enum PlaylistTimingType {
 	None = 'none',
 	ForwardTime = 'forward-time',
 	BackTime = 'back-time',
+	Duration = 'duration',
 }
 
 export interface PlaylistTimingBase {
@@ -49,4 +50,29 @@ export interface PlaylistTimingBackTime extends PlaylistTimingBase {
 	expectedEnd: Time
 }
 
-export type RundownPlaylistTiming = PlaylistTimingNone | PlaylistTimingForwardTime | PlaylistTimingBackTime
+/**
+ * This mode is intended for shows with a "floating start",
+ * meaning they will start based on when the show before them on the channel ends.
+ * In this mode, we will preserve the Duration and automatically calculate the expectedEnd
+ * based on the _actual_ start of the show (playlist.startedPlayback).
+ *
+ * The optional expectedStart property allows setting a start property of the show that will not affect
+ * timing calculations, only purpose is to drive UI and inform the users about the preliminary plan as
+ * planned in the editorial planning tool.
+ */
+export interface PlaylistTimingDuration extends PlaylistTimingBase {
+	type: PlaylistTimingType.Duration
+	/** A stipulated start time, to drive UIs pre-show, but not affecting calculations during the show.
+	 */
+	expectedStart?: Time
+	/** Planned duration of the rundown playlist
+	 *  When the show starts, an expectedEnd gets automatically calculated with this as an offset from that starting point
+	 */
+	expectedDuration: number
+}
+
+export type RundownPlaylistTiming =
+	| PlaylistTimingNone
+	| PlaylistTimingForwardTime
+	| PlaylistTimingBackTime
+	| PlaylistTimingDuration

--- a/packages/corelib/src/playout/rundownTiming.ts
+++ b/packages/corelib/src/playout/rundownTiming.ts
@@ -13,6 +13,7 @@
 
 import {
 	PlaylistTimingBackTime,
+	PlaylistTimingDuration,
 	PlaylistTimingForwardTime,
 	PlaylistTimingNone,
 	PlaylistTimingType,
@@ -32,6 +33,10 @@ export namespace PlaylistTiming {
 
 	export function isPlaylistTimingBackTime(timing: RundownPlaylistTiming): timing is PlaylistTimingBackTime {
 		return timing.type === PlaylistTimingType.BackTime
+	}
+
+	export function isPlaylistDurationTimed(timing: RundownPlaylistTiming): timing is PlaylistTimingDuration {
+		return timing.type === PlaylistTimingType.Duration
 	}
 
 	export function getExpectedStart(timing: RundownPlaylistTiming): number | undefined {

--- a/packages/corelib/src/playout/rundownTiming.ts
+++ b/packages/corelib/src/playout/rundownTiming.ts
@@ -47,12 +47,14 @@ export namespace PlaylistTiming {
 				timing.expectedStart ||
 				(timing.expectedDuration ? timing.expectedEnd - timing.expectedDuration : undefined)
 			)
+		} else if (PlaylistTiming.isPlaylistDurationTimed(timing)) {
+			return timing.expectedStart
 		} else {
 			return undefined
 		}
 	}
 
-	export function getExpectedEnd(timing: RundownPlaylistTiming): number | undefined {
+	export function getExpectedEnd(timing: RundownPlaylistTiming, startedPlayback?: number | undefined): number | undefined {
 		if (PlaylistTiming.isPlaylistTimingBackTime(timing)) {
 			return timing.expectedEnd
 		} else if (PlaylistTiming.isPlaylistTimingForwardTime(timing)) {
@@ -60,6 +62,14 @@ export namespace PlaylistTiming {
 				timing.expectedEnd ||
 				(timing.expectedDuration ? timing.expectedStart + timing.expectedDuration : undefined)
 			)
+		} else if (PlaylistTiming.isPlaylistDurationTimed(timing)) {
+			if (!startedPlayback) {
+				// before the show, estimate the end from start + dur
+				return timing.expectedStart ? timing.expectedStart + timing.expectedDuration : undefined
+			} else {
+				// after starting the show, project the end from startedPlayback + dur
+				return startedPlayback + timing.expectedDuration
+			}
 		} else {
 			return undefined
 		}

--- a/packages/corelib/src/playout/rundownTiming.ts
+++ b/packages/corelib/src/playout/rundownTiming.ts
@@ -85,13 +85,18 @@ export namespace PlaylistTiming {
 		}
 	}
 
-	export function getEstimatedEnd(timing: RundownPlaylistTiming, now: number, remainingPlaylistDuration?: number, startedPlayback?: number): number | undefined {
-		let frontAnchor = PlaylistTiming.getExpectedStart(timing)
-		if (PlaylistTiming.isPlaylistDurationTimed(timing)) {
-			frontAnchor = startedPlayback ??PlaylistTiming.getExpectedStart(timing)
+	export function getEstimatedEnd(
+		timing: RundownPlaylistTiming,
+		now: number,
+		remainingPlaylistDuration?: number,
+		startedPlayback?: number
+	): number | undefined {
+		if (remainingPlaylistDuration !== undefined) {
+			const frontAnchor = startedPlayback ? now : Math.max(now, PlaylistTiming.getExpectedStart(timing) ?? now)
+
+			return frontAnchor + remainingPlaylistDuration
 		}
-		
-		return remainingPlaylistDuration !== undefined ? Math.max(now, frontAnchor ?? now) + remainingPlaylistDuration : undefined
+		return undefined
 	}
 
 	export function sortTimings(

--- a/packages/corelib/src/playout/rundownTiming.ts
+++ b/packages/corelib/src/playout/rundownTiming.ts
@@ -84,7 +84,16 @@ export namespace PlaylistTiming {
 			return undefined
 		}
 	}
-	
+
+	export function getEstimatedEnd(timing: RundownPlaylistTiming, now: number, remainingPlaylistDuration?: number, startedPlayback?: number): number | undefined {
+		let frontAnchor = PlaylistTiming.getExpectedStart(timing)
+		if (PlaylistTiming.isPlaylistDurationTimed(timing)) {
+			frontAnchor = startedPlayback ??PlaylistTiming.getExpectedStart(timing)
+		}
+		
+		return remainingPlaylistDuration !== undefined ? Math.max(now, frontAnchor ?? now) + remainingPlaylistDuration : undefined
+	}
+
 	export function sortTimings(
 		a: ReadonlyDeep<{ timing: RundownPlaylistTiming }>,
 		b: ReadonlyDeep<{ timing: RundownPlaylistTiming }>

--- a/packages/corelib/src/playout/rundownTiming.ts
+++ b/packages/corelib/src/playout/rundownTiming.ts
@@ -54,7 +54,7 @@ export namespace PlaylistTiming {
 		}
 	}
 
-	export function getExpectedEnd(timing: RundownPlaylistTiming, startedPlayback?: number | undefined): number | undefined {
+	export function getExpectedEnd(timing: RundownPlaylistTiming, startedPlayback?: number): number | undefined {
 		if (PlaylistTiming.isPlaylistTimingBackTime(timing)) {
 			return timing.expectedEnd
 		} else if (PlaylistTiming.isPlaylistTimingForwardTime(timing)) {
@@ -84,7 +84,7 @@ export namespace PlaylistTiming {
 			return undefined
 		}
 	}
-
+	
 	export function sortTimings(
 		a: ReadonlyDeep<{ timing: RundownPlaylistTiming }>,
 		b: ReadonlyDeep<{ timing: RundownPlaylistTiming }>

--- a/packages/live-status-gateway-api/api/components/timing/activePlaylistTiming/activePlaylistTimingMode.yaml
+++ b/packages/live-status-gateway-api/api/components/timing/activePlaylistTiming/activePlaylistTimingMode.yaml
@@ -5,3 +5,4 @@ enum:
   - none
   - forward-time
   - back-time
+  - duration

--- a/packages/live-status-gateway-api/src/generated/asyncapi.yaml
+++ b/packages/live-status-gateway-api/src/generated/asyncapi.yaml
@@ -660,6 +660,7 @@ channels:
                         - none
                         - forward-time
                         - back-time
+                        - duration
                     startedPlayback:
                       description: Unix timestamp of when the playlist started (milliseconds)
                       type: number

--- a/packages/live-status-gateway-api/src/generated/schema.ts
+++ b/packages/live-status-gateway-api/src/generated/schema.ts
@@ -423,6 +423,7 @@ enum ActivePlaylistTimingMode {
 	NONE = 'none',
 	FORWARD_MINUS_TIME = 'forward-time',
 	BACK_MINUS_TIME = 'back-time',
+	DURATION = 'duration',
 }
 
 /**

--- a/packages/live-status-gateway/src/topics/activePlaylistTopic.ts
+++ b/packages/live-status-gateway/src/topics/activePlaylistTopic.ts
@@ -181,7 +181,8 @@ export class ActivePlaylistTopic extends WebSocketTopicBase implements WebSocket
 								? this._activePlaylist.timing.expectedStart
 								: undefined,
 						expectedEnd:
-							this._activePlaylist.timing.type !== PlaylistTimingType.None
+							this._activePlaylist.timing.type !== PlaylistTimingType.None &&
+							this._activePlaylist.timing.type !== PlaylistTimingType.Duration
 								? this._activePlaylist.timing.expectedEnd
 								: undefined,
 					},
@@ -402,6 +403,8 @@ function translatePlaylistTimingType(type: PlaylistTimingType): ActivePlaylistTi
 			return ActivePlaylistTimingMode.BACK_MINUS_TIME
 		case PlaylistTimingType.ForwardTime:
 			return ActivePlaylistTimingMode.FORWARD_MINUS_TIME
+		case PlaylistTimingType.Duration:
+			return ActivePlaylistTimingMode.DURATION
 		default:
 			assertNever(type)
 			// Cast and return the value anyway, so that the application works

--- a/packages/webui/src/client/lib/rundownTiming.ts
+++ b/packages/webui/src/client/lib/rundownTiming.ts
@@ -887,9 +887,11 @@ export function getPlaylistTimingDiff(
 			diff =
 				(timingContext.asPlayedPlaylistDuration || 0) -
 				(timing.expectedDuration ?? timingContext.totalPlaylistDuration ?? 0)
-		} else if (PlaylistTiming.isPlaylistTimingBackTime(timing)) {
-			// we want to see how late we've ended compared to the expectedEnd
-			diff = startedPlayback + (timingContext.asPlayedPlaylistDuration || 0) - timing.expectedEnd
+		} else if (PlaylistTiming.isPlaylistDurationTimed(timing)) {
+			//  we want to know how heavy/light we were compared to the original plan
+			diff =
+				(timingContext.asPlayedPlaylistDuration || 0) -
+				(timing.expectedDuration ?? timingContext.totalPlaylistDuration ?? 0)
 		}
 	}
 

--- a/packages/webui/src/client/lib/rundownTiming.ts
+++ b/packages/webui/src/client/lib/rundownTiming.ts
@@ -855,6 +855,13 @@ export function getPlaylistTimingDiff(
 		frontAnchor = Math.max(currentTime, playlist.startedPlayback ?? Math.max(timing.expectedStart, currentTime))
 	} else if (PlaylistTiming.isPlaylistTimingBackTime(timing)) {
 		backAnchor = timingContext.nextRundownAnchor ?? timing.expectedEnd
+	} else if (PlaylistTiming.isPlaylistDurationTimed(timing)) {
+		const backAnchorTimeWithoutBreaks =
+			timingContext.nextRundownAnchor ??
+			PlaylistTiming.getExpectedEnd(timing, playlist.startedPlayback) ??
+			currentTime + timing.expectedDuration
+		backAnchor = timingContext.nextRundownAnchor ?? backAnchorTimeWithoutBreaks
+		frontAnchor = Math.max(currentTime, playlist.startedPlayback || PlaylistTiming.getExpectedStart(timing) || 0)
 	}
 
 	let diff = PlaylistTiming.isPlaylistTimingNone(timing)

--- a/packages/webui/src/client/ui/RundownView/RundownHeader/RundownHeaderExpectedEnd.tsx
+++ b/packages/webui/src/client/ui/RundownView/RundownHeader/RundownHeaderExpectedEnd.tsx
@@ -30,7 +30,7 @@ export function RundownHeaderExpectedEnd({
 			{!simplified && expectedEnd !== undefined ? (
 				<Countdown label={t('Plan. End')} time={expectedEnd} className="rundown-header__show-timers-countdown" />
 			) : null}
-			{estEnd !== null ? (
+			{estEnd !== undefined ? (
 				<Countdown label={t('Est. End')} time={estEnd} className="rundown-header__show-timers-countdown" />
 			) : null}
 		</div>

--- a/packages/webui/src/client/ui/RundownView/RundownHeader/RundownHeaderExpectedEnd.tsx
+++ b/packages/webui/src/client/ui/RundownView/RundownHeader/RundownHeaderExpectedEnd.tsx
@@ -3,6 +3,7 @@ import { PlaylistTiming } from '@sofie-automation/corelib/dist/playout/rundownTi
 import { useTranslation } from 'react-i18next'
 import { Countdown } from './Countdown'
 import { useTiming } from '../RundownTiming/withTiming'
+import { RundownPlaylistTiming } from '@sofie-automation/blueprints-integration'
 
 export function RundownHeaderExpectedEnd({
 	playlist,
@@ -14,17 +15,34 @@ export function RundownHeaderExpectedEnd({
 	const { t } = useTranslation()
 	const timingDurations = useTiming()
 
-	const expectedStart = PlaylistTiming.getExpectedStart(playlist.timing)
-	const expectedEnd = PlaylistTiming.getExpectedEnd(playlist.timing, playlist.startedPlayback)
+	// todo: this should live with the others in client/lib/rundwownTimings.ts
+	function getEstimatedEnd(
+		timing: RundownPlaylistTiming,
+		now: number,
+		remainingPlaylistDuration?: number,
+		startedPlayback?: number
+	): number | undefined {
+		let frontAnchor = PlaylistTiming.getExpectedStart(timing)
+
+		if (PlaylistTiming.isPlaylistDurationTimed(timing)) {
+			frontAnchor = startedPlayback ?? PlaylistTiming.getExpectedStart(timing)
+		}
+
+		return remainingPlaylistDuration !== undefined
+			? Math.max(now, frontAnchor ?? now) + remainingPlaylistDuration
+			: undefined
+	}
+
 	const now = timingDurations.currentTime ?? Date.now()
+	const expectedEnd = PlaylistTiming.getExpectedEnd(playlist.timing, playlist.startedPlayback)
+	const estEnd = getEstimatedEnd(
+		playlist.timing,
+		now,
+		timingDurations.remainingPlaylistDuration,
+		playlist.startedPlayback
+	)
 
-	// Use remainingPlaylistDuration which includes current part's remaining time
-	const estEnd =
-		timingDurations.remainingPlaylistDuration !== undefined
-			? Math.max(now, expectedStart ?? now) + timingDurations.remainingPlaylistDuration
-			: null
-
-	if (expectedEnd === undefined && estEnd === null) return null
+	if (expectedEnd === undefined && estEnd === undefined) return null
 
 	return (
 		<div className="rundown-header__show-timers-endtimes">

--- a/packages/webui/src/client/ui/RundownView/RundownHeader/RundownHeaderExpectedEnd.tsx
+++ b/packages/webui/src/client/ui/RundownView/RundownHeader/RundownHeaderExpectedEnd.tsx
@@ -15,7 +15,7 @@ export function RundownHeaderExpectedEnd({
 	const timingDurations = useTiming()
 
 	const expectedStart = PlaylistTiming.getExpectedStart(playlist.timing)
-	const expectedEnd = PlaylistTiming.getExpectedEnd(playlist.timing)
+	const expectedEnd = PlaylistTiming.getExpectedEnd(playlist.timing, playlist.startedPlayback)
 	const now = timingDurations.currentTime ?? Date.now()
 
 	// Use remainingPlaylistDuration which includes current part's remaining time

--- a/packages/webui/src/client/ui/RundownView/RundownHeader/RundownHeaderExpectedEnd.tsx
+++ b/packages/webui/src/client/ui/RundownView/RundownHeader/RundownHeaderExpectedEnd.tsx
@@ -3,7 +3,6 @@ import { PlaylistTiming } from '@sofie-automation/corelib/dist/playout/rundownTi
 import { useTranslation } from 'react-i18next'
 import { Countdown } from './Countdown'
 import { useTiming } from '../RundownTiming/withTiming'
-import { RundownPlaylistTiming } from '@sofie-automation/blueprints-integration'
 
 export function RundownHeaderExpectedEnd({
 	playlist,
@@ -15,27 +14,9 @@ export function RundownHeaderExpectedEnd({
 	const { t } = useTranslation()
 	const timingDurations = useTiming()
 
-	// todo: this should live with the others in client/lib/rundwownTimings.ts
-	function getEstimatedEnd(
-		timing: RundownPlaylistTiming,
-		now: number,
-		remainingPlaylistDuration?: number,
-		startedPlayback?: number
-	): number | undefined {
-		let frontAnchor = PlaylistTiming.getExpectedStart(timing)
-
-		if (PlaylistTiming.isPlaylistDurationTimed(timing)) {
-			frontAnchor = startedPlayback ?? PlaylistTiming.getExpectedStart(timing)
-		}
-
-		return remainingPlaylistDuration !== undefined
-			? Math.max(now, frontAnchor ?? now) + remainingPlaylistDuration
-			: undefined
-	}
-
 	const now = timingDurations.currentTime ?? Date.now()
 	const expectedEnd = PlaylistTiming.getExpectedEnd(playlist.timing, playlist.startedPlayback)
-	const estEnd = getEstimatedEnd(
+	const estEnd = PlaylistTiming.getEstimatedEnd(
 		playlist.timing,
 		now,
 		timingDurations.remainingPlaylistDuration,


### PR DESCRIPTION
## Type of Contribution

This is a: Feature

## Current Behavior

Today you can specify a planned start and planned duration, which to Sofie means the show is scheduled to run within a certain block of walltime. 

For floating-start shows, today, you can specify just the duration, then manually start it at the right time. You can currently not hint about the preliminary start time, the best estimate, from the editorial side. 

## New Behavior

Adding a new timing mode which changes the rules. The intention is to protect the Duration property, and enforce a rule that generates the Planned end property from the actual started time + this planned Duration. 

**As described in the code comments:**
This mode is inteded for shows with a "floating start", meaning they will start based on when the show before them on the channel ends. In this mode, we will preserve the Duration and automatically calculate the expectedEnd based on the _actual_ start of the show (playlist.startedPlayback).

The optional expectedStart property allows setting a start property of the show that will not affect timing calculations, only purpose is to drive UI and inform the users about the preliminary plan as planned in the editorial planning tool.



## Testing

Feature tested with simple regression testing on other timing modes in the adjacent code spaces.

<img width="1071" height="64" alt="Screenshot 2026-03-25 at 11 08 34" src="https://github.com/user-attachments/assets/b10e81c6-e29d-49e5-a5d6-d79be90007df" />

<img width="1071" height="64" alt="Screenshot 2026-03-25 at 11 08 41" src="https://github.com/user-attachments/assets/31c34b7b-b098-459a-88d3-d1d2095233b8" />

<img width="1071" height="64" alt="Screenshot 2026-03-25 at 11 08 54" src="https://github.com/user-attachments/assets/aae3e0e3-9a3a-46f8-b3d7-39073f04a47d" />




<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

**This is a bit of a mess...**
We follow existing patterns of timing properties and calculations being scattered across corelib, ui libs and ui frontend files.

There's duplications, and nested if/else statements in various places, stacked on top of each other as needed. 

We want to change this to a clear pattern in the next scope of work!

## Time Frame

* This Bug Fix is critical for us, please review and merge it as soon as possible.

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

## Other Information

This is a re-post of https://github.com/bbc/sofie-core/pull/79, which seemed to get lost in all the merging and conflict resolution.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
