### PR TITLE
fix: preserve deleted next if syncIngestUpdateToPartInstance callback is implemented

### DIFF
--- a/packages/job-worker/src/ingest/__tests__/updateNext.test.ts
+++ b/packages/job-worker/src/ingest/__tests__/updateNext.test.ts
@@ -7,6 +7,7 @@ import { protectString } from '@sofie-automation/corelib/dist/protectedString'
 import { saveIntoDb } from '../../db/changes.js'
 import { ensureNextPartIsValid as ensureNextPartIsValidRaw } from '../updateNext.js'
 import { MockJobContext, setupDefaultJobEnvironment } from '../../__mocks__/context.js'
+import { setupMockShowStyleCompound } from '../../__mocks__/presetCollections.js'
 import { runJobWithPlayoutModel } from '../../playout/lock.js'
 
 jest.mock('../../playout/setNext')
@@ -537,6 +538,47 @@ describe('ensureNextPartIsValid', () => {
 			expect.objectContaining({ part: expect.objectContaining({ _id: 'mock_part1' }) }),
 			false
 		)
+	})
+	test('Next part instance is orphaned: "deleted" and `syncIngestUpdateToPartInstance` exists', async () => {
+		const showStyleCompound = await setupMockShowStyleCompound(context)
+		await context.mockCollections.Rundowns.update(rundownId, {
+			$set: {
+				showStyleBaseId: showStyleCompound._id,
+				showStyleVariantId: showStyleCompound.showStyleVariantId,
+			},
+		})
+		context.updateShowStyleBlueprint({
+			syncIngestUpdateToPartInstance: jest.fn(),
+		})
+
+		const instanceId: PartInstanceId = protectString('orphaned_first_part_with_callback')
+		await context.mockCollections.PartInstances.insertOne(
+			literal<DBPartInstance>({
+				_id: instanceId,
+				rundownId: rundownId,
+				segmentId: protectString('mock_segment1'),
+				playlistActivationId: protectString('active'),
+				segmentPlayoutId: protectString(''),
+				takeCount: 0,
+				rehearsal: false,
+				part: literal<DBPart>({
+					_id: protectString('orphan_with_callback_1'),
+					_rank: 1.5,
+					rundownId: rundownId,
+					segmentId: protectString('mock_segment1'),
+					externalId: 'o1-callback',
+					title: 'Orphan 1 Callback',
+					expectedDurationWithTransition: undefined,
+				}),
+				orphaned: 'deleted',
+			})
+		)
+
+		await resetPartIds(null, instanceId, false)
+
+		await expect(ensureNextPartIsValid()).resolves.toBeFalsy()
+
+		expect(setNextPartMock).not.toHaveBeenCalled()
 	})
 	test('Next part is invalid, but instance is not', async () => {
 		// Insert a temporary instance

--- a/packages/job-worker/src/ingest/updateNext.ts
+++ b/packages/job-worker/src/ingest/updateNext.ts
@@ -5,8 +5,13 @@ import { setNextPart } from '../playout/setNext.js'
 import { isPartPlayable } from '@sofie-automation/corelib/dist/dataModel/Part'
 
 /**
- * Make sure that the nextPartInstance for the current Playlist is still correct
- * This will often change the nextPartInstance
+ * Make sure that the nextPartInstance for the current Playlist is still correct.
+ * This will often change the nextPartInstance.
+ *
+ * If the selected next part has been deleted by ingest, the default behavior is to
+ * drop it and autoselect a replacement. If the show-style blueprint defines
+ * `syncIngestUpdateToPartInstance`, the deleted next part is kept selected here so
+ * the blueprint can decide whether to remove it or preserve it.
  * @param context Context of the job being run
  * @param playoutModel Playout Model to operate on
  * @returns Whether the timeline should be updated following this operation
@@ -43,14 +48,22 @@ export async function ensureNextPartIsValid(context: JobContext, playoutModel: P
 
 	const orderedSegments = playoutModel.getAllOrderedSegments()
 	const orderedParts = playoutModel.getAllOrderedParts()
+	const nextPartIsDeleted = nextPartInstance?.partInstance.orphaned === 'deleted'
 
-	if (!nextPartInstance || nextPartInstance.partInstance.orphaned === 'deleted') {
-		// Don't have a nextPart or it has been deleted, so autoselect something
+	if (nextPartIsDeleted && (await hasSyncIngestUpdateToPartInstance(context, playoutModel, nextPartInstance))) {
+		// Source has deleted this part, but it is selected as next.
+		// Keep it selected, and let blueprint function `syncIngestUpdateToPartInstance` decide what to do with it.
+		span?.end()
+		return false
+	}
+
+	if (!nextPartInstance || nextPartIsDeleted) {
+		// Don't have a nextPart, so autoselect something
 		const newNextPart = selectNextPart(
 			context,
 			playlist,
 			currentPartInstance?.partInstance ?? null,
-			nextPartInstance?.partInstance ?? null,
+			null,
 			orderedSegments,
 			orderedParts,
 			{ ignoreUnplayable: true, ignoreQuickLoop: false }
@@ -96,4 +109,27 @@ export async function ensureNextPartIsValid(context: JobContext, playoutModel: P
 
 	span?.end()
 	return false
+}
+
+async function hasSyncIngestUpdateToPartInstance(
+	context: JobContext,
+	playoutModel: PlayoutModel,
+	nextPartInstance: PlayoutModel['nextPartInstance']
+): Promise<boolean> {
+	if (!nextPartInstance) return false
+	const rundown = playoutModel.getRundown(nextPartInstance.partInstance.part.rundownId)
+	if (!rundown) return false
+	if (!rundown.rundown.showStyleVariantId) return false
+
+	try {
+		const showStyle = await context.getShowStyleCompound(
+			rundown.rundown.showStyleVariantId,
+			rundown.rundown.showStyleBaseId
+		)
+		const blueprint = await context.getShowStyleBlueprint(showStyle._id)
+
+		return !!blueprint.blueprint.syncIngestUpdateToPartInstance
+	} catch {
+		return false
+	}
 }


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This PR is posted on behalf of EVS Broadcast Equipment.

## Type of Contribution

This is a: Feature

## Current Behavior

<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

If the next part is deleted during an ingest operation, it is removed from the rundown regardless of whether it directly affects the NEXT preview and regardless of whether the `syncIngestUpdateToPartInstance` callback is implemented in the blueprint.

## New Behavior

<!--
What is the new behavior?
-->

This implementation gives blueprints control over whether the next part should be deleted or retained.

If a blueprint implements the `syncIngestUpdateToPartInstance` callback, Core assumes the blueprint intends to manage the lifecycle of the next part.

### Case 1: `syncIngestUpdateToPartInstance` is not implemented
Core preserves the existing behavior and automatically removes the next part.

### Case 2:`syncIngestUpdateToPartInstance` is implemented
Core no longer automatically removes the next part. Instead, responsibility is delegated to the blueprint, allowing `syncIngestUpdateToPartInstance` to decide whether the next part should be kept or deleted.

This gives blueprints full control over handling next-part lifecycle behavior during ingest updates.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [x] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

This PR affects data ingesting.

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

Not urgent.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
