### PR TITLE
Fix crash on connection timeout

### DIFF
--- a/packages/playout-gateway/src/index.ts
+++ b/packages/playout-gateway/src/index.ts
@@ -44,6 +44,7 @@ if (logPath) {
 	})
 
 	logger = Winston.createLogger({
+		exitOnError: false,
 		transports: [transportConsole, transportFile],
 	})
 	logger.info('Logging to', logPath)
@@ -67,6 +68,7 @@ if (logPath) {
 	})
 
 	logger = Winston.createLogger({
+		exitOnError: false,
 		transports: [transportConsole],
 	})
 	logger.info('Logging to Console')


### PR DESCRIPTION
## About the Contributor

This pull request is posted on behalf of the BBC.

## Type of Contribution

This is a Bug fix

## Current Behavior

The update to TSR 4eed5eee996d89b43f7794ec271bd40e80351318 seems to have changed the behaviour when a timeout occurs so that some sort of exception occurs. Winston in playout gateway sees this exception and exits.

## New Behavior

Change Winston config to not exit on errors.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

This affects how playout gateway handles errors.

## Time Frame

* This Bug Fix is critical for us, please review and merge it as soon as possible.

## Other Information

This PR is not immediately needed if we prevent TSR passing the errors to Sofie core, as in this PR: https://github.com/Sofie-Automation/sofie-timeline-state-resolver/pull/457 but it might be a good idea to do anyway.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
