### PR TITLE
feat: partInstances invalid state  SOFIE-317 

### DIFF
--- a/meteor/server/publications/segmentPartNotesUI/__tests__/generateNotesForSegment.test.ts
+++ b/meteor/server/publications/segmentPartNotesUI/__tests__/generateNotesForSegment.test.ts
@@ -486,4 +486,121 @@ describe('generateNotesForSegment', () => {
 			])
 		)
 	})
+
+	test('partInstance with runtime invalidReason', async () => {
+		const playlistId = protectString<RundownPlaylistId>('playlist0')
+		const nrcsName = 'some nrcs'
+
+		const segment: Pick<DBSegment, SegmentFields> = {
+			_id: protectString('segment0'),
+			_rank: 1,
+			rundownId: protectString('rundown0'),
+			name: 'A segment',
+			notes: [],
+			orphaned: undefined,
+		}
+
+		const partInstance0: Pick<DBPartInstance, PartInstanceFields> = {
+			_id: protectString('instance0'),
+			segmentId: segment._id,
+			rundownId: segment.rundownId,
+			orphaned: undefined,
+			reset: false,
+			invalidReason: {
+				message: generateTranslation('Runtime error occurred'),
+				severity: NoteSeverity.ERROR,
+			},
+			part: {
+				_id: protectString('part0'),
+				title: 'Test Part',
+			} as any,
+		}
+
+		const notes = generateNotesForSegment(playlistId, segment, nrcsName, [], [partInstance0])
+		expect(notes).toEqual(
+			literal<UISegmentPartNote[]>([
+				{
+					_id: protectString('segment0_partinstance_instance0_invalid_runtime'),
+					note: {
+						type: NoteSeverity.ERROR,
+						message: partInstance0.invalidReason!.message,
+						rank: segment._rank,
+						origin: {
+							segmentId: segment._id,
+							rundownId: segment.rundownId,
+							name: partInstance0.part.title,
+							partId: partInstance0.part._id,
+							segmentName: segment.name,
+						},
+					},
+					playlistId: playlistId,
+					rundownId: segment.rundownId,
+					segmentId: segment._id,
+				},
+			])
+		)
+	})
+
+	test('partInstance with runtime invalidReason but reset - no note', async () => {
+		const playlistId = protectString<RundownPlaylistId>('playlist0')
+		const nrcsName = 'some nrcs'
+
+		const segment: Pick<DBSegment, SegmentFields> = {
+			_id: protectString('segment0'),
+			_rank: 1,
+			rundownId: protectString('rundown0'),
+			name: 'A segment',
+			notes: [],
+			orphaned: undefined,
+		}
+
+		const partInstance0: Pick<DBPartInstance, PartInstanceFields> = {
+			_id: protectString('instance0'),
+			segmentId: segment._id,
+			rundownId: segment.rundownId,
+			orphaned: undefined,
+			reset: true,
+			invalidReason: {
+				message: generateTranslation('Runtime error occurred'),
+				severity: NoteSeverity.ERROR,
+			},
+			part: {
+				_id: protectString('part0'),
+				title: 'Test Part',
+			} as any,
+		}
+
+		const notes = generateNotesForSegment(playlistId, segment, nrcsName, [], [partInstance0])
+		expect(notes).toHaveLength(0)
+	})
+
+	test('partInstance without invalidReason - no note', async () => {
+		const playlistId = protectString<RundownPlaylistId>('playlist0')
+		const nrcsName = 'some nrcs'
+
+		const segment: Pick<DBSegment, SegmentFields> = {
+			_id: protectString('segment0'),
+			_rank: 1,
+			rundownId: protectString('rundown0'),
+			name: 'A segment',
+			notes: [],
+			orphaned: undefined,
+		}
+
+		const partInstance0: Pick<DBPartInstance, PartInstanceFields> = {
+			_id: protectString('instance0'),
+			segmentId: segment._id,
+			rundownId: segment.rundownId,
+			orphaned: undefined,
+			reset: false,
+			invalidReason: undefined,
+			part: {
+				_id: protectString('part0'),
+				title: 'Test Part',
+			} as any,
+		}
+
+		const notes = generateNotesForSegment(playlistId, segment, nrcsName, [], [partInstance0])
+		expect(notes).toHaveLength(0)
+	})
 })

