### PR TITLE
fix: device trigger observer crash when stopped before first reactive update

### DIFF
--- a/meteor/server/api/deviceTriggers/RundownContentObserver.ts
+++ b/meteor/server/api/deviceTriggers/RundownContentObserver.ts
@@ -33,9 +33,7 @@ export class RundownContentObserver {
 	#observers: Meteor.LiveQueryHandle[] = []
 	#cache: ContentCache
 	#cancelCache: () => void
-	#cleanup: (() => void) | undefined = () => {
-		throw new Error('RundownContentObserver.#cleanup has not been set!')
-	}
+	#cleanup: (() => void) | undefined
 	#disposed = false
 
 	private constructor(onChanged: ChangedHandler) {

--- a/meteor/server/api/deviceTriggers/StudioObserver.ts
+++ b/meteor/server/api/deviceTriggers/StudioObserver.ts
@@ -249,5 +249,6 @@ export class StudioObserver extends EventEmitter {
 		this.#playlistInStudioLiveQuery.stop()
 		this.updatePlaylistInStudio.cancel()
 		this.#rundownsLiveQuery?.stop()
+		this.#pieceInstancesLiveQuery?.stop()
 	}
 }


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of SuperFly.tv.

Fixes #1463.

## Type of Contribution

This is a: Bug fix

## Current Behaviour

<!--
Please describe how things worked before this PR.
If it's a bug fix: Describe the bug (what was happening?)
-->

Sofie randomly crashes with an unhandled rejection:

```
Error: RundownContentObserver.#cleanup has not been set!
    at RundownContentObserver.stop (RundownContentObserver.ts:178)
    at RundownsObserver.stop (RundownsObserver.ts:89)
    at StudioObserver (StudioObserver.ts:...)
    at PromiseDebounce (PromiseDebounce.ts:78)
```

This happens when an observer is stopped (because the playlist state changed)
before the debounced reactive cache has fired even once — i.e. before
`onChanged(cache)` has had a chance to set `#cleanup` to the real function.

Separately, `StudioObserver.stop()` was not stopping `#pieceInstancesLiveQuery`,
leaving the piece instances observer running and firing callbacks into a disposed
context, producing `TypeError: attempted to get private field on non-instance`
errors in the logs.

## New Behaviour

<!--
What is the new behaviour?
-->

- `RundownContentObserver.#cleanup` is initialised to `undefined` instead of a
  throwing sentinel. `stop()` already uses `this.#cleanup?.()` (optional call),
  so it is now correctly a no-op when cleanup has not yet been set.
- `StudioObserver.stop()` now stops `#pieceInstancesLiveQuery` alongside
  `#rundownsLiveQuery`, so all child observers are torn down on disposal.

**Root cause:** https://github.com/Sofie-Automation/sofie-core/commit/193815dccd92f1d86acff5b316bc0956b9e8f0e4 widened the `#cleanup` type to
`(() => void) | undefined` and updated `stop()` to use `?.()`, but left the
initial value as the throwing sentinel rather than changing it to `undefined`.
The optional chaining only short-circuits on `null`/`undefined`, so the sentinel
was still called. The crash became consistently reproducible after `d117426d2c`
added `rehearsal` and `studioId` to the RundownPlaylist field specifier, causing
`updateShowStyle` to fire more often and making the race condition much more
likely to trigger.

The partial fix for `#pieceInstancesLiveQuery` in `95b11871c6` only added a
`stop()` call in the "disposed while awaiting create" guard block, but not in
the main `stop()` method.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
-->

Device triggers / Action triggers observer chain (`StudioObserver`,
`RundownContentObserver`, `RundownsObserver`, `PieceInstancesObserver`).

## Time Frame

This is a crash bug affecting nightly builds. Please review and merge as soon as
possible.

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

Manual testing: activate a rundown playlist, then rapidly toggle rehearsal mode
or perform several quick take-next operations. Previously this would eventually
crash Meteor; with this fix it should remain stable. Device triggers should
continue to function correctly after playlist state changes.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
