### PR TITLE
fix: `/healthz` and `/readyz` wait for initial device connection (SOFIE-4325)

### DIFF
--- a/packages/mos-gateway/src/mosHandler.ts
+++ b/packages/mos-gateway/src/mosHandler.ts
@@ -81,9 +81,9 @@ export class MosHandler {
 	private _logger: Winston.Logger
 	private _disposed = false
 	private _settings?: MosGatewayConfig
-	private _coreHandler: CoreHandler | undefined
+	private _coreHandler!: CoreHandler
 	private _observers: Array<Observer<any>> = []
-	private _triggerupdateDevicesTimeout: any = null
+	private _triggerUpdateDevicesTimeout: any = null
 	private mosTypes: MosTypes
 
 	public static async create(
@@ -119,9 +119,6 @@ export class MosHandler {
 			}
 		}
 		*/
-		if (!coreHandler) {
-			throw Error('coreHandler is undefined!')
-		}
 
 		if (!coreHandler.core) {
 			throw Error('coreHandler.core is undefined!')
@@ -133,15 +130,14 @@ export class MosHandler {
 
 		this.mosTypes = getMosTypes(this.strict)
 
-		await this._updateDevices()
-
-		if (!this._coreHandler) throw Error('_coreHandler is undefined!')
-		this._coreHandler.onConnected(() => {
+		coreHandler.onConnected(() => {
 			// This is called whenever a connection to Core has been (re-)established
 			this.setupObservers()
 			this.sendStatusOfAllMosDevices()
 		})
 		this.setupObservers()
+
+		this.triggerUpdateDevices()
 	}
 	async dispose(): Promise<void> {
 		this._disposed = true
@@ -209,10 +205,13 @@ export class MosHandler {
 				this._logger.debug('test log debug')
 			}
 		}
-		if (this._triggerupdateDevicesTimeout) {
-			clearTimeout(this._triggerupdateDevicesTimeout)
+		this.triggerUpdateDevices()
+	}
+	private triggerUpdateDevices() {
+		if (this._triggerUpdateDevicesTimeout) {
+			clearTimeout(this._triggerUpdateDevicesTimeout)
 		}
-		this._triggerupdateDevicesTimeout = setTimeout(() => {
+		this._triggerUpdateDevicesTimeout = setTimeout(() => {
 			this._updateDevices().catch((e) => {
 				this._logger.error(stringifyError(e))
 			})

--- a/packages/mos-gateway/src/mosHandler.ts
+++ b/packages/mos-gateway/src/mosHandler.ts
@@ -130,6 +130,8 @@ export class MosHandler {
 
 		this.mosTypes = getMosTypes(this.strict)
 
+		await this._initMosConnection()
+
 		coreHandler.onConnected(() => {
 			// This is called whenever a connection to Core has been (re-)established
 			this.setupObservers()


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://nrkno.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor
<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This pull request is posted on behalf of the NRK.


## Type of Contribution

This is a:
<!-- (pick one) -->
Bug fix


## Current Behavior
<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->
The Kubernetes `/healthz` and `/readyz` don't return an OK signal until devices configured at boot-up have connected.


## New Behavior
<!--
What is the new behavior?
-->
The device connection is detached from boot-up, since it's not really necessary for the boot-up process. This allows the instance to stay up instead of being restarted.


## Testing
<!--
When you add a feature, you should also provide relevant unit tests, in order to 
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
* 
-->

This PR affects the MOS Gateway bootup process.


## Time Frame
<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->
Not urgent, but we would like to get this merged into the in-development release.


## Other Information
<!-- The more information you can provide, the easier the pull request will be to merge -->


## Status
<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.