--- a/meteor/server/publications/segmentPartNotesUI/__tests__/publication.test.ts
+++ b/meteor/server/publications/segmentPartNotesUI/__tests__/publication.test.ts
@@ -69,7 +69,7 @@ describe('manipulateUISegmentPartNotesPublicationData', () => {
 			Rundowns: new ReactiveCacheCollection('Rundowns'),
 			Segments: new ReactiveCacheCollection('Segments'),
 			Parts: new ReactiveCacheCollection('Parts'),
-			DeletedPartInstances: new ReactiveCacheCollection('DeletedPartInstances'),
+			PartInstances: new ReactiveCacheCollection('PartInstances'),
 		}
 
 		newCache.Rundowns.insert({
@@ -356,11 +356,11 @@ describe('manipulateUISegmentPartNotesPublicationData', () => {
 			invalid: false,
 			invalidReason: undefined,
 		})
-		newCache.DeletedPartInstances.insert({
+		newCache.PartInstances.insert({
 			_id: 'instance0',
 			segmentId: segmentId0,
 			rundownId: rundownId,
-			orphaned: undefined,
+			orphaned: 'deleted',
 			reset: false,
 			part: 'part' as any,
 		})
@@ -421,6 +421,7 @@ describe('manipulateUISegmentPartNotesPublicationData', () => {
 				[
 					{
 						_id: 'instance0',
+						orphaned: 'deleted',
 						part: 'part',
 						reset: false,
 						rundownId: 'rundown0',

--- a/meteor/server/publications/segmentPartNotesUI/generateNotesForSegment.ts
+++ b/meteor/server/publications/segmentPartNotesUI/generateNotesForSegment.ts
@@ -155,5 +155,31 @@ export function generateNotesForSegment(
 		}
 	}
 
+	// Generate notes for runtime invalidReason on PartInstances
+	// This is distinct from planned invalidReason on Parts - these are runtime validation issues
+	for (const partInstance of partInstances) {
+		// Skip if the PartInstance has been reset (no longer relevant) or has no runtime invalidReason
+		if (partInstance.reset || !partInstance.invalidReason) continue
+
+		notes.push({
+			_id: protectString(`${segment._id}_partinstance_${partInstance._id}_invalid_runtime`),
+			playlistId,
+			rundownId: partInstance.rundownId,
+			segmentId: segment._id,
+			note: {
+				type: partInstance.invalidReason.severity ?? NoteSeverity.ERROR,
+				message: partInstance.invalidReason.message,
+				rank: segment._rank,
+				origin: {
+					segmentId: partInstance.segmentId,
+					partId: partInstance.part._id,
+					rundownId: partInstance.rundownId,
+					segmentName: segment.name,
+					name: partInstance.part.title,
+				},
+			},
+		})
+	}
+
 	return notes
 }

--- a/meteor/server/publications/segmentPartNotesUI/publication.ts
+++ b/meteor/server/publications/segmentPartNotesUI/publication.ts
@@ -91,7 +91,7 @@ async function setupUISegmentPartNotesPublicationObservers(
 						triggerUpdate({ invalidateSegmentIds: [doc.segmentId, oldDoc.segmentId] }),
 					removed: (doc) => triggerUpdate({ invalidateSegmentIds: [doc.segmentId] }),
 				}),
-				cache.DeletedPartInstances.find({}).observe({
+				cache.PartInstances.find({}).observe({
 					added: (doc) => triggerUpdate({ invalidateSegmentIds: [doc.segmentId] }),
 					changed: (doc, oldDoc) =>
 						triggerUpdate({ invalidateSegmentIds: [doc.segmentId, oldDoc.segmentId] }),
@@ -184,13 +184,13 @@ export async function manipulateUISegmentPartNotesPublicationData(
 interface UpdateNotesData {
 	rundownsCache: Map<RundownId, Pick<Rundown, RundownFields>>
 	parts: Map<SegmentId, Pick<DBPart, PartFields>[]>
-	deletedPartInstances: Map<SegmentId, Pick<DBPartInstance, PartInstanceFields>[]>
+	partInstances: Map<SegmentId, Pick<DBPartInstance, PartInstanceFields>[]>
 }
 function compileUpdateNotesData(cache: ReadonlyDeep<ContentCache>): UpdateNotesData {
 	return {
 		rundownsCache: normalizeArrayToMap(cache.Rundowns.find({}).fetch(), '_id'),
 		parts: groupByToMap(cache.Parts.find({}).fetch(), 'segmentId'),
-		deletedPartInstances: groupByToMap(cache.DeletedPartInstances.find({}).fetch(), 'segmentId'),
+		partInstances: groupByToMap(cache.PartInstances.find({}).fetch(), 'segmentId'),
 	}
 }
 
@@ -205,7 +205,7 @@ function updateNotesForSegment(
 		segment,
 		getRundownNrcsName(state.rundownsCache.get(segment.rundownId)),
 		state.parts.get(segment._id) ?? [],
-		state.deletedPartInstances.get(segment._id) ?? []
+		state.partInstances.get(segment._id) ?? []
 	)
 
 	// Insert generated notes

--- a/meteor/server/publications/segmentPartNotesUI/reactiveContentCache.ts
+++ b/meteor/server/publications/segmentPartNotesUI/reactiveContentCache.ts
@@ -35,7 +35,7 @@ export const partFieldSpecifier = literal<MongoFieldSpecifierOnesStrict<Pick<DBP
 	invalidReason: 1,
 })
 
-export type PartInstanceFields = '_id' | 'segmentId' | 'rundownId' | 'orphaned' | 'reset' | 'part'
+export type PartInstanceFields = '_id' | 'segmentId' | 'rundownId' | 'orphaned' | 'reset' | 'part' | 'invalidReason'
 export const partInstanceFieldSpecifier = literal<
 	MongoFieldSpecifierOnesStrict<Pick<PartInstance, PartInstanceFields>>
 >({
@@ -44,7 +44,9 @@ export const partInstanceFieldSpecifier = literal<
 	rundownId: 1,
 	orphaned: 1,
 	reset: 1,
+	invalidReason: 1,
 	// @ts-expect-error Deep not supported
+	'part._id': 1,
 	'part.title': 1,
 })
 
@@ -52,7 +54,7 @@ export interface ContentCache {
 	Rundowns: ReactiveCacheCollection<Pick<Rundown, RundownFields>>
 	Segments: ReactiveCacheCollection<Pick<DBSegment, SegmentFields>>
 	Parts: ReactiveCacheCollection<Pick<DBPart, PartFields>>
-	DeletedPartInstances: ReactiveCacheCollection<Pick<PartInstance, PartInstanceFields>>
+	PartInstances: ReactiveCacheCollection<Pick<PartInstance, PartInstanceFields>>
 }
 
 export function createReactiveContentCache(): ContentCache {
@@ -60,9 +62,7 @@ export function createReactiveContentCache(): ContentCache {
 		Rundowns: new ReactiveCacheCollection<Pick<Rundown, RundownFields>>('rundowns'),
 		Segments: new ReactiveCacheCollection<Pick<DBSegment, SegmentFields>>('segments'),
 		Parts: new ReactiveCacheCollection<Pick<DBPart, PartFields>>('parts'),
-		DeletedPartInstances: new ReactiveCacheCollection<Pick<PartInstance, PartInstanceFields>>(
-			'deletedPartInstances'
-		),
+		PartInstances: new ReactiveCacheCollection<Pick<PartInstance, PartInstanceFields>>('partInstances'),
 	}
 
 	return cache

--- a/meteor/server/publications/segmentPartNotesUI/rundownContentObserver.ts
+++ b/meteor/server/publications/segmentPartNotesUI/rundownContentObserver.ts
@@ -58,8 +58,12 @@ export class RundownContentObserver {
 				}
 			),
 			PartInstances.observeChanges(
-				{ rundownId: { $in: rundownIds }, reset: { $ne: true }, orphaned: 'deleted' },
-				cache.DeletedPartInstances.link(),
+				{
+					rundownId: { $in: rundownIds },
+					reset: { $ne: true },
+					$or: [{ invalidReason: { $exists: true } }, { orphaned: 'deleted' }],
+				},
+				cache.PartInstances.link(),
 				{ projection: partInstanceFieldSpecifier }
 			),
 		])

--- a/packages/blueprints-integration/src/context/onSetAsNextContext.ts
+++ b/packages/blueprints-integration/src/context/onSetAsNextContext.ts
@@ -1,5 +1,6 @@
 import {
 	IBlueprintMutatablePart,
+	IBlueprintMutatablePartInstance,
 	IBlueprintPart,
 	IBlueprintPartInstance,
 	IBlueprintPiece,
@@ -75,10 +76,16 @@ export interface IOnSetAsNextContext
 	/** Update a piecesInstance */
 	updatePieceInstance(pieceInstanceId: string, piece: Partial<IBlueprintPiece>): Promise<IBlueprintPieceInstance>
 
-	/** Update a partInstance */
+	/**
+	 * Update a partInstance
+	 * @param part Which part to update
+	 * @param props Properties of the Part itself
+	 * @param instanceProps Properties of the PartInstance (runtime state)
+	 */
 	updatePartInstance(
 		part: 'current' | 'next',
-		props: Partial<IBlueprintMutatablePart>
+		props: Partial<IBlueprintMutatablePart>,
+		instanceProps?: Partial<IBlueprintMutatablePartInstance>
 	): Promise<IBlueprintPartInstance>
 
 	/**

--- a/packages/blueprints-integration/src/context/partsAndPieceActionContext.ts
+++ b/packages/blueprints-integration/src/context/partsAndPieceActionContext.ts
@@ -1,6 +1,7 @@
 import { ReadonlyDeep } from 'type-fest'
 import {
 	IBlueprintMutatablePart,
+	IBlueprintMutatablePartInstance,
 	IBlueprintPart,
 	IBlueprintPartInstance,
 	IBlueprintPiece,
@@ -67,10 +68,16 @@ export interface IPartAndPieceActionContext {
 	/** Update a piecesInstance */
 	updatePieceInstance(pieceInstanceId: string, piece: Partial<IBlueprintPiece>): Promise<IBlueprintPieceInstance>
 
-	/** Update a partInstance */
+	/**
+	 * Update a partInstance
+	 * @param part Which part to update
+	 * @param props Properties of the Part itself
+	 * @param instanceProps Properties of the PartInstance (runtime state)
+	 */
 	updatePartInstance(
 		part: 'current' | 'next',
-		props: Partial<IBlueprintMutatablePart>
+		props: Partial<IBlueprintMutatablePart>,
+		instanceProps?: Partial<IBlueprintMutatablePartInstance>
 	): Promise<IBlueprintPartInstance>
 	/** Inform core that a take out of the partinstance should be blocked until the specified time */
 	blockTakeUntil(time: Time | null): Promise<void>

--- a/packages/blueprints-integration/src/context/syncIngestChangesContext.ts
+++ b/packages/blueprints-integration/src/context/syncIngestChangesContext.ts
@@ -1,6 +1,7 @@
 import type { IRundownUserContext } from './rundownContext.js'
 import type {
 	IBlueprintMutatablePart,
+	IBlueprintMutatablePartInstance,
 	IBlueprintPartInstance,
 	IBlueprintPiece,
 	IBlueprintPieceInstance,
@@ -38,8 +39,15 @@ export interface ISyncIngestUpdateToPartInstanceContext extends IRundownUserCont
 	// /** Remove a ActionInstance */
 	// removeActionInstances(...actionInstanceIds: string[]): string[]
 
-	/** Update a partInstance */
-	updatePartInstance(props: Partial<IBlueprintMutatablePart>): IBlueprintPartInstance
+	/**
+	 * Update a partInstance
+	 * @param props Properties of the Part itself
+	 * @param instanceProps Properties of the PartInstance (runtime state)
+	 */
+	updatePartInstance(
+		props: Partial<IBlueprintMutatablePart>,
+		instanceProps?: Partial<IBlueprintMutatablePartInstance>
+	): IBlueprintPartInstance
 
 	/** Remove the partInstance. This is only valid when `playstatus: 'next'` */
 	removePartInstance(): void

--- a/packages/blueprints-integration/src/documents/partInstance.ts
+++ b/packages/blueprints-integration/src/documents/partInstance.ts
@@ -1,10 +1,27 @@
 import type { Time } from '../common.js'
 import type { IBlueprintPartDB } from './part.js'
+import type { ITranslatableMessage } from '../translations.js'
 
 export type PartEndState = unknown
 
+/**
+ * Properties of a PartInstance that can be modified at runtime by blueprints.
+ * These are runtime state properties, distinct from the planned Part properties.
+ */
+export interface IBlueprintMutatablePartInstance {
+	/**
+	 * If set, this PartInstance exists and is valid as being next, but it cannot be taken in its current state.
+	 * This can be used to block taking a PartInstance that requires user action to resolve.
+	 * This is a runtime validation issue, distinct from the planned `invalidReason` on the Part itself.
+	 */
+	invalidReason?: ITranslatableMessage
+}
+
 /** The Part instance sent from Core */
-export interface IBlueprintPartInstance<TPrivateData = unknown, TPublicData = unknown> {
+export interface IBlueprintPartInstance<
+	TPrivateData = unknown,
+	TPublicData = unknown,
+> extends IBlueprintMutatablePartInstance {
 	_id: string
 	/** The segment ("Title") this line belongs to */
 	segmentId: string

--- a/packages/corelib/src/dataModel/PartInstance.ts
+++ b/packages/corelib/src/dataModel/PartInstance.ts
@@ -1,7 +1,7 @@
 import { PartEndState, Time } from '@sofie-automation/blueprints-integration'
 import { PartCalculatedTimings } from '../playout/timings.js'
 import { PartInstanceId, RundownId, RundownPlaylistActivationId, SegmentId, SegmentPlayoutId } from './Ids.js'
-import { DBPart } from './Part.js'
+import { DBPart, PartInvalidReason } from './Part.js'
 
 export interface DBPartInstance {
 	_id: PartInstanceId
@@ -40,6 +40,13 @@ export interface DBPartInstance {
 
 	/** If taking out of the current part is blocked, this is the time it is blocked until */
 	blockTakeUntil?: number
+
+	/**
+	 * If set, this PartInstance exists and is valid as being next, but it cannot be taken in its current state.
+	 * This can be used to block taking a PartInstance that requires user action to resolve.
+	 * This is a runtime validation issue, distinct from the planned `invalidReason` on the Part itself.
+	 */
+	invalidReason?: PartInvalidReason
 }
 
 export interface PartInstance extends DBPartInstance {

--- a/packages/corelib/src/error.ts
+++ b/packages/corelib/src/error.ts
@@ -64,6 +64,7 @@ export enum UserErrorMessage {
 	IdempotencyKeyAlreadyUsed = 48,
 	RateLimitExceeded = 49,
 	SystemSingleStudio = 50,
+	TakePartInstanceInvalid = 51,
 }
 
 const UserErrorMessagesTranslations: { [key in UserErrorMessage]: string } = {
@@ -126,6 +127,7 @@ const UserErrorMessagesTranslations: { [key in UserErrorMessage]: string } = {
 	[UserErrorMessage.IdempotencyKeyAlreadyUsed]: t(`Idempotency-Key is already used`),
 	[UserErrorMessage.RateLimitExceeded]: t(`Rate limit exceeded`),
 	[UserErrorMessage.SystemSingleStudio]: t(`System must have exactly one studio`),
+	[UserErrorMessage.TakePartInstanceInvalid]: t(`Part has issues and cannot be taken`),
 }
 
 export interface SerializedUserError {

--- a/packages/job-worker/src/blueprints/__tests__/context-OnSetAsNextContext.test.ts
+++ b/packages/job-worker/src/blueprints/__tests__/context-OnSetAsNextContext.test.ts
@@ -186,7 +186,25 @@ describe('Test blueprint api context', () => {
 
 			await context.updatePartInstance('next', { title: 'My Part' } as Partial<IBlueprintMutatablePart<unknown>>)
 			expect(mockActionService.updatePartInstance).toHaveBeenCalledTimes(1)
-			expect(mockActionService.updatePartInstance).toHaveBeenCalledWith('next', { title: 'My Part' })
+			expect(mockActionService.updatePartInstance).toHaveBeenCalledWith('next', { title: 'My Part' }, {})
+		})
+
+		test('updatePartInstance with instanceProps', async () => {
+			const { context, mockActionService } = await getTestee()
+
+			await context.updatePartInstance(
+				'next',
+				{ title: 'My Part' } as Partial<IBlueprintMutatablePart<unknown>>,
+				{ invalidReason: { key: 'test' } }
+			)
+			expect(mockActionService.updatePartInstance).toHaveBeenCalledTimes(1)
+			expect(mockActionService.updatePartInstance).toHaveBeenCalledWith(
+				'next',
+				{ title: 'My Part' },
+				{
+					invalidReason: { key: 'test' },
+				}
+			)
 		})
 
 		test('manuallySelected when false', async () => {

--- a/packages/job-worker/src/blueprints/__tests__/context-OnTakeContext.test.ts
+++ b/packages/job-worker/src/blueprints/__tests__/context-OnTakeContext.test.ts
@@ -201,7 +201,25 @@ describe('Test blueprint api context', () => {
 
 			await context.updatePartInstance('next', { title: 'My Part' } as Partial<IBlueprintMutatablePart<unknown>>)
 			expect(mockActionService.updatePartInstance).toHaveBeenCalledTimes(1)
-			expect(mockActionService.updatePartInstance).toHaveBeenCalledWith('next', { title: 'My Part' })
+			expect(mockActionService.updatePartInstance).toHaveBeenCalledWith('next', { title: 'My Part' }, {})
+		})
+
+		test('updatePartInstance with instanceProps', async () => {
+			const { context, mockActionService } = await getTestee()
+
+			await context.updatePartInstance(
+				'next',
+				{ title: 'My Part' } as Partial<IBlueprintMutatablePart<unknown>>,
+				{ invalidReason: { key: 'test' } }
+			)
+			expect(mockActionService.updatePartInstance).toHaveBeenCalledTimes(1)
+			expect(mockActionService.updatePartInstance).toHaveBeenCalledWith(
+				'next',
+				{ title: 'My Part' },
+				{
+					invalidReason: { key: 'test' },
+				}
+			)
 		})
 
 		test('isRehearsal when true', async () => {

--- a/packages/job-worker/src/blueprints/__tests__/context-adlibActions.test.ts
+++ b/packages/job-worker/src/blueprints/__tests__/context-adlibActions.test.ts
@@ -172,7 +172,25 @@ describe('Test blueprint api context', () => {
 
 			await context.updatePartInstance('next', { title: 'My Part' } as Partial<IBlueprintMutatablePart<unknown>>)
 			expect(mockActionService.updatePartInstance).toHaveBeenCalledTimes(1)
-			expect(mockActionService.updatePartInstance).toHaveBeenCalledWith('next', { title: 'My Part' })
+			expect(mockActionService.updatePartInstance).toHaveBeenCalledWith('next', { title: 'My Part' }, {})
+		})
+
+		test('updatePartInstance with instanceProps', async () => {
+			const { context, mockActionService } = await getTestee()
+
+			await context.updatePartInstance(
+				'next',
+				{ title: 'My Part' } as Partial<IBlueprintMutatablePart<unknown>>,
+				{ invalidReason: { key: 'test' } }
+			)
+			expect(mockActionService.updatePartInstance).toHaveBeenCalledTimes(1)
+			expect(mockActionService.updatePartInstance).toHaveBeenCalledWith(
+				'next',
+				{ title: 'My Part' },
+				{
+					invalidReason: { key: 'test' },
+				}
+			)
 		})
 
 		test('isRehearsal when true', async () => {

--- a/packages/job-worker/src/blueprints/context/OnSetAsNextContext.ts
+++ b/packages/job-worker/src/blueprints/context/OnSetAsNextContext.ts
@@ -3,6 +3,7 @@ import { ContextInfo } from './CommonContext.js'
 import { ShowStyleUserContext } from './ShowStyleUserContext.js'
 import {
 	IBlueprintMutatablePart,
+	IBlueprintMutatablePartInstance,
 	IBlueprintPart,
 	IBlueprintPartInstance,
 	IBlueprintPiece,
@@ -130,9 +131,10 @@ export class OnSetAsNextContext
 
 	async updatePartInstance(
 		part: 'current' | 'next',
-		props: Partial<IBlueprintMutatablePart<unknown>>
+		props: Partial<IBlueprintMutatablePart<unknown>>,
+		instanceProps: Partial<IBlueprintMutatablePartInstance> = {}
 	): Promise<IBlueprintPartInstance<unknown>> {
-		return this.partAndPieceInstanceService.updatePartInstance(part, props)
+		return this.partAndPieceInstanceService.updatePartInstance(part, props, instanceProps)
 	}
 
 	async removePieceInstances(part: 'current' | 'next', pieceInstanceIds: string[]): Promise<string[]> {

--- a/packages/job-worker/src/blueprints/context/OnTakeContext.ts
+++ b/packages/job-worker/src/blueprints/context/OnTakeContext.ts
@@ -1,5 +1,6 @@
 import {
 	IBlueprintMutatablePart,
+	IBlueprintMutatablePartInstance,
 	IBlueprintPart,
 	IBlueprintPartInstance,
 	IBlueprintPiece,
@@ -131,9 +132,10 @@ export class OnTakeContext extends ShowStyleUserContext implements IOnTakeContex
 
 	async updatePartInstance(
 		part: 'current' | 'next',
-		props: Partial<IBlueprintMutatablePart>
+		props: Partial<IBlueprintMutatablePart>,
+		instanceProps: Partial<IBlueprintMutatablePartInstance> = {}
 	): Promise<IBlueprintPartInstance> {
-		return this.partAndPieceInstanceService.updatePartInstance(part, props)
+		return this.partAndPieceInstanceService.updatePartInstance(part, props, instanceProps)
 	}
 
 	async stopPiecesOnLayers(sourceLayerIds: string[], timeOffset?: number): Promise<string[]> {

--- a/packages/job-worker/src/blueprints/context/SyncIngestUpdateToPartInstanceContext.ts
+++ b/packages/job-worker/src/blueprints/context/SyncIngestUpdateToPartInstanceContext.ts
@@ -14,6 +14,7 @@ import {
 	IBlueprintPieceInstance,
 	OmitId,
 	IBlueprintMutatablePart,
+	IBlueprintMutatablePartInstance,
 	IBlueprintPartInstance,
 	SomeContent,
 	WithTimeline,
@@ -25,6 +26,7 @@ import {
 	convertPieceInstanceToBlueprints,
 	convertPartInstanceToBlueprints,
 	convertPartialBlueprintMutablePartToCore,
+	convertPartialBlueprintMutatablePartInstanceToCore,
 } from './lib.js'
 import { DBRundown } from '@sofie-automation/corelib/dist/dataModel/Rundown'
 import { JobContext, JobStudio, ProcessedShowStyleCompound } from '../../jobs/index.js'
@@ -203,7 +205,10 @@ export class SyncIngestUpdateToPartInstanceContext
 
 		return convertPieceInstanceToBlueprints(pieceInstance.pieceInstance)
 	}
-	updatePartInstance(updatePart: Partial<IBlueprintMutatablePart>): IBlueprintPartInstance {
+	updatePartInstance(
+		updatePart: Partial<IBlueprintMutatablePart>,
+		instanceProps: Partial<IBlueprintMutatablePartInstance> = {}
+	): IBlueprintPartInstance {
 		if (!this.#partInstance) throw new Error(`PartInstance has been removed`)
 
 		// for autoNext, the new expectedDuration cannot be shorter than the time a part has been on-air for
@@ -221,8 +226,20 @@ export class SyncIngestUpdateToPartInstanceContext
 			updatePart,
 			this.showStyleCompound.blueprintId
 		)
+		const playoutUpdatePartInstance = convertPartialBlueprintMutatablePartInstanceToCore(
+			instanceProps,
+			this.showStyleCompound.blueprintId
+		)
 
-		if (!this.#partInstance.updatePartProps(playoutUpdatePart)) {
+		const partPropsUpdated = this.#partInstance.updatePartProps(playoutUpdatePart)
+		let instancePropsUpdated = false
+
+		if (playoutUpdatePartInstance) {
+			this.#partInstance.setInvalidReason(playoutUpdatePartInstance.invalidReason)
+			instancePropsUpdated = true
+		}
+
+		if (!partPropsUpdated && !instancePropsUpdated) {
 			throw new Error(`Cannot update PartInstance. Some valid properties must be defined`)
 		}
 

--- a/packages/job-worker/src/blueprints/context/SyncIngestUpdateToPartInstanceContext.ts
+++ b/packages/job-worker/src/blueprints/context/SyncIngestUpdateToPartInstanceContext.ts
@@ -235,8 +235,12 @@ export class SyncIngestUpdateToPartInstanceContext
 		let instancePropsUpdated = false
 
 		if (playoutUpdatePartInstance) {
-			this.#partInstance.setInvalidReason(playoutUpdatePartInstance.invalidReason)
 			instancePropsUpdated = true
+
+			if (this.playStatus === 'next') {
+				// Only allow changing the invalidReason for the 'next' PartInstance
+				this.#partInstance.setInvalidReason(playoutUpdatePartInstance.invalidReason)
+			}
 		}
 
 		if (!partPropsUpdated && !instancePropsUpdated) {

--- a/packages/job-worker/src/blueprints/context/adlibActions.ts
+++ b/packages/job-worker/src/blueprints/context/adlibActions.ts
@@ -2,6 +2,7 @@ import {
 	IActionExecutionContext,
 	IDataStoreActionExecutionContext,
 	IBlueprintMutatablePart,
+	IBlueprintMutatablePartInstance,
 	IBlueprintPart,
 	IBlueprintPartInstance,
 	IBlueprintPiece,
@@ -210,9 +211,10 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 
 	async updatePartInstance(
 		part: 'current' | 'next',
-		props: Partial<IBlueprintMutatablePart>
+		props: Partial<IBlueprintMutatablePart>,
+		instanceProps: Partial<IBlueprintMutatablePartInstance> = {}
 	): Promise<IBlueprintPartInstance> {
-		return this.partAndPieceInstanceService.updatePartInstance(part, props)
+		return this.partAndPieceInstanceService.updatePartInstance(part, props, instanceProps)
 	}
 
 	async stopPiecesOnLayers(sourceLayerIds: string[], timeOffset?: number): Promise<string[]> {

--- a/packages/job-worker/src/blueprints/context/lib.ts
+++ b/packages/job-worker/src/blueprints/context/lib.ts
@@ -1,6 +1,6 @@
 import { AdLibAction } from '@sofie-automation/corelib/dist/dataModel/AdlibAction'
 import { AdLibPiece } from '@sofie-automation/corelib/dist/dataModel/AdLibPiece'
-import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
+import { DBPart, PartInvalidReason } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
 import {
 	deserializePieceTimelineObjectsBlob,
@@ -35,6 +35,7 @@ import {
 	IBlueprintAdLibPieceDB,
 	IBlueprintConfig,
 	IBlueprintMutatablePart,
+	IBlueprintMutatablePartInstance,
 	IBlueprintPartDB,
 	IBlueprintPartInstance,
 	IBlueprintPiece,
@@ -51,6 +52,7 @@ import {
 	IBlueprintShowStyleVariant,
 	IOutputLayer,
 	ISourceLayer,
+	NoteSeverity,
 	PieceAbSessionInfo,
 	RundownPlaylistTiming,
 } from '@sofie-automation/blueprints-integration'
@@ -218,6 +220,7 @@ export function convertPartInstanceToBlueprints(partInstance: ReadonlyDeep<DBPar
 		previousPartEndState: clone(partInstance.previousPartEndState),
 		orphaned: partInstance.orphaned,
 		blockTakeUntil: partInstance.blockTakeUntil,
+		invalidReason: partInstance.invalidReason ? clone(partInstance.invalidReason.message) : undefined,
 	}
 
 	return obj
@@ -716,6 +719,39 @@ export function convertPartialBlueprintMutablePartToCore(
 
 	return playoutUpdatePart
 }
+
+export interface PlayoutMutatablePartInstance extends Omit<IBlueprintMutatablePartInstance, 'invalidReason'> {
+	invalidReason?: PartInvalidReason
+}
+
+/**
+ * Converts a partial IBlueprintMutatablePartInstance and wraps translatable messages with blueprint namespace
+ */
+export function convertPartialBlueprintMutatablePartInstanceToCore(
+	instanceProps: Partial<IBlueprintMutatablePartInstance>,
+	blueprintId: BlueprintId
+): Partial<PlayoutMutatablePartInstance> {
+	const result: Partial<PlayoutMutatablePartInstance> = {
+		...instanceProps,
+		invalidReason: undefined,
+	}
+
+	if (instanceProps.invalidReason) {
+		result.invalidReason = {
+			message: wrapTranslatableMessageFromBlueprints(instanceProps.invalidReason, [blueprintId]),
+			severity: NoteSeverity.ERROR,
+		}
+	} else if ('invalidReason' in instanceProps) {
+		// Explicitly clearing invalidReason
+		result.invalidReason = undefined
+	} else {
+		// Not touching invalidReason at all
+		delete result.invalidReason
+	}
+
+	return result
+}
+
 export function createBlueprintQuickLoopInfo(playlist: ReadonlyDeep<DBRundownPlaylist>): BlueprintQuickLookInfo | null {
 	const playlistLoopProps = playlist.quickLoop
 	if (!playlistLoopProps) return null

--- a/packages/job-worker/src/blueprints/context/services/PartAndPieceInstanceActionService.ts
+++ b/packages/job-worker/src/blueprints/context/services/PartAndPieceInstanceActionService.ts
@@ -3,6 +3,7 @@ import { PlayoutModel } from '../../../playout/model/PlayoutModel.js'
 import { PlayoutPartInstanceModel } from '../../../playout/model/PlayoutPartInstanceModel.js'
 import {
 	IBlueprintMutatablePart,
+	IBlueprintMutatablePartInstance,
 	IBlueprintPart,
 	IBlueprintPartInstance,
 	IBlueprintPiece,
@@ -20,6 +21,7 @@ import {
 	convertPartInstanceToBlueprints,
 	convertPartToBlueprints,
 	convertPartialBlueprintMutablePartToCore,
+	convertPartialBlueprintMutatablePartInstanceToCore,
 	convertPieceInstanceToBlueprints,
 	convertPieceToBlueprints,
 	convertResolvedPieceInstanceToBlueprints,
@@ -363,7 +365,8 @@ export class PartAndPieceInstanceActionService {
 
 	async updatePartInstance(
 		part: 'current' | 'next',
-		props: Partial<IBlueprintMutatablePart>
+		props: Partial<IBlueprintMutatablePart>,
+		instanceProps: Partial<IBlueprintMutatablePartInstance>
 	): Promise<IBlueprintPartInstance> {
 		const partInstance = this.#getPartInstance(part)
 		if (!partInstance) {
@@ -371,8 +374,23 @@ export class PartAndPieceInstanceActionService {
 		}
 
 		const playoutUpdatePart = convertPartialBlueprintMutablePartToCore(props, this.showStyleCompound.blueprintId)
+		const playoutUpdatePartInstance = convertPartialBlueprintMutatablePartInstanceToCore(
+			instanceProps,
+			this.showStyleCompound.blueprintId
+		)
 
-		if (!partInstance.updatePartProps(playoutUpdatePart)) {
+		const partPropsUpdated = partInstance.updatePartProps(playoutUpdatePart)
+		let instancePropsUpdated = false
+
+		if (playoutUpdatePartInstance && 'invalidReason' in playoutUpdatePartInstance) {
+			if (part !== 'next') {
+				throw new Error(`Can only set invalidReason on the next PartInstance`)
+			}
+			partInstance.setInvalidReason(playoutUpdatePartInstance.invalidReason)
+			instancePropsUpdated = true
+		}
+
+		if (!partPropsUpdated && !instancePropsUpdated) {
 			throw new Error('Some valid properties must be defined')
 		}
 

--- a/packages/job-worker/src/blueprints/context/services/__tests__/PartAndPieceInstanceActionService.test.ts
+++ b/packages/job-worker/src/blueprints/context/services/__tests__/PartAndPieceInstanceActionService.test.ts
@@ -4,6 +4,7 @@ import {
 	IBlueprintPart,
 	IBlueprintPiece,
 	IBlueprintPieceType,
+	NoteSeverity,
 	PieceLifespan,
 } from '@sofie-automation/blueprints-integration'
 import { PlayoutModel } from '../../../../playout/model/PlayoutModel.js'
@@ -1839,7 +1840,7 @@ describe('Test blueprint api context', () => {
 				await wrapWithPlayoutModel(jobContext, playlistId, async (playoutModel) => {
 					const { service } = await getTestee(jobContext, playoutModel)
 
-					await expect(service.updatePartInstance('current', { title: 'new' })).rejects.toThrow(
+					await expect(service.updatePartInstance('current', { title: 'new' }, {})).rejects.toThrow(
 						'PartInstance could not be found'
 					)
 				})
@@ -1848,17 +1849,17 @@ describe('Test blueprint api context', () => {
 				await setPartInstances(jobContext, playlistId, partInstance, undefined)
 				await wrapWithPlayoutModel(jobContext, playlistId, async (playoutModel) => {
 					const { service } = await getTestee(jobContext, playoutModel)
-					await expect(service.updatePartInstance('current', {})).rejects.toThrow(
+					await expect(service.updatePartInstance('current', {}, {})).rejects.toThrow(
 						'Some valid properties must be defined'
 					)
 					await expect(
-						service.updatePartInstance('current', { _id: 'bad', nope: 'ok' } as any)
+						service.updatePartInstance('current', { _id: 'bad', nope: 'ok' } as any, {})
 					).rejects.toThrow('Some valid properties must be defined')
 
-					await expect(service.updatePartInstance('next', { title: 'new' })).rejects.toThrow(
+					await expect(service.updatePartInstance('next', { title: 'new' }, {})).rejects.toThrow(
 						'PartInstance could not be found'
 					)
-					await service.updatePartInstance('current', { title: 'new' })
+					await service.updatePartInstance('current', { title: 'new' }, {})
 				})
 			})
 			test('good', async () => {
@@ -1886,7 +1887,7 @@ describe('Test blueprint api context', () => {
 						classes: ['123'],
 						badProperty: 9, // This will be dropped
 					}
-					const resultPart = await service.updatePartInstance('next', partInstance0Delta)
+					const resultPart = await service.updatePartInstance('next', partInstance0Delta, {})
 					const partInstance1 = playoutModel.nextPartInstance! as PlayoutPartInstanceModelImpl
 					expect(partInstance1).toBeTruthy()
 
@@ -1905,6 +1906,54 @@ describe('Test blueprint api context', () => {
 
 					expect(service.nextPartState).toEqual(ActionPartChange.SAFE_CHANGE)
 					expect(service.currentPartState).toEqual(ActionPartChange.NONE)
+				})
+			})
+			test('invalidReason on current - throws error', async () => {
+				const { jobContext, playlistId, rundownId } = await setupMyDefaultRundown()
+
+				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
+					rundownId,
+				})) as DBPartInstance
+				expect(partInstance).toBeTruthy()
+
+				// Set a current part instance
+				await setPartInstances(jobContext, playlistId, partInstance, undefined)
+				await wrapWithPlayoutModel(jobContext, playlistId, async (playoutModel) => {
+					const { service } = await getTestee(jobContext, playoutModel)
+
+					await expect(
+						service.updatePartInstance('current', {}, { invalidReason: { key: 'test' } })
+					).rejects.toThrow('Can only set invalidReason on the next PartInstance')
+				})
+			})
+			test('invalidReason on next - sets and clears', async () => {
+				const { jobContext, playlistId, rundownId } = await setupMyDefaultRundown()
+
+				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
+					rundownId,
+				})) as DBPartInstance
+				expect(partInstance).toBeTruthy()
+
+				// Set as next part instance
+				await setPartInstances(jobContext, playlistId, undefined, partInstance)
+				await wrapWithPlayoutModel(jobContext, playlistId, async (playoutModel) => {
+					const { service } = await getTestee(jobContext, playoutModel)
+
+					// Set invalidReason
+					const invalidReason = { key: 'test_error', args: { foo: 'bar' } }
+					await service.updatePartInstance('next', {}, { invalidReason })
+					const partInstance1 = playoutModel.nextPartInstance! as PlayoutPartInstanceModelImpl
+					expect(partInstance1.partInstance.invalidReason).toEqual({
+						message: {
+							...invalidReason,
+							namespaces: [expect.any(String)],
+						},
+						severity: NoteSeverity.ERROR,
+					})
+
+					// Clear invalidReason
+					await service.updatePartInstance('next', {}, { invalidReason: undefined })
+					expect(partInstance1.partInstance.invalidReason).toBeUndefined()
 				})
 			})
 		})

--- a/packages/job-worker/src/playout/model/PlayoutPartInstanceModel.ts
+++ b/packages/job-worker/src/playout/model/PlayoutPartInstanceModel.ts
@@ -11,6 +11,7 @@ import { IBlueprintMutatablePart, PieceLifespan, Time } from '@sofie-automation/
 import { PartCalculatedTimings } from '@sofie-automation/corelib/dist/playout/timings'
 import { PlayoutPieceInstanceModel } from './PlayoutPieceInstanceModel.js'
 import { CoreUserEditingDefinition } from '@sofie-automation/corelib/dist/dataModel/UserEditingDefinitions'
+import { PartInvalidReason } from '@sofie-automation/corelib/dist/dataModel/Part'
 
 /**
  * Token returned when making a backup copy of a PlayoutPartInstanceModel
@@ -55,6 +56,14 @@ export interface PlayoutPartInstanceModel {
 	 * @param timestamp Timestampt to block until
 	 */
 	blockTakeUntil(timestamp: Time | null): void
+
+	/**
+	 * Set the invalid reason for this PartInstance.
+	 * This indicates a runtime validation issue that prevents taking the part.
+	 * This is distinct from the planned `invalidReason` on the Part itself.
+	 * @param reason The reason the part is invalid, or undefined to clear
+	 */
+	setInvalidReason(reason: PartInvalidReason | undefined): void
 
 	/**
 	 * Get a PieceInstance which belongs to this PartInstance

--- a/packages/job-worker/src/playout/model/implementation/PlayoutPartInstanceModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutPartInstanceModelImpl.ts
@@ -25,7 +25,7 @@ import { PlayoutPieceInstanceModel } from '../PlayoutPieceInstanceModel.js'
 import { PlayoutPieceInstanceModelImpl } from './PlayoutPieceInstanceModelImpl.js'
 import { EmptyPieceTimelineObjectsBlob } from '@sofie-automation/corelib/dist/dataModel/Piece'
 import _ from 'underscore'
-import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
+import { DBPart, PartInvalidReason } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { PlayoutMutatablePartSampleKeys } from '../../../blueprints/context/lib.js'
 import { QuickLoopService } from '../services/QuickLoopService.js'
 
@@ -215,6 +215,10 @@ export class PlayoutPartInstanceModelImpl implements PlayoutPartInstanceModel {
 
 	blockTakeUntil(timestamp: Time | null): void {
 		this.#compareAndSetPartInstanceValue('blockTakeUntil', timestamp ?? undefined)
+	}
+
+	setInvalidReason(reason: PartInvalidReason | undefined): void {
+		this.#compareAndSetPartInstanceValue('invalidReason', reason)
 	}
 
 	getPieceInstance(id: PieceInstanceId): PlayoutPieceInstanceModel | undefined {

--- a/packages/job-worker/src/playout/take.ts
+++ b/packages/job-worker/src/playout/take.ts
@@ -230,6 +230,10 @@ export async function performTakeToNextedPart(
 	if (!takeRundown)
 		throw new Error(`takeRundown: takeRundown not found! ("${takePartInstance.partInstance.rundownId}")`)
 
+	if (takePartInstance.partInstance.invalidReason) {
+		throw UserError.create(UserErrorMessage.TakePartInstanceInvalid)
+	}
+
 	const showStyle = await pShowStyle
 	const blueprint = await context.getShowStyleBlueprint(showStyle._id)
 

--- a/packages/webui/src/client/lib/partInstanceUtil.ts
+++ b/packages/webui/src/client/lib/partInstanceUtil.ts
@@ -1,0 +1,67 @@
+import type { DBPart, PartInvalidReason } from '@sofie-automation/corelib/dist/dataModel/Part'
+
+/**
+ * Minimal interface for a PartInstance containing the properties needed for invalidReason checks.
+ */
+export interface PartInstanceLike {
+	part: Pick<DBPart, 'invalid' | 'invalidReason'>
+	invalidReason?: PartInvalidReason
+}
+
+export interface PartInvalidReasonExt extends PartInvalidReason {
+	/**
+	 * If this invalid reason came from the instance (playout) rather than the part (ingest)
+	 */
+	isInstanceInvalid: boolean
+}
+
+/**
+ * Get the effective invalidReason for a PartInstance.
+ *
+ * If the Part has a planned invalidReason (from ingest), it takes precedence.
+ * Otherwise, returns the runtime invalidReason from the PartInstance (from playout).
+ *
+ * This distinction matters because:
+ * - Part.invalidReason is planned/static (set during ingest, shouldn't create real PartInstance)
+ * - PartInstance.invalidReason is runtime/dynamic (set during playout, can be fixed)
+ *
+ * @param partInstance The PartInstance object
+ * @returns The effective invalidReason to display, or undefined if none
+ */
+export function getEffectiveInvalidReason(partInstance: PartInstanceLike): PartInvalidReasonExt | undefined {
+	// Planned invalidReason (from Part/ingest) takes precedence
+	// It shouldn't be possible to create a real PartInstance of an invalid Part
+	if (partInstance.part.invalidReason) {
+		return {
+			...partInstance.part.invalidReason,
+			isInstanceInvalid: false,
+		}
+	}
+
+	// Runtime invalidReason (from PartInstance/playout)
+	if (partInstance.invalidReason) {
+		return {
+			...partInstance.invalidReason,
+			isInstanceInvalid: true,
+		}
+	}
+
+	return undefined
+}
+
+/**
+ * Check if the effective state is "invalid" for a PartInstance.
+ *
+ * A PartInstance is considered invalid if either:
+ * - The Part has `invalid: true` (planned invalid, may not have an invalidReason)
+ * - The PartInstance has a runtime invalidReason (runtime invalid)
+ *
+ * Note: This is separate from getEffectiveInvalidReason because part.invalid can be true
+ * without an invalidReason being set (legacy behavior).
+ *
+ * @param partInstance The PartInstance object
+ * @returns true if the part should be shown as invalid
+ */
+export function isPartInstanceInvalid(partInstance: PartInstanceLike): boolean {
+	return !!partInstance.part.invalid || !!partInstance.invalidReason
+}

--- a/packages/webui/src/client/styles/rundownView.scss
+++ b/packages/webui/src/client/styles/rundownView.scss
@@ -848,19 +848,38 @@ svg.icon {
 		}
 		.segment-timeline__part {
 			.segment-timeline__part__invalid-cover {
+				mix-blend-mode: color-burn;
 				background-image:
 					repeating-linear-gradient(
 						45deg,
 						var(--invalid-reason-color-transparent) 0%,
-						var(--invalid-reason-color-transparent) 4px,
-						var(--invalid-reason-color-opaque) 4px,
+						var(--invalid-reason-color-transparent) 5px,
+						var(--invalid-reason-color-opaque) 5px,
 						var(--invalid-reason-color-opaque) 8px
 					),
 					repeating-linear-gradient(
 						-45deg,
 						var(--invalid-reason-color-transparent) 0%,
-						var(--invalid-reason-color-transparent) 4px,
-						var(--invalid-reason-color-opaque) 4px,
+						var(--invalid-reason-color-transparent) 5px,
+						var(--invalid-reason-color-opaque) 5px,
+						var(--invalid-reason-color-opaque) 8px
+					) !important;
+			}
+			.segment-timeline__part__invalid-part-instance-cover {
+				mix-blend-mode: color-burn;
+				background-image:
+					repeating-linear-gradient(
+						45deg,
+						var(--invalid-reason-color-transparent) 0%,
+						var(--invalid-reason-color-transparent) 6px,
+						var(--invalid-reason-color-opaque) 6px,
+						var(--invalid-reason-color-opaque) 8px
+					),
+					repeating-linear-gradient(
+						-45deg,
+						var(--invalid-reason-color-transparent) 0%,
+						var(--invalid-reason-color-transparent) 6px,
+						var(--invalid-reason-color-opaque) 6px,
 						var(--invalid-reason-color-opaque) 8px
 					) !important;
 			}
@@ -1313,21 +1332,48 @@ svg.icon {
 				bottom: 0;
 				right: 1px;
 				z-index: 10;
-				pointer-events: none;
+				pointer-events: all;
+				mix-blend-mode: color-burn;
 				background-image:
 					repeating-linear-gradient(
 						45deg,
 						var(--invalid-reason-color-transparent) 0%,
 						var(--invalid-reason-color-transparent) 5px,
 						var(--invalid-reason-color-opaque) 5px,
-						var(--invalid-reason-color-opaque) 10px
+						var(--invalid-reason-color-opaque) 8px
 					),
 					repeating-linear-gradient(
 						-45deg,
 						var(--invalid-reason-color-transparent) 0%,
 						var(--invalid-reason-color-transparent) 5px,
 						var(--invalid-reason-color-opaque) 5px,
-						var(--invalid-reason-color-opaque) 10px
+						var(--invalid-reason-color-opaque) 8px
+					);
+			}
+
+			.segment-timeline__part__invalid-part-instance-cover {
+				position: absolute;
+				top: 0;
+				left: 1px;
+				bottom: 0;
+				right: 1px;
+				z-index: 10;
+				pointer-events: all;
+				mix-blend-mode: color-burn;
+				background-image:
+					repeating-linear-gradient(
+						45deg,
+						var(--invalid-reason-color-transparent) 0%,
+						var(--invalid-reason-color-transparent) 6px,
+						var(--invalid-reason-color-opaque) 6px,
+						var(--invalid-reason-color-opaque) 8px
+					),
+					repeating-linear-gradient(
+						-45deg,
+						var(--invalid-reason-color-transparent) 0%,
+						var(--invalid-reason-color-transparent) 6px,
+						var(--invalid-reason-color-opaque) 6px,
+						var(--invalid-reason-color-opaque) 8px
 					);
 			}
 

--- a/packages/webui/src/client/ui/SegmentList/LinePart.tsx
+++ b/packages/webui/src/client/ui/SegmentList/LinePart.tsx
@@ -19,6 +19,7 @@ import { LoopingIcon } from '../../lib/ui/icons/looping.js'
 import type { ISourceLayerExtended } from '@sofie-automation/corelib/src/dataModel/ShowStyleBase.js'
 import type { PieceUi } from '@sofie-automation/corelib/src/dataModel/Piece.js'
 import type { PartExtended } from '@sofie-automation/corelib/src/dataModel/Part.js'
+import { isPartInstanceInvalid } from '../../lib/partInstanceUtil.js'
 
 interface IProps {
 	segment: SegmentUi
@@ -85,6 +86,9 @@ export function LinePart({
 	const isOutsideActiveQuickLoop =
 		isPlaylistLooping && !isInsideQuickLoop && !isEntirePlaylistLooping && !isNextPart && !hasAlreadyPlayed
 
+	// Check for both planned and runtime invalidReason
+	const isInvalid = isPartInstanceInvalid(part.instance)
+
 	const getPartContext = useCallback(() => {
 		const partElement = document.querySelector('#' + SegmentTimelinePartElementId + part.instance._id)
 		const partDocumentOffset = getElementDocumentOffset(partElement)
@@ -142,7 +146,7 @@ export function LinePart({
 					'segment-opl__part--has-played': hasAlreadyPlayed && (!isPlaylistLooping || !isInsideQuickLoop),
 					'segment-opl__part--outside-quickloop': isOutsideActiveQuickLoop,
 					'segment-opl__part--quickloop-start': isQuickLoopStart,
-					'segment-opl__part--invalid': part.instance.part.invalid,
+					'segment-opl__part--invalid': isInvalid,
 					'segment-opl__part--timing-sibling': isPreceededByTimingGroupSibling,
 				}),
 				//@ts-expect-error A Data attribute is perfectly fine

--- a/packages/webui/src/client/ui/SegmentList/LinePartTimeline.tsx
+++ b/packages/webui/src/client/ui/SegmentList/LinePartTimeline.tsx
@@ -16,6 +16,7 @@ import { QuickLoopEnd } from './QuickLoopEnd.js'
 import { getShowHiddenSourceLayers } from '../../lib/localStorage.js'
 import type { PieceExtended, PieceUi } from '@sofie-automation/corelib/src/dataModel/Piece.js'
 import type { PartExtended } from '@sofie-automation/corelib/src/dataModel/Part.js'
+import { getEffectiveInvalidReason, isPartInstanceInvalid } from '../../lib/partInstanceUtil.js'
 
 const TIMELINE_DEFAULT_BASE = 30 * 1000
 
@@ -100,7 +101,9 @@ export const LinePartTimeline: React.FC<IProps> = function LinePartTimeline({
 	const willAutoNextIntoThisPart = isNext ? currentPartWillAutonext : part.willProbablyAutoNext
 	const willAutoNextOut = !!part.instance.part.autoNext
 
-	const isInvalid = !!part.instance.part.invalid
+	// Check for both planned and runtime invalidReason
+	const effectiveInvalidReason = getEffectiveInvalidReason(part.instance)
+	const isInvalid = isPartInstanceInvalid(part.instance)
 
 	const loop = mainPiece?.instance.piece.content?.loop
 	const endsInFreeze = !part.instance.part.autoNext && !loop && !!mainPiece?.instance.piece.content?.sourceDuration
@@ -140,8 +143,8 @@ export const LinePartTimeline: React.FC<IProps> = function LinePartTimeline({
 					)}
 				</StudioContext.Consumer>
 			)}
-			{part.instance.part.invalid && !part.instance.part.gap && (
-				<InvalidPartCover className="segment-opl__main-piece invalid" part={part.instance.part} align="start" />
+			{isInvalid && !part.instance.part.gap && (
+				<InvalidPartCover className="segment-opl__main-piece invalid" invalidReason={effectiveInvalidReason} />
 			)}
 			{!isLive && !isInvalid && (
 				<TakeLine isNext={isNext} autoNext={willAutoNextIntoThisPart} isQuickLoopStart={isQuickLoopStart} />

--- a/packages/webui/src/client/ui/SegmentStoryboard/SegmentStoryboard.scss
+++ b/packages/webui/src/client/ui/SegmentStoryboard/SegmentStoryboard.scss
@@ -606,20 +606,49 @@ $break-width: 35rem;
 		right: 1px;
 		z-index: 1;
 		pointer-events: all;
+		mix-blend-mode: color-burn;
+		opacity: 100%;
 		background-image:
 			repeating-linear-gradient(
 				45deg,
 				var(--invalid-reason-color-transparent) 0%,
 				var(--invalid-reason-color-transparent) 5px,
 				var(--invalid-reason-color-opaque) 5px,
-				var(--invalid-reason-color-opaque) 10px
+				var(--invalid-reason-color-opaque) 8px
 			),
 			repeating-linear-gradient(
 				-45deg,
 				var(--invalid-reason-color-transparent) 0%,
 				var(--invalid-reason-color-transparent) 5px,
 				var(--invalid-reason-color-opaque) 5px,
-				var(--invalid-reason-color-opaque) 10px
+				var(--invalid-reason-color-opaque) 8px
+			);
+
+	}
+	> .segment-storyboard__part__invalid-part-instance-cover {
+		position: absolute;
+		top: 0;
+		left: 1px;
+		bottom: 0;
+		right: 1px;
+		z-index: 1;
+		pointer-events: all;
+		mix-blend-mode: color-burn;
+		opacity: 100%;
+		background-image:
+			repeating-linear-gradient(
+				45deg,
+				var(--invalid-reason-color-transparent) 0%,
+				var(--invalid-reason-color-transparent) 6px,
+				var(--invalid-reason-color-opaque) 6px,
+				var(--invalid-reason-color-opaque) 8px
+			),
+			repeating-linear-gradient(
+				-45deg,
+				var(--invalid-reason-color-transparent) 0%,
+				var(--invalid-reason-color-transparent) 6px,
+				var(--invalid-reason-color-opaque) 6px,
+				var(--invalid-reason-color-opaque) 8px
 			);
 	}
 

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPart.tsx
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPart.tsx
@@ -23,6 +23,7 @@ import { type RundownTimingContext, getPartInstanceTimingId } from '../../lib/ru
 import { TimingDataResolution, TimingTickResolution, useTiming } from '../RundownView/RundownTiming/withTiming.js'
 import { LoopingIcon } from '../../lib/ui/icons/looping.js'
 import type { PartExtended } from '@sofie-automation/corelib/src/dataModel/Part.js'
+import { getEffectiveInvalidReason, isPartInstanceInvalid } from '../../lib/partInstanceUtil.js'
 
 interface IProps {
 	className?: string
@@ -126,7 +127,9 @@ export function StoryboardPart({
 
 	useRundownViewEventBusListener(RundownViewEvents.HIGHLIGHT, onHighlight)
 
-	const isInvalid = part.instance.part.invalid
+	// Get effective invalidReason: planned (Part) takes precedence over runtime (PartInstance)
+	const effectiveInvalidReason = getEffectiveInvalidReason(part.instance)
+	const isInvalid = isPartInstanceInvalid(part.instance)
 	const isFloated = part.instance.part.floated
 	const isInsideQuickLoop = timingDurations.partsInQuickLoop?.[getPartInstanceTimingId(part.instance)] ?? false
 	const isOutsideActiveQuickLoop = !isInsideQuickLoop && isPlaylistLooping && !isEntirePlaylistLooping && !isNextPart
@@ -142,7 +145,7 @@ export function StoryboardPart({
 						'invert-flash': highlight,
 						'segment-storyboard__part--next': isNextPart,
 						'segment-storyboard__part--live': isLivePart,
-						'segment-storyboard__part--invalid': part.instance.part.invalid,
+						'segment-storyboard__part--invalid': isInvalid,
 						'segment-storyboard__part--outside-quickloop': isOutsideActiveQuickLoop,
 						'segment-storyboard__part--quickloop-start': isQuickLoopStart,
 						'segment-storyboard__part--quickloop-end': isQuickLoopEnd,
@@ -179,7 +182,14 @@ export function StoryboardPart({
 				</>
 			)}
 			{isInvalid ? (
-				<InvalidPartCover className="segment-storyboard__part__invalid-cover" part={part.instance.part} />
+				<InvalidPartCover
+					className={
+						effectiveInvalidReason?.isInstanceInvalid
+							? 'segment-storyboard__part__invalid-part-instance-cover'
+							: 'segment-storyboard__part__invalid-cover'
+					}
+					invalidReason={effectiveInvalidReason}
+				/>
 			) : null}
 			{isFloated ? <div className="segment-storyboard__part__floated-cover"></div> : null}
 			<div className="segment-storyboard__part__title">{part.instance.part.title}</div>
@@ -187,7 +197,7 @@ export function StoryboardPart({
 			<div
 				className={classNames('segment-storyboard__part__next-line', {
 					'segment-storyboard__part__next-line--autonext': willBeAutoNextedInto,
-					'segment-storyboard__part__next-line--invalid': part.instance.part.invalid,
+					'segment-storyboard__part__next-line--invalid': isInvalid,
 					'segment-storyboard__part__next-line--next': isNextPart,
 					'segment-storyboard__part__next-line--live': isLivePart,
 					'segment-storyboard__part__next-line--quickloop-start': isQuickLoopStart,

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPart.tsx
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPart.tsx
@@ -246,7 +246,7 @@ export function StoryboardPart({
 					</div>
 				</>
 			)}
-			{!isLastSegment && isLastPartInSegment && !isEndOfLoopingShow && !part.instance.part.invalid && (
+			{!isLastSegment && isLastPartInSegment && !isEndOfLoopingShow && !isInvalid && (
 				<div
 					className={classNames('segment-storyboard__part__segment-end', {
 						'segment-storyboard__part__segment-end--next': isLivePart && (!isLastSegment || doesPlaylistHaveNextPart),

--- a/packages/webui/src/client/ui/SegmentTimeline/Parts/InvalidPartCover.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/Parts/InvalidPartCover.tsx
@@ -1,14 +1,17 @@
 import React, { useContext, useRef } from 'react'
-import type { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
+import type { PartInvalidReason } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { type IPreviewPopUpSession, PreviewPopUpContext } from '../../PreviewPopUp/PreviewPopUpContext.js'
 
 interface IProps {
 	className?: string
-	part: DBPart
-	align?: 'start' | 'center' | 'end'
+	/**
+	 * The effective invalidReason to display.
+	 * Can be from Part (planned) or PartInstance (runtime).
+	 */
+	invalidReason: PartInvalidReason | undefined
 }
 
-export function InvalidPartCover({ className, part }: Readonly<IProps>): JSX.Element {
+export function InvalidPartCover({ className, invalidReason }: Readonly<IProps>): JSX.Element {
 	const element = React.createRef<HTMLDivElement>()
 
 	const previewContext = useContext(PreviewPopUpContext)
@@ -19,11 +22,11 @@ export function InvalidPartCover({ className, part }: Readonly<IProps>): JSX.Ele
 			return
 		}
 
-		if (part.invalidReason?.message && !previewSession.current) {
+		if (invalidReason?.message && !previewSession.current) {
 			previewSession.current = previewContext.requestPreview(e.target as HTMLDivElement, [
 				{
 					type: 'warning',
-					content: part.invalidReason?.message,
+					content: invalidReason.message,
 				},
 			])
 		}

--- a/packages/webui/src/client/ui/SegmentTimeline/Parts/SegmentTimelinePart.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/Parts/SegmentTimelinePart.tsx
@@ -52,6 +52,7 @@ import {
 	isEndOfLoopingShow as getIsEndOfLoopingShow,
 	isEntirePlaylistLooping as getIsEntirePlaylistLooping,
 } from '@sofie-automation/corelib/src/playout/stateCacheResolver.js'
+import { getEffectiveInvalidReason, isPartInstanceInvalid } from '../../../lib/partInstanceUtil.js'
 
 export const SegmentTimelineLineElementId = 'rundown__segment__line__'
 export const SegmentTimelinePartElementId = 'rundown__segment__part__'
@@ -673,6 +674,7 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 		const { t } = this.props
 
 		const innerPart = this.props.part.instance.part
+		const partInstance = this.props.part.instance
 
 		const isEndOfShow =
 			this.props.isLastSegment &&
@@ -685,9 +687,14 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 			this.props.isLastInSegment,
 			this.props.part.instance.part
 		)
+
+		// Get effective invalidReason: planned (Part) takes precedence over runtime (PartInstance)
+		const effectiveInvalidReason = getEffectiveInvalidReason(partInstance)
+		const isInvalid = isPartInstanceInvalid(partInstance)
+
 		let invalidReasonColorVars: CSSProperties | undefined = undefined
-		if (innerPart.invalidReason && innerPart.invalidReason.color) {
-			const invalidColor = SegmentTimelinePartClass.convertHexToRgb(innerPart.invalidReason.color)
+		if (effectiveInvalidReason && 'color' in effectiveInvalidReason && effectiveInvalidReason.color) {
+			const invalidColor = SegmentTimelinePartClass.convertHexToRgb(effectiveInvalidReason.color)
 			if (invalidColor) {
 				invalidReasonColorVars = {
 					['--invalid-reason-color-opaque']: `rgba(${invalidColor.red}, ${invalidColor.green}, ${invalidColor.blue}, 1)`,
@@ -715,7 +722,7 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 						{
 							live: this.state.isLive,
 							next: (this.state.isNext || this.props.isAfterLastValidInSegmentAndItsLive) && !innerPart.invalid,
-							invalid: innerPart.invalid && !innerPart.gap,
+							invalid: isInvalid && !innerPart.gap,
 							floated: innerPart.floated,
 							gap: innerPart.gap,
 							'invert-flash': this.state.highlight,
@@ -750,8 +757,15 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 						</div>
 					)}
 					{this.renderTimelineOutputGroups(this.props.part)}
-					{innerPart.invalid ? (
-						<InvalidPartCover className="segment-timeline__part__invalid-cover" part={innerPart} />
+					{isInvalid ? (
+						<InvalidPartCover
+							className={
+								effectiveInvalidReason?.isInstanceInvalid
+									? 'segment-timeline__part__invalid-part-instance-cover'
+									: 'segment-timeline__part__invalid-cover'
+							}
+							invalidReason={effectiveInvalidReason}
+						/>
 					) : null}
 					{innerPart.floated ? <div className="segment-timeline__part__floated-cover"></div> : null}
 					{this.props.playlist.nextTimeOffset &&
@@ -760,7 +774,7 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 								className={ClassNames('segment-timeline__part__nextline', {
 									// This is the base, basic line
 									'auto-next':
-										!innerPart.invalid &&
+										!isInvalid &&
 										!innerPart.gap &&
 										((this.state.isNext && this.props.autoNextPart) ||
 											(!this.state.isNext && this.props.part.willProbablyAutoNext)),

--- a/packages/webui/src/client/ui/SegmentTimeline/Parts/SegmentTimelinePart.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/Parts/SegmentTimelinePart.tsx
@@ -573,13 +573,14 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 	private renderEndOfSegment = (
 		t: TFunction,
 		innerPart: DBPart,
+		isInvalid: boolean,
 		isEndOfShow: boolean,
-		isEndOfLoopingShow?: boolean
+		isEndOfLoopingShow: boolean
 	) => {
 		const isNext =
 			this.state.isLive &&
 			((!this.props.isLastSegment && !this.props.isLastInSegment) || !!this.props.playlist.nextPartInfo) &&
-			!innerPart.invalid
+			!isInvalid
 		let timeOffset = SegmentTimelinePartClass.getPartDisplayDuration(this.props.part, this.props.timingDurations)
 
 		if (this.state.isLive) {
@@ -610,7 +611,7 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 						</div>
 					</div>
 				)}
-				{!isEndOfShow && !isEndOfLoopingShow && this.props.isLastInSegment && !innerPart.invalid && (
+				{!isEndOfShow && !isEndOfLoopingShow && this.props.isLastInSegment && !isInvalid && (
 					<div
 						className={ClassNames('segment-timeline__part__segment-end', {
 							'is-next': isNext,
@@ -721,7 +722,7 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 						'segment-timeline__part',
 						{
 							live: this.state.isLive,
-							next: (this.state.isNext || this.props.isAfterLastValidInSegmentAndItsLive) && !innerPart.invalid,
+							next: (this.state.isNext || this.props.isAfterLastValidInSegmentAndItsLive) && !isInvalid,
 							invalid: isInvalid && !innerPart.gap,
 							floated: innerPart.floated,
 							gap: innerPart.gap,
@@ -778,7 +779,7 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 										!innerPart.gap &&
 										((this.state.isNext && this.props.autoNextPart) ||
 											(!this.state.isNext && this.props.part.willProbablyAutoNext)),
-									invalid: innerPart.invalid && !innerPart.gap,
+									invalid: isInvalid && !innerPart.gap,
 									floated: innerPart.floated,
 								})}
 								style={{
@@ -791,7 +792,7 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 											(this.props.autoNextPart || this.props.part.willProbablyAutoNext) && !this.state.isNext,
 									})}
 								>
-									{innerPart.invalid && !innerPart.gap ? null : (
+									{isInvalid && !innerPart.gap ? null : (
 										<React.Fragment>
 											{this.props.autoNextPart || this.props.part.willProbablyAutoNext
 												? t('Auto')
@@ -813,7 +814,7 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 								'auto-next':
 									(this.state.isNext && this.props.autoNextPart) ||
 									(!this.state.isNext && this.props.part.willProbablyAutoNext),
-								invalid: innerPart.invalid && !innerPart.gap,
+								invalid: isInvalid && !innerPart.gap,
 								floated: innerPart.floated,
 								offset: !!this.props.playlist.nextTimeOffset,
 								'quickloop-start': isQuickLoopStart,
@@ -825,7 +826,7 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 										(this.props.autoNextPart || this.props.part.willProbablyAutoNext) && !this.state.isNext,
 								})}
 							>
-								{innerPart.invalid && !innerPart.gap ? null : (
+								{isInvalid && !innerPart.gap ? null : (
 									<React.Fragment>
 										{(this.state.isNext && this.props.autoNextPart) ||
 										(!this.state.isNext && this.props.part.willProbablyAutoNext)
@@ -858,7 +859,7 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 						</div>
 					)}
 					{isQuickLoopEnd && <div className="segment-timeline__part__nextline__quickloop-end" />}
-					{this.renderEndOfSegment(t, innerPart, isEndOfShow, isPartEndOfLoopingShow)}
+					{this.renderEndOfSegment(t, innerPart, isInvalid, isEndOfShow, isPartEndOfLoopingShow)}
 				</div>
 			)
 		} else {
@@ -879,7 +880,7 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 				>
 					{/* render it empty, just to take up space */}
 					{this.state.isInsideViewport
-						? this.renderEndOfSegment(t, innerPart, isEndOfShow, isPartEndOfLoopingShow)
+						? this.renderEndOfSegment(t, innerPart, isInvalid, isEndOfShow, isPartEndOfLoopingShow)
 						: null}
 				</div>
 			)


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the BBC

## Type of Contribution

This is a:  Feature 


## New Behavior

This allows the nexted partinstance to be marked as invalid, while preserving it as the next partinstance.
Visually it is similar to an invalid part, but not the same

<img width="1824" height="399" alt="image" src="https://github.com/user-attachments/assets/b745ef05-7ebd-4237-9976-7423570788fd" />

It is already possible for blueprints to block a take in `onTake`, this expands upon that ability by making it visible to the user that a part is unplayable right now, while keeping it as the next one to be taken.  
This is intended to be used when hitting resource limitations, typically one that is fixable by using an adlib.

This behaves differently to a part being invalid, as this partinstance will remain as nexted. the user is free to use adlibs, change the next and other actions as usual, but they are blocked from taking into this part.


## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [x] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
