### PR TITLE
feat: Resolve device action errors using blueprint deviceActionMessages

### DIFF
--- a/meteor/server/api/__tests__/peripheralDevice.resolveActionResult.test.ts
+++ b/meteor/server/api/__tests__/peripheralDevice.resolveActionResult.test.ts
@@ -1,0 +1,185 @@
+import { DeviceStatusContext, TSR } from '@sofie-automation/blueprints-integration'
+import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import { PeripheralDeviceId, StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { Blueprints, PeripheralDevices, Studios } from '../../collections'
+import { evalBlueprint } from '../blueprints/cache'
+import { resolveActionResult } from '../peripheralDevice'
+
+jest.mock('../deviceTriggers/observer')
+jest.mock('../blueprints/cache')
+
+const mockEvalBlueprint = evalBlueprint as jest.MockedFunction<typeof evalBlueprint>
+
+const ACTION_ERROR_CODE = 'ACTION_HTTP_REQUEST_FAILED'
+const deviceId = protectString<PeripheralDeviceId>('device0')
+const studioId = protectString<StudioId>('studio0')
+
+function makeErrorResult(overrides: Partial<TSR.ActionExecutionResult> = {}): TSR.ActionExecutionResult {
+	return {
+		result: TSR.ActionExecutionResultCode.Error,
+		response: { key: 'HTTP request to {{url}} failed: {{errorMessage}}' },
+		code: ACTION_ERROR_CODE,
+		context: {
+			url: 'http://graphics/api',
+			errorMessage: 'connection refused',
+		},
+		...overrides,
+	}
+}
+
+describe('resolveActionResult', () => {
+	beforeEach(() => {
+		jest.spyOn(PeripheralDevices, 'findOneAsync').mockReset()
+		jest.spyOn(Studios, 'findOneAsync').mockReset()
+		jest.spyOn(Blueprints, 'findOneAsync').mockReset()
+		mockEvalBlueprint.mockReset()
+	})
+
+	afterEach(() => {
+		jest.restoreAllMocks()
+	})
+
+	it('returns Ok results unchanged', async () => {
+		const result: TSR.ActionExecutionResult = {
+			result: TSR.ActionExecutionResultCode.Ok,
+			response: { key: 'Action completed' },
+		}
+
+		const resolved = await resolveActionResult(deviceId, result)
+
+		expect(resolved).toBe(result)
+		expect(PeripheralDevices.findOneAsync).not.toHaveBeenCalled()
+	})
+
+	it('returns non-Ok results without a code unchanged', async () => {
+		const result = makeErrorResult({ code: undefined })
+
+		const resolved = await resolveActionResult(deviceId, result)
+
+		expect(resolved).toBe(result)
+		expect(PeripheralDevices.findOneAsync).not.toHaveBeenCalled()
+	})
+
+	it('interpolates a matching string template from deviceActionMessages', async () => {
+		jest.spyOn(PeripheralDevices, 'findOneAsync').mockResolvedValue({
+			name: 'Playout Gateway',
+			studioAndConfigId: { studioId, configId: 'config0' },
+		} as any)
+		jest.spyOn(Studios, 'findOneAsync').mockResolvedValue({ blueprintId: 'blueprint0' } as any)
+		jest.spyOn(Blueprints, 'findOneAsync').mockResolvedValue({
+			_id: 'blueprint0',
+			name: 'test',
+			code: '',
+		} as any)
+		mockEvalBlueprint.mockReturnValue({
+			deviceActionMessages: {
+				[ACTION_ERROR_CODE]: 'Failed to trigger graphics at {{url}}: {{errorMessage}}',
+			},
+		} as any)
+
+		const resolved = await resolveActionResult(deviceId, makeErrorResult())
+
+		expect(resolved.response).toEqual({
+			key: 'Failed to trigger graphics at http://graphics/api: connection refused',
+		})
+	})
+
+	it('uses a DeviceStatusMessageFunction from deviceActionMessages', async () => {
+		jest.spyOn(PeripheralDevices, 'findOneAsync').mockResolvedValue({
+			name: 'Playout Gateway',
+			studioAndConfigId: { studioId, configId: 'config0' },
+		} as any)
+		jest.spyOn(Studios, 'findOneAsync').mockResolvedValue({ blueprintId: 'blueprint0' } as any)
+		jest.spyOn(Blueprints, 'findOneAsync').mockResolvedValue({
+			_id: 'blueprint0',
+			name: 'test',
+			code: '',
+		} as any)
+		mockEvalBlueprint.mockReturnValue({
+			deviceActionMessages: {
+				[ACTION_ERROR_CODE]: (context: DeviceStatusContext) =>
+					`${context.deviceName} could not reach ${context.url as string}`,
+			},
+		} as any)
+
+		const resolved = await resolveActionResult(deviceId, makeErrorResult())
+
+		expect(resolved.response).toEqual({
+			key: 'Playout Gateway could not reach http://graphics/api',
+		})
+	})
+
+	it('clears the response when the blueprint suppresses the message', async () => {
+		jest.spyOn(PeripheralDevices, 'findOneAsync').mockResolvedValue({
+			name: 'Playout Gateway',
+			studioAndConfigId: { studioId, configId: 'config0' },
+		} as any)
+		jest.spyOn(Studios, 'findOneAsync').mockResolvedValue({ blueprintId: 'blueprint0' } as any)
+		jest.spyOn(Blueprints, 'findOneAsync').mockResolvedValue({
+			_id: 'blueprint0',
+			name: 'test',
+			code: '',
+		} as any)
+		mockEvalBlueprint.mockReturnValue({
+			deviceActionMessages: {
+				[ACTION_ERROR_CODE]: '',
+			},
+		} as any)
+
+		const original = makeErrorResult()
+		const resolved = await resolveActionResult(deviceId, original)
+
+		expect(resolved).toMatchObject({
+			result: TSR.ActionExecutionResultCode.Error,
+			code: ACTION_ERROR_CODE,
+			context: original.context,
+			response: { key: '' },
+		})
+	})
+
+	it('returns the original result when there is no matching deviceActionMessages entry', async () => {
+		jest.spyOn(PeripheralDevices, 'findOneAsync').mockResolvedValue({
+			name: 'Playout Gateway',
+			studioAndConfigId: { studioId, configId: 'config0' },
+		} as any)
+		jest.spyOn(Studios, 'findOneAsync').mockResolvedValue({ blueprintId: 'blueprint0' } as any)
+		jest.spyOn(Blueprints, 'findOneAsync').mockResolvedValue({
+			_id: 'blueprint0',
+			name: 'test',
+			code: '',
+		} as any)
+		mockEvalBlueprint.mockReturnValue({
+			deviceActionMessages: {},
+		} as any)
+
+		const result = makeErrorResult()
+		const resolved = await resolveActionResult(deviceId, result)
+
+		expect(resolved).toBe(result)
+	})
+
+	it('returns the original result when the device has no studio', async () => {
+		jest.spyOn(PeripheralDevices, 'findOneAsync').mockResolvedValue({
+			name: 'Playout Gateway',
+		} as any)
+
+		const result = makeErrorResult()
+		const resolved = await resolveActionResult(deviceId, result)
+
+		expect(resolved).toBe(result)
+		expect(Studios.findOneAsync).not.toHaveBeenCalled()
+	})
+
+	it('returns the original result when blueprint lookup fails', async () => {
+		jest.spyOn(PeripheralDevices, 'findOneAsync').mockResolvedValue({
+			name: 'Playout Gateway',
+			studioAndConfigId: { studioId, configId: 'config0' },
+		} as any)
+		jest.spyOn(Studios, 'findOneAsync').mockResolvedValue(undefined)
+
+		const result = makeErrorResult()
+		const resolved = await resolveActionResult(deviceId, result)
+
+		expect(resolved).toBe(result)
+	})
+})

--- a/meteor/server/api/__tests__/peripheralDevice.resolveActionResult.test.ts
+++ b/meteor/server/api/__tests__/peripheralDevice.resolveActionResult.test.ts
@@ -158,6 +158,41 @@ describe('resolveActionResult', () => {
 		expect(resolved).toBe(result)
 	})
 
+	it('resolves messages for child devices via the parent studio', async () => {
+		const parentDeviceId = protectString<PeripheralDeviceId>('parent0')
+		jest.spyOn(PeripheralDevices, 'findOneAsync').mockImplementation(async (id) => {
+			if (id === deviceId) {
+				return {
+					name: 'casparcg0',
+					parentDeviceId,
+				} as any
+			}
+			if (id === parentDeviceId) {
+				return {
+					studioAndConfigId: { studioId, configId: 'config0' },
+				} as any
+			}
+			return undefined
+		})
+		jest.spyOn(Studios, 'findOneAsync').mockResolvedValue({ blueprintId: 'blueprint0' } as any)
+		jest.spyOn(Blueprints, 'findOneAsync').mockResolvedValue({
+			_id: 'blueprint0',
+			name: 'test',
+			code: '',
+		} as any)
+		mockEvalBlueprint.mockReturnValue({
+			deviceActionMessages: {
+				[ACTION_ERROR_CODE]: 'Failed to trigger graphics at {{url}}: {{errorMessage}}',
+			},
+		} as any)
+
+		const resolved = await resolveActionResult(deviceId, makeErrorResult())
+
+		expect(resolved.response).toEqual({
+			key: 'Failed to trigger graphics at http://graphics/api: connection refused',
+		})
+	})
+
 	it('returns the original result when the device has no studio', async () => {
 		jest.spyOn(PeripheralDevices, 'findOneAsync').mockResolvedValue({
 			name: 'Playout Gateway',

--- a/meteor/server/api/client.ts
+++ b/meteor/server/api/client.ts
@@ -30,6 +30,7 @@ import {
 } from '../security/check'
 import { UserActionsLog } from '../collections'
 import { executePeripheralDeviceFunctionWithCustomTimeout } from './peripheralDevice/executeFunction'
+import { resolveActionResult } from './peripheralDevice'
 import { LeveledLogMethodFixed } from '@sofie-automation/corelib/dist/logging'
 import { assertConnectionHasOneOfPermissions } from '../security/auth'
 
@@ -458,7 +459,7 @@ class ServerClientAPIClass extends MethodContextAPI implements NewClientAPI {
 		actionId: string,
 		payload?: Record<string, any>
 	) {
-		return ServerClientAPI.callPeripheralDeviceFunctionOrAction(
+		const result = await ServerClientAPI.callPeripheralDeviceFunctionOrAction(
 			this,
 			context,
 			deviceId,
@@ -470,6 +471,7 @@ class ServerClientAPIClass extends MethodContextAPI implements NewClientAPI {
 			actionId,
 			payload
 		)
+		return resolveActionResult(deviceId, result)
 	}
 	async callBackgroundPeripheralDeviceFunction(
 		deviceId: PeripheralDeviceId,

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -75,7 +75,7 @@ import { assertConnectionHasOneOfPermissions } from '../security/auth'
 import { DBStudio } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { getRootSubpath } from '../lib'
 import { evalBlueprint } from './blueprints/cache'
-import { StudioBlueprintManifest } from '@sofie-automation/blueprints-integration'
+import { StudioBlueprintManifest, TSR } from '@sofie-automation/blueprints-integration'
 import { StatusMessageResolver } from '@sofie-automation/corelib'
 import { interpollateTranslation } from '@sofie-automation/corelib/dist/TranslatableMessage'
 import { Blueprint } from '@sofie-automation/corelib/dist/dataModel/Blueprint'
@@ -186,6 +186,82 @@ async function resolveDeviceStatusDetails(
 		// Log error but don't fail - fall back to original messages
 		logger.error(`Error resolving device status messages: ${e}`)
 		return []
+	}
+}
+
+/**
+ * Resolve a TSR ActionExecutionResult using the Studio blueprint's deviceActionMessages.
+ * If the result has a structured `code` and `context`, and the blueprint defines a custom
+ * message template for that code, the `response` field is replaced with the resolved message.
+ *
+ * @param deviceId - The peripheral device ID (used to look up the studio and blueprint)
+ * @param result - The action execution result from TSR
+ * @returns The result with `response` resolved if a custom message was found
+ */
+export async function resolveActionResult(
+	deviceId: PeripheralDeviceId,
+	result: TSR.ActionExecutionResult
+): Promise<TSR.ActionExecutionResult> {
+	if (result.result === TSR.ActionExecutionResultCode.Ok) return result
+	if (!result.code) return result
+
+	try {
+		const device = (await PeripheralDevices.findOneAsync(deviceId, {
+			projection: { name: 1, studioAndConfigId: 1 },
+		})) as Pick<PeripheralDevice, 'name' | 'studioAndConfigId'> | undefined
+
+		if (!device?.studioAndConfigId?.studioId) return result
+
+		const studio = (await Studios.findOneAsync(device.studioAndConfigId.studioId, {
+			projection: { blueprintId: 1 },
+		})) as Pick<DBStudio, 'blueprintId'> | undefined
+
+		if (!studio?.blueprintId) return result
+
+		const blueprint = (await Blueprints.findOneAsync(studio.blueprintId, {
+			projection: { _id: 1, name: 1, code: 1 },
+		})) as Pick<Blueprint, '_id' | 'name' | 'code'> | undefined
+
+		if (!blueprint) return result
+
+		const blueprintManifest = evalBlueprint(blueprint) as StudioBlueprintManifest
+
+		if (!blueprintManifest.deviceActionMessages) return result
+
+		const resolver = new StatusMessageResolver(blueprint._id, blueprintManifest.deviceActionMessages, undefined)
+
+		// Use the existing TSR response as the fallback default message
+		const defaultMessage = result.response?.key ?? ''
+
+		const resolved = resolver.getDeviceStatusMessage(
+			result.code,
+			{
+				...(result.context ?? {}),
+				deviceName: device.name,
+				deviceId: unprotectString(deviceId),
+			},
+			defaultMessage
+		)
+
+		if (resolved === null) {
+			// Message suppressed by blueprint
+			return result
+		}
+
+		// resolved.key is either the custom blueprint message or the defaultMessage
+		if (resolved.key === defaultMessage) {
+			// No custom message found - keep original response unchanged
+			return result
+		}
+
+		const interpolated = interpollateTranslation(resolved.key, resolved.args)
+		return {
+			...result,
+			response: { key: interpolated },
+		}
+	} catch (e) {
+		logger.error(`Error resolving device action messages: ${e}`)
+		return result
 	}
 }
 

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -83,6 +83,32 @@ import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 
 const apmNamespace = 'peripheralDevice'
 
+type StudioBlueprintLookup = {
+	blueprint: Pick<Blueprint, '_id' | 'name' | 'code'>
+	manifest: StudioBlueprintManifest
+}
+
+/**
+ * Load and evaluate the Studio blueprint manifest for a studio.
+ * Returns undefined when the studio has no blueprint or lookup fails.
+ */
+async function getStudioBlueprintManifest(studioId: StudioId): Promise<StudioBlueprintLookup | undefined> {
+	const studio = (await Studios.findOneAsync(studioId, {
+		projection: { blueprintId: 1 },
+	})) as Pick<DBStudio, 'blueprintId'> | undefined
+
+	if (!studio?.blueprintId) return undefined
+
+	const blueprint = (await Blueprints.findOneAsync(studio.blueprintId, {
+		projection: { _id: 1, name: 1, code: 1 },
+	})) as Pick<Blueprint, '_id' | 'name' | 'code'> | undefined
+
+	if (!blueprint) return undefined
+
+	const manifest = evalBlueprint(blueprint) as StudioBlueprintManifest
+	return { blueprint, manifest }
+}
+
 /**
  * Resolve device status details using the Studio blueprint's deviceStatusMessages.
  * This allows blueprints to customize status messages shown to operators.
@@ -101,27 +127,13 @@ async function resolveDeviceStatusDetails(
 	defaultMessages: string[]
 ): Promise<string[]> {
 	try {
-		// Get the studio and its blueprint
-		const studio = (await Studios.findOneAsync(studioId, {
-			projection: { blueprintId: 1 },
-		})) as Pick<DBStudio, 'blueprintId'> | undefined
-
-		if (!studio?.blueprintId) {
+		const studioBlueprint = await getStudioBlueprintManifest(studioId)
+		if (!studioBlueprint) {
 			// No blueprint, return empty (caller will use original messages)
 			return []
 		}
 
-		// Get the blueprint code
-		const blueprint = (await Blueprints.findOneAsync(studio.blueprintId, {
-			projection: { _id: 1, name: 1, code: 1 },
-		})) as Pick<Blueprint, '_id' | 'name' | 'code'> | undefined
-
-		if (!blueprint) {
-			return []
-		}
-
-		// Evaluate the blueprint to get the manifest with deviceStatusMessages
-		const blueprintManifest = evalBlueprint(blueprint) as StudioBlueprintManifest
+		const { blueprint, manifest: blueprintManifest } = studioBlueprint
 
 		logger.debug(
 			`Blueprint ${blueprint._id} deviceStatusMessages keys: ${Object.keys(blueprintManifest.deviceStatusMessages ?? {}).join(', ')}`
@@ -213,19 +225,10 @@ export async function resolveActionResult(
 
 		if (!device?.studioAndConfigId?.studioId) return result
 
-		const studio = (await Studios.findOneAsync(device.studioAndConfigId.studioId, {
-			projection: { blueprintId: 1 },
-		})) as Pick<DBStudio, 'blueprintId'> | undefined
+		const studioBlueprint = await getStudioBlueprintManifest(device.studioAndConfigId.studioId)
+		if (!studioBlueprint) return result
 
-		if (!studio?.blueprintId) return result
-
-		const blueprint = (await Blueprints.findOneAsync(studio.blueprintId, {
-			projection: { _id: 1, name: 1, code: 1 },
-		})) as Pick<Blueprint, '_id' | 'name' | 'code'> | undefined
-
-		if (!blueprint) return result
-
-		const blueprintManifest = evalBlueprint(blueprint) as StudioBlueprintManifest
+		const { blueprint, manifest: blueprintManifest } = studioBlueprint
 
 		if (!blueprintManifest.deviceActionMessages) return result
 

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -220,12 +220,23 @@ export async function resolveActionResult(
 
 	try {
 		const device = (await PeripheralDevices.findOneAsync(deviceId, {
-			projection: { name: 1, studioAndConfigId: 1 },
-		})) as Pick<PeripheralDevice, 'name' | 'studioAndConfigId'> | undefined
+			projection: { name: 1, studioAndConfigId: 1, parentDeviceId: 1 },
+		})) as Pick<PeripheralDevice, 'name' | 'studioAndConfigId' | 'parentDeviceId'> | undefined
 
-		if (!device?.studioAndConfigId?.studioId) return result
+		if (!device) return result
 
-		const studioBlueprint = await getStudioBlueprintManifest(device.studioAndConfigId.studioId)
+		// Child devices (like casparcg0) don't have studioAndConfigId directly - get it from parent
+		let studioId = device.studioAndConfigId?.studioId
+		if (!studioId && device.parentDeviceId) {
+			const parentDevice = await PeripheralDevices.findOneAsync(device.parentDeviceId, {
+				projection: { studioAndConfigId: 1 },
+			})
+			studioId = parentDevice?.studioAndConfigId?.studioId
+		}
+
+		if (!studioId) return result
+
+		const studioBlueprint = await getStudioBlueprintManifest(studioId)
 		if (!studioBlueprint) return result
 
 		const { blueprint, manifest: blueprintManifest } = studioBlueprint

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -193,10 +193,11 @@ async function resolveDeviceStatusDetails(
  * Resolve a TSR ActionExecutionResult using the Studio blueprint's deviceActionMessages.
  * If the result has a structured `code` and `context`, and the blueprint defines a custom
  * message template for that code, the `response` field is replaced with the resolved message.
+ * When the blueprint suppresses the message (empty string template), `response` is cleared.
  *
  * @param deviceId - The peripheral device ID (used to look up the studio and blueprint)
  * @param result - The action execution result from TSR
- * @returns The result with `response` resolved if a custom message was found
+ * @returns The result with `response` resolved, cleared on suppression, or unchanged when no custom message applies
  */
 export async function resolveActionResult(
 	deviceId: PeripheralDeviceId,
@@ -244,8 +245,11 @@ export async function resolveActionResult(
 		)
 
 		if (resolved === null) {
-			// Message suppressed by blueprint
-			return result
+			// Message suppressed by blueprint - clear response so the UI doesn't show the raw TSR message
+			return {
+				...result,
+				response: { key: '' },
+			}
 		}
 
 		// resolved.key is either the custom blueprint message or the defaultMessage

--- a/meteor/yarn.lock
+++ b/meteor/yarn.lock
@@ -2421,7 +2421,7 @@ __metadata:
   dependencies:
     "@mos-connection/model": "npm:^5.0.0-alpha.0"
     kairos-lib: "npm:^1.0.0"
-    timeline-state-resolver-types: "npm:10.0.0-nightly-main-20260601-094843-59ce43391.0"
+    timeline-state-resolver-types: "npm:10.0.0-nightly-main-20260602-133931-c0882da4d.0"
     tslib: "npm:^2.8.1"
     type-fest: "npm:^4.41.0"
   languageName: node
@@ -12415,13 +12415,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"timeline-state-resolver-types@npm:10.0.0-nightly-main-20260601-094843-59ce43391.0":
-  version: 10.0.0-nightly-main-20260601-094843-59ce43391.0
-  resolution: "timeline-state-resolver-types@npm:10.0.0-nightly-main-20260601-094843-59ce43391.0"
+"timeline-state-resolver-types@npm:10.0.0-nightly-main-20260602-133931-c0882da4d.0":
+  version: 10.0.0-nightly-main-20260602-133931-c0882da4d.0
+  resolution: "timeline-state-resolver-types@npm:10.0.0-nightly-main-20260602-133931-c0882da4d.0"
   dependencies:
     kairos-lib: "npm:1.0.0"
     tslib: "npm:^2.8.1"
-  checksum: 10/87a33b766a94e809cdcd3517f695c4e171bbb3a451ad390adbfc2ca31be8ccff0a3531e81f0a548b683d9fea964252043837b89c6cd12c7d27d0f7e9205b65f2
+  checksum: 10/8021f03e15a7b6f581ea4c5b77e809238a3e8120a7b0a8eed40d3a1afcb03749aaed33177b96a0c42078dcd19da08703f125ee3a1f28739bfcb9782344321bc8
   languageName: node
   linkType: hard
 

--- a/packages/blueprints-integration/src/api/studio.ts
+++ b/packages/blueprints-integration/src/api/studio.ts
@@ -112,6 +112,31 @@ export interface StudioBlueprintManifest<
 	 */
 	deviceStatusMessages?: Record<string, string | DeviceStatusMessageFunction>
 
+	/**
+	 * Alternate device action error messages, to override the default messages from TSR devices.
+	 * Keys are action error code strings from TSR devices (e.g., 'ACTION_HTTPSEND_REQUEST_FAILED').
+	 *
+	 * Similar to deviceStatusMessages but applies to device action execution failures
+	 * (e.g., HTTP Send failures, device restart failures) rather than ongoing status errors.
+	 *
+	 * Import action error codes from 'timeline-state-resolver-types' for type safety.
+	 * Values can be:
+	 * - String templates using {{variable}} syntax for interpolation with context values
+	 * - Functions that receive DeviceStatusContext and return a custom message string
+	 * - Empty string to suppress the message entirely (action result will show as generic error)
+	 *
+	 * @example
+	 * ```typescript
+	 * import { HttpSendActionErrorCode } from 'timeline-state-resolver-types'
+	 *
+	 * deviceActionMessages: {
+	 *   [HttpSendActionErrorCode.REQUEST_FAILED]: 'Failed to trigger graphics: {{errorMessage}}',
+	 *   [HttpSendActionErrorCode.MISSING_URL]: 'HTTP action not configured - missing URL',
+	 * }
+	 * ```
+	 */
+	deviceActionMessages?: Record<string, string | DeviceStatusMessageFunction | undefined>
+
 	/** Returns the items used to build the baseline (default state) of a studio, this is the baseline used when there's no active rundown */
 	getBaseline: (context: IStudioBaselineContext) => BlueprintResultStudioBaseline
 

--- a/packages/blueprints-integration/src/api/studio.ts
+++ b/packages/blueprints-integration/src/api/studio.ts
@@ -135,7 +135,7 @@ export interface StudioBlueprintManifest<
 	 * }
 	 * ```
 	 */
-	deviceActionMessages?: Record<string, string | DeviceStatusMessageFunction | undefined>
+	deviceActionMessages?: Record<string, string | DeviceStatusMessageFunction>
 
 	/** Returns the items used to build the baseline (default state) of a studio, this is the baseline used when there's no active rundown */
 	getBaseline: (context: IStudioBaselineContext) => BlueprintResultStudioBaseline

--- a/packages/playout-gateway/package.json
+++ b/packages/playout-gateway/package.json
@@ -55,7 +55,7 @@
 		"@sofie-automation/shared-lib": "26.3.0-2",
 		"debug": "^4.4.3",
 		"influx": "^5.12.0",
-		"timeline-state-resolver": "10.0.0-nightly-main-20260601-094843-59ce43391.0",
+		"timeline-state-resolver": "10.0.0-nightly-main-20260602-133931-c0882da4d.0",
 		"tslib": "^2.8.1",
 		"underscore": "^1.13.8",
 		"winston": "^3.19.0"

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -51,7 +51,7 @@
 	"dependencies": {
 		"@mos-connection/model": "^5.0.0-alpha.0",
 		"kairos-lib": "^1.0.0",
-		"timeline-state-resolver-types": "10.0.0-nightly-main-20260601-094843-59ce43391.0",
+		"timeline-state-resolver-types": "10.0.0-nightly-main-20260602-133931-c0882da4d.0",
 		"tslib": "^2.8.1",
 		"type-fest": "^4.41.0"
 	},

--- a/packages/yarn.lock
+++ b/packages/yarn.lock
@@ -7142,7 +7142,7 @@ __metadata:
   dependencies:
     "@mos-connection/model": "npm:^5.0.0-alpha.0"
     kairos-lib: "npm:^1.0.0"
-    timeline-state-resolver-types: "npm:10.0.0-nightly-main-20260601-094843-59ce43391.0"
+    timeline-state-resolver-types: "npm:10.0.0-nightly-main-20260602-133931-c0882da4d.0"
     tslib: "npm:^2.8.1"
     type-fest: "npm:^4.41.0"
   languageName: unknown
@@ -23576,7 +23576,7 @@ asn1@evs-broadcast/node-asn1:
     "@sofie-automation/shared-lib": "npm:26.3.0-2"
     debug: "npm:^4.4.3"
     influx: "npm:^5.12.0"
-    timeline-state-resolver: "npm:10.0.0-nightly-main-20260601-094843-59ce43391.0"
+    timeline-state-resolver: "npm:10.0.0-nightly-main-20260602-133931-c0882da4d.0"
     tslib: "npm:^2.8.1"
     underscore: "npm:^1.13.8"
     winston: "npm:^3.19.0"
@@ -28320,30 +28320,30 @@ asn1@evs-broadcast/node-asn1:
   languageName: node
   linkType: hard
 
-"timeline-state-resolver-api@npm:10.0.0-nightly-main-20260601-094843-59ce43391.0":
-  version: 10.0.0-nightly-main-20260601-094843-59ce43391.0
-  resolution: "timeline-state-resolver-api@npm:10.0.0-nightly-main-20260601-094843-59ce43391.0"
+"timeline-state-resolver-api@npm:10.0.0-nightly-main-20260602-133931-c0882da4d.0":
+  version: 10.0.0-nightly-main-20260602-133931-c0882da4d.0
+  resolution: "timeline-state-resolver-api@npm:10.0.0-nightly-main-20260602-133931-c0882da4d.0"
   dependencies:
     tslib: "npm:^2.8.1"
   peerDependencies:
-    timeline-state-resolver-types: 10.0.0-nightly-main-20260601-094843-59ce43391.0
-  checksum: 10/f439634295b2a6162a1dfd4201728bd8d8afa5c1c1eca11581e5569bd41e01028c702279de536960c66146e8323aab79913b5d556855575ccf4a53c993934a85
+    timeline-state-resolver-types: 10.0.0-nightly-main-20260602-133931-c0882da4d.0
+  checksum: 10/f292583d9e0f07a4074a4b0ab9c03ac05fbdb8d912c7db1e4a63dc66ccc5aef6f421c7b3f7f8cde400393ebec6e105ebbb8e2379096cee7001a57c1bf41a4092
   languageName: node
   linkType: hard
 
-"timeline-state-resolver-types@npm:10.0.0-nightly-main-20260601-094843-59ce43391.0":
-  version: 10.0.0-nightly-main-20260601-094843-59ce43391.0
-  resolution: "timeline-state-resolver-types@npm:10.0.0-nightly-main-20260601-094843-59ce43391.0"
+"timeline-state-resolver-types@npm:10.0.0-nightly-main-20260602-133931-c0882da4d.0":
+  version: 10.0.0-nightly-main-20260602-133931-c0882da4d.0
+  resolution: "timeline-state-resolver-types@npm:10.0.0-nightly-main-20260602-133931-c0882da4d.0"
   dependencies:
     kairos-lib: "npm:1.0.0"
     tslib: "npm:^2.8.1"
-  checksum: 10/87a33b766a94e809cdcd3517f695c4e171bbb3a451ad390adbfc2ca31be8ccff0a3531e81f0a548b683d9fea964252043837b89c6cd12c7d27d0f7e9205b65f2
+  checksum: 10/8021f03e15a7b6f581ea4c5b77e809238a3e8120a7b0a8eed40d3a1afcb03749aaed33177b96a0c42078dcd19da08703f125ee3a1f28739bfcb9782344321bc8
   languageName: node
   linkType: hard
 
-"timeline-state-resolver@npm:10.0.0-nightly-main-20260601-094843-59ce43391.0":
-  version: 10.0.0-nightly-main-20260601-094843-59ce43391.0
-  resolution: "timeline-state-resolver@npm:10.0.0-nightly-main-20260601-094843-59ce43391.0"
+"timeline-state-resolver@npm:10.0.0-nightly-main-20260602-133931-c0882da4d.0":
+  version: 10.0.0-nightly-main-20260602-133931-c0882da4d.0
+  resolution: "timeline-state-resolver@npm:10.0.0-nightly-main-20260602-133931-c0882da4d.0"
   dependencies:
     "@tv2media/v-connection": "npm:^7.3.4"
     atem-connection: "npm:3.7.0"
@@ -28368,8 +28368,8 @@ asn1@evs-broadcast/node-asn1:
     sprintf-js: "npm:^1.1.3"
     superfly-timeline: "npm:^9.2.0"
     threadedclass: "npm:^1.4.0"
-    timeline-state-resolver-api: "npm:10.0.0-nightly-main-20260601-094843-59ce43391.0"
-    timeline-state-resolver-types: "npm:10.0.0-nightly-main-20260601-094843-59ce43391.0"
+    timeline-state-resolver-api: "npm:10.0.0-nightly-main-20260602-133931-c0882da4d.0"
+    timeline-state-resolver-types: "npm:10.0.0-nightly-main-20260602-133931-c0882da4d.0"
     tslib: "npm:^2.8.1"
     tv-automation-quantel-gateway-client: "npm:^3.1.7"
     type-fest: "npm:^3.13.1"
@@ -28377,7 +28377,7 @@ asn1@evs-broadcast/node-asn1:
     utf-8-validate: "npm:^6.0.6"
     ws: "npm:^8.21.0"
     xml-js: "npm:^1.6.11"
-  checksum: 10/10dd02f3405673796de06f9c0c624777cbc37ace663f82b065ad4becb043d2d5825fca11a3f3221e8d20ad5e58ce2e9567b0668682a9ba0bda26ea0e97932479
+  checksum: 10/30ad64cafb8800f069e74c3f188381569c0446d76c03345daa0526d74296e50d5d050f1854211797e1acd87c7fab7b109aeaf3cae52dd35483141203252d9fcd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## About the Contributor

This pull request is posted on behalf of the BBC.

## Type of Contribution

Feature

## Current Behavior

Device action errors (e.g. HTTP Send failures, CasparCG restart failures) are returned to the UI as raw strings from the Playout Gateway. Blueprint authors have no way to customise these messages.

## New Behavior

- `deviceActionMessages` added to `StudioBlueprintManifest` — blueprint authors can provide custom message templates (with `{{variable}}` interpolation) keyed by action error code string
- `resolveActionResult()` resolves structured action errors server-side using the studio blueprint, reusing the `StatusMessageResolver` infrastructure from PR #1604
- Wired into `executePeripheralDeviceAction` so customised messages reach the UI automatically

Example blueprint configuration:

```typescript
import { HttpSendActionErrorCode } from 'timeline-state-resolver-types'

deviceActionMessages: {
  [HttpSendActionErrorCode.REQUEST_FAILED]: 'HTTP action failed - could not reach {{url}}: {{errorMessage}}',
  [HttpSendActionErrorCode.MISSING_URL]: 'HTTP action not configured - no URL set in the timeline object',
}
```

This is the companion to PR #1604 which covered device *status* errors — this PR covers device *action* execution failures.

## Testing Instructions

Requires the TSR stacked PR (on #418) for structured error codes from devices.

1. Configure `deviceActionMessages` in a studio blueprint with a custom message for `HttpSendActionErrorCode.REQUEST_FAILED`
2. Trigger an HTTP Send action with an unreachable URL
3. Verify the custom message (with interpolated `{{url}}` and `{{errorMessage}}`) appears in the UI notification

## Status

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
