### PR TITLE
fix: correctly update LSG state after initialization

### DIFF
--- a/packages/live-status-gateway/src/connector.ts
+++ b/packages/live-status-gateway/src/connector.ts
@@ -53,6 +53,7 @@ export class Connector implements IConnector {
 			await this._liveStatusServer.init()
 
 			this._logger.info('Initialization done')
+			this.initialized = true
 			return
 		} catch (e: any) {
 			this._logger.error('Error during initialization:')


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the BBC.

## Type of Contribution

This is a: Bug fix

## Current Behavior

The Live Status Gateway (LSG) exposes Kubernetes-style health endpoints via `HealthEndpoints` (`/healthz`, `/readyz`, `/metrics`).

The liveness handler returns HTTP 503 with the body **Not initialized** whenever `connector.initialized` is false.

The LSG `Connector` class declares `initialized = false` and should set it after a successful startup.

On the success path, `init()` completed core and live-status server setup and logged `Initialization done`, but it never set `this.initialized = true`. As a result, `/healthz` kept reporting not initialized even though the process was running normally, which breaks liveness probes.

## New Behavior

After `LiveStatusServer` has finished initializing and startup has succeeded, `Connector.init()` now sets `this.initialized = true` before returning.

`/healthz` can then move past the initialization gate and reflect core connection status as intended.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [X] No unit test changes are needed for this PR

### Affected areas

- Live Status Gateway (`packages/live-status-gateway`) health/liveness endpoint behaviour

## Time Frame

Important for deployments that rely on `/healthz` for liveness. We would appreciate review and merge as soon as possible so probes match actual process readiness.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [X] PR is ready to be reviewed.
- [X] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
