### PR TITLE
feat: expose `playoutPersistentState` to blueprint `syncIngestUpdateToPartInstance` SOFIE-455

### DIFF
--- a/packages/blueprints-integration/src/api/showStyle.ts
+++ b/packages/blueprints-integration/src/api/showStyle.ts
@@ -116,7 +116,8 @@ export interface ShowStyleBlueprintManifest<
 		context: ISyncIngestUpdateToPartInstanceContext,
 		existingPartInstance: BlueprintSyncIngestPartInstance,
 		newData: BlueprintSyncIngestNewData,
-		playoutStatus: 'previous' | 'current' | 'next'
+		playoutStatus: 'previous' | 'current' | 'next',
+		playoutPersistentState: BlueprintPlayoutPersistentStore<TimelinePersistentState>
 	) => void
 
 	/**

--- a/packages/job-worker/src/ingest/syncChangesToPartInstance.ts
+++ b/packages/job-worker/src/ingest/syncChangesToPartInstance.ts
@@ -36,6 +36,7 @@ import { setNextPart } from '../playout/setNext.js'
 import { PartId, RundownId, SegmentId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import type { WrappedShowStyleBlueprint } from '../blueprints/cache.js'
 import { DBSegment } from '@sofie-automation/corelib/dist/dataModel/Segment'
+import { PersistentPlayoutStateStore } from '../blueprints/context/services/PersistantStateStore.js'
 
 type PlayStatus = 'previous' | 'current' | 'next'
 export interface PartInstanceToSync {
@@ -152,18 +153,26 @@ export class SyncChangesToPartInstancesWorker {
 			if (!this.#blueprint.blueprint.syncIngestUpdateToPartInstance)
 				throw new Error('Blueprint does not have syncIngestUpdateToPartInstance')
 
+			const blueprintPersistentState = new PersistentPlayoutStateStore(
+				this.#playoutModel.playlist.privatePlayoutPersistentState,
+				this.#playoutModel.playlist.publicPlayoutPersistentState
+			)
+
 			// The blueprint handles what in the updated part is going to be synced into the partInstance:
 			this.#blueprint.blueprint.syncIngestUpdateToPartInstance(
 				syncContext,
 				existingResultPartInstance,
 				newResultData,
-				instanceToSync.playStatus
+				instanceToSync.playStatus,
+				blueprintPersistentState
 			)
 
 			// Persist t-timer changes
 			for (const timer of syncContext.changedTTimers) {
 				this.#playoutModel.updateTTimer(timer)
 			}
+
+			blueprintPersistentState.saveToModel(this.#playoutModel)
 		} catch (err) {
 			logger.error(`Error in showStyleBlueprint.syncIngestUpdateToPartInstance: ${stringifyError(err)}`)
 


### PR DESCRIPTION


<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the BBC

## Type of Contribution

This is a:  Feature 

## Current Behavior

<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

## New Behavior

Expose the blueprint owned `playoutPersistentState` to `syncIngestUpdateToPartInstance`, so that the sync can be aware of or update the state based on changes being made.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
