### PR TITLE
feat: split thumbnail previews

### DIFF
--- a/meteor/server/publications/pieceContentStatusUI/__tests__/checkPieceContentStatus.test.ts
+++ b/meteor/server/publications/pieceContentStatusUI/__tests__/checkPieceContentStatus.test.ts
@@ -14,6 +14,7 @@ import {
 	SourceLayerType,
 	IBlueprintPieceGeneric,
 	PieceLifespan,
+	SplitsContent,
 	VTContent,
 } from '@sofie-automation/blueprints-integration'
 import { ShelfButtonSize } from '@sofie-automation/shared-lib/dist/core/model/StudioSettings'
@@ -818,5 +819,169 @@ describe('lib/mediaObjects', () => {
 				packageContainerPackageStatuses: [],
 			})
 		)
+	})
+
+	describe('SPLITS boxPreviews', () => {
+		const mockStudioSettings: IStudioSettings = {
+			supportedMediaFormats: '1920x1080i5000',
+			mediaPreviewsUrl: 'http://preview/',
+			supportedAudioStreams: '4',
+			frameRate: 25,
+			minimumTakeSpan: DEFAULT_MINIMUM_TAKE_SPAN,
+			allowHold: false,
+			allowPieceDirectPlay: false,
+			enableBuckets: false,
+			enableEvaluationForm: false,
+			shelfAdlibButtonSize: ShelfButtonSize.LARGE,
+		}
+
+		const mockDefaultStudio = defaultStudio(protectString('studio0'))
+		const mockStudio: Complete<PieceContentStatusStudio> = {
+			_id: mockDefaultStudio._id,
+			settings: mockStudioSettings,
+			packageContainerSettings: {
+				previewContainerIds: ['previews0'],
+				thumbnailContainerIds: ['thumbnails0'],
+			},
+			routeSets: applyAndValidateOverrides(mockDefaultStudio.routeSetsWithOverrides).obj,
+			mappings: applyAndValidateOverrides(mockDefaultStudio.mappingsWithOverrides).obj,
+			packageContainers: applyAndValidateOverrides(mockDefaultStudio.packageContainersWithOverrides).obj,
+		}
+
+		const splitsLayer = literal<ISourceLayer>({
+			_id: '',
+			_rank: 0,
+			name: 'Splits',
+			type: SourceLayerType.SPLITS,
+		})
+
+		const messageFactory = new PieceContentStatusMessageFactory(undefined)
+		const mockOwnerId = protectString<RundownId>('rundown0')
+
+		async function insertMediaObject(mediaId: string): Promise<void> {
+			await mockMediaObjectsCollection.insertAsync(
+				literal<MediaObject>({
+					_id: protectString(''),
+					_attachments: {},
+					_rev: '',
+					cinf: '',
+					collectionId: 'studio0',
+					mediaId,
+					mediaPath: '',
+					mediaSize: 0,
+					mediaTime: 0,
+					mediainfo: literal<MediaInfo>({
+						name: mediaId,
+						field_order: PackageInfo.FieldOrder.Progressive,
+						streams: [
+							literal<MediaStream>({
+								width: 1920,
+								height: 1080,
+								codec: {
+									type: MediaStreamType.Video,
+									time_base: '1/50',
+								},
+							}),
+						],
+					}),
+					objId: '',
+					previewPath: 'previews',
+					previewSize: 0,
+					previewTime: 0,
+					studioId: protectString('studio0'),
+					thumbSize: 0,
+					thumbTime: 0,
+					tinf: '',
+				})
+			)
+		}
+
+		test('MediaObject fallback: index-aligned boxPreviews with dots in file names', async () => {
+			await insertMediaObject('CLIPS/HEAD3_SNOW.MP4')
+			await insertMediaObject('CLIPS/OTHER.MP4')
+
+			const [status] = await checkPieceContentStatusAndDependencies(
+				mockStudio,
+				mockOwnerId,
+				messageFactory,
+				literal<PieceGeneric>({
+					_id: protectString('split1'),
+					name: 'Split',
+					prerollDuration: 0,
+					externalId: '',
+					lifespan: PieceLifespan.WithinPart,
+					privateData: {},
+					outputLayerId: '',
+					sourceLayerId: '',
+					content: literal<SplitsContent>({
+						boxSourceConfiguration: [
+							{
+								type: SourceLayerType.CAMERA,
+								studioLabel: 'Cam 1',
+								switcherInput: 1,
+							},
+							{
+								type: SourceLayerType.VT,
+								studioLabel: 'Snow',
+								switcherInput: '',
+								fileName: 'clips/head3_Snow.mp4',
+								path: 'clips/head3_Snow.mp4',
+							},
+							{
+								type: SourceLayerType.VT,
+								studioLabel: 'Other',
+								switcherInput: '',
+								fileName: 'clips/other.mp4',
+								path: 'clips/other.mp4',
+							},
+						],
+					}),
+					timelineObjectsString: EmptyPieceTimelineObjectsBlob,
+				}),
+				splitsLayer
+			)
+
+			expect(status.thumbnailUrl).toBeUndefined()
+			expect(status.previewUrl).toBeUndefined()
+			expect(status.boxPreviews).toHaveLength(3)
+			expect(status.boxPreviews?.[0]).toEqual({})
+			expect(status.boxPreviews?.[1]?.thumbnailUrl).toContain('CLIPS%2FHEAD3_SNOW.MP4')
+			expect(status.boxPreviews?.[2]?.thumbnailUrl).toContain('CLIPS%2FOTHER.MP4')
+		})
+
+		test('case-insensitive fileName matching', async () => {
+			await insertMediaObject('CLIPS/FOO.MP4')
+
+			const [status] = await checkPieceContentStatusAndDependencies(
+				mockStudio,
+				mockOwnerId,
+				messageFactory,
+				literal<PieceGeneric>({
+					_id: protectString('split2'),
+					name: 'Split',
+					prerollDuration: 0,
+					externalId: '',
+					lifespan: PieceLifespan.WithinPart,
+					privateData: {},
+					outputLayerId: '',
+					sourceLayerId: '',
+					content: literal<SplitsContent>({
+						boxSourceConfiguration: [
+							{
+								type: SourceLayerType.VT,
+								studioLabel: 'Foo',
+								switcherInput: '',
+								fileName: 'clips/foo.mp4',
+								path: 'clips/foo.mp4',
+							},
+						],
+					}),
+					timelineObjectsString: EmptyPieceTimelineObjectsBlob,
+				}),
+				splitsLayer
+			)
+
+			expect(status.boxPreviews?.[0]?.thumbnailUrl).toBeDefined()
+		})
 	})
 })

--- a/meteor/server/publications/pieceContentStatusUI/checkPieceContentStatus.ts
+++ b/meteor/server/publications/pieceContentStatusUI/checkPieceContentStatus.ts
@@ -8,6 +8,7 @@ import {
 	LiveSpeakContent,
 	PackageInfo,
 	SourceLayerType,
+	SplitsContent,
 	VTContent,
 } from '@sofie-automation/blueprints-integration'
 import { getExpectedPackageId } from '@sofie-automation/corelib/dist/dataModel/ExpectedPackages'
@@ -52,11 +53,17 @@ import {
 	PackageInfoLight,
 	PieceDependencies,
 } from './common'
-import { PieceContentStatusObj } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
+import { PieceContentStatusObj, SplitBoxPreviewUrls } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
 import { PieceContentStatusMessageFactory, PieceContentStatusMessageRequiredArgs } from './messageFactory'
 import { PackageStatusMessage } from '@sofie-automation/shared-lib/dist/packageStatusMessages'
 import { BucketAdLib } from '@sofie-automation/corelib/dist/dataModel/BucketAdLibPiece'
 import { StudioPackageContainerSettings } from '@sofie-automation/shared-lib/dist/core/model/PackageContainer'
+import {
+	buildPublishedBoxPreviews,
+	getMediaIdFromSplitBox,
+	getMediaIdsFromSplitsContent,
+	normalizeSplitBoxMediaId,
+} from '@sofie-automation/shared-lib/dist/package-manager/splitBoxMedia'
 
 const DEFAULT_MESSAGE_FACTORY = new PieceContentStatusMessageFactory(undefined)
 
@@ -241,24 +248,45 @@ export async function checkPieceContentStatusAndDependencies(
 	}
 
 	if (studio.settings.mockPieceContentStatus) {
-		return [
-			{
-				status: PieceStatusCode.OK,
-				messages: [],
-				progress: undefined,
+		const mockStatus: PieceContentStatusObj = {
+			status: PieceStatusCode.OK,
+			messages: [],
+			progress: undefined,
 
-				freezes: [],
-				blacks: [],
-				scenes: [],
+			freezes: [],
+			blacks: [],
+			scenes: [],
 
-				thumbnailUrl: '/dev/fakeThumbnail.png',
-				previewUrl: '/dev/fakePreview.mp4',
+			thumbnailUrl: '/dev/fakeThumbnail.png',
+			previewUrl: '/dev/fakePreview.mp4',
 
-				packageName: '/dev/fakePreview.mp4',
-				contentDuration: 30 * 1000,
-			},
-			pieceDependencies,
-		]
+			packageName: '/dev/fakePreview.mp4',
+			contentDuration: 30 * 1000,
+		}
+
+		if (sourceLayer.type === SourceLayerType.SPLITS) {
+			const splitsContent = piece.content as SplitsContent | undefined
+			if (splitsContent?.boxSourceConfiguration) {
+				return [
+					{
+						...mockStatus,
+						thumbnailUrl: undefined,
+						previewUrl: undefined,
+						boxPreviews: splitsContent.boxSourceConfiguration.map((box) =>
+							getMediaIdFromSplitBox(box)
+								? {
+										thumbnailUrl: '/dev/fakeThumbnail.png',
+										previewUrl: '/dev/fakePreview.mp4',
+									}
+								: {}
+						),
+					},
+					pieceDependencies,
+				]
+			}
+		}
+
+		return [mockStatus, pieceDependencies]
 	}
 
 	const ignoreMediaStatus = piece.content && piece.content.ignoreMediaObjectStatus
@@ -295,6 +323,17 @@ export async function checkPieceContentStatusAndDependencies(
 				) as Promise<PackageContainerPackageStatusLight | undefined>
 			}
 
+			const getMediaObject = async (mediaId: string) => {
+				pieceDependencies.mediaObjects.push(mediaId)
+				return MediaObjects.findOneAsync(
+					{
+						studioId: studio._id,
+						mediaId,
+					},
+					{ projection: mediaObjectFieldSpecifier }
+				) as Promise<MediaObjectLight | undefined>
+			}
+
 			// Using Expected Packages:
 			const status = await checkPieceContentExpectedPackageStatus(
 				piece,
@@ -305,6 +344,9 @@ export async function checkPieceContentStatusAndDependencies(
 				getPackageContainerPackageStatus,
 				messageFactory || DEFAULT_MESSAGE_FACTORY
 			)
+			if (sourceLayer.type === SourceLayerType.SPLITS && status.boxPreviews) {
+				await fillSplitsBoxPreviewsFromMediaObjects(studio, piece, status, getMediaObject)
+			}
 			return [status, pieceDependencies]
 		} else {
 			// Fallback to MediaObject statuses:
@@ -317,6 +359,11 @@ export async function checkPieceContentStatusAndDependencies(
 					},
 					{ projection: mediaObjectFieldSpecifier }
 				) as Promise<MediaObjectLight | undefined>
+			}
+
+			if (sourceLayer.type === SourceLayerType.SPLITS) {
+				const status = await checkPieceContentSplitsMediaObjectStatus(piece, studio, getMediaObject)
+				return [status, pieceDependencies]
 			}
 
 			const status = await checkPieceContentMediaObjectStatus(
@@ -353,6 +400,89 @@ export async function checkPieceContentStatusAndDependencies(
 interface MediaObjectMessage {
 	status: PieceStatusCode
 	message: ITranslatableMessage | null
+}
+
+async function fillSplitsBoxPreviewsFromMediaObjects(
+	studio: PieceContentStatusStudio,
+	piece: PieceContentStatusPiece,
+	status: PieceContentStatusObj,
+	getMediaObject: (mediaId: string) => Promise<MediaObjectLight | undefined>
+): Promise<void> {
+	const splitsContent = piece.content as SplitsContent | undefined
+	const boxes = splitsContent?.boxSourceConfiguration
+	if (!boxes?.length || !status.boxPreviews) return
+
+	const newPreviews = [...status.boxPreviews]
+	for (let i = 0; i < boxes.length; i++) {
+		const mediaId = getMediaIdFromSplitBox(boxes[i])
+		if (!mediaId) continue
+
+		const preview = newPreviews[i] ?? {}
+		if (preview.thumbnailUrl || preview.previewUrl) continue
+
+		const mediaObject = await getMediaObject(mediaId)
+		if (!mediaObject) continue
+
+		newPreviews[i] = {
+			thumbnailUrl: getAssetUrlFromContentMetaData(mediaObject, 'thumbnail', studio.settings.mediaPreviewsUrl),
+			previewUrl: getAssetUrlFromContentMetaData(mediaObject, 'preview', studio.settings.mediaPreviewsUrl),
+		}
+	}
+	status.boxPreviews = newPreviews
+}
+
+async function checkPieceContentSplitsMediaObjectStatus(
+	piece: PieceContentStatusPiece,
+	studio: PieceContentStatusStudio,
+	getMediaObject: (mediaId: string) => Promise<MediaObjectLight | undefined>
+): Promise<PieceContentStatusObj> {
+	const splitsContent = piece.content as SplitsContent | undefined
+	const boxes = splitsContent?.boxSourceConfiguration ?? []
+	const previewByMediaId = new Map<string, SplitBoxPreviewUrls>()
+	let contentDuration: number | undefined
+
+	for (const mediaId of getMediaIdsFromSplitsContent({ boxSourceConfiguration: boxes })) {
+		const mediaObject = await getMediaObject(mediaId)
+		if (!mediaObject) continue
+
+		previewByMediaId.set(mediaId, {
+			thumbnailUrl: getAssetUrlFromContentMetaData(mediaObject, 'thumbnail', studio.settings.mediaPreviewsUrl),
+			previewUrl: getAssetUrlFromContentMetaData(mediaObject, 'preview', studio.settings.mediaPreviewsUrl),
+		})
+
+		if (mediaObject.mediainfo?.streams?.length) {
+			const maximumStreamDuration = mediaObject.mediainfo.streams.reduce(
+				(prev, current) =>
+					current.duration !== undefined ? Math.max(prev, Number.parseFloat(current.duration)) : prev,
+				Number.NaN
+			)
+			if (Number.isFinite(maximumStreamDuration)) {
+				contentDuration = Math.max(contentDuration ?? 0, maximumStreamDuration)
+			}
+		}
+	}
+
+	let pieceStatus = PieceStatusCode.UNKNOWN
+	if (previewByMediaId.size > 0) {
+		pieceStatus = PieceStatusCode.OK
+	}
+
+	return {
+		status: pieceStatus,
+		messages: [],
+		progress: 0,
+
+		freezes: [],
+		blacks: [],
+		scenes: [],
+
+		thumbnailUrl: undefined,
+		previewUrl: undefined,
+
+		packageName: null,
+		contentDuration,
+		boxPreviews: buildPublishedBoxPreviews(boxes, previewByMediaId),
+	}
 }
 
 async function checkPieceContentMediaObjectStatus(
@@ -609,6 +739,8 @@ async function checkPieceContentExpectedPackageStatus(
 	messageFactory: PieceContentStatusMessageFactory
 ): Promise<PieceContentStatusObj> {
 	const settings: IStudioSettings | undefined = studio?.settings
+	const isSplitsLayer = sourceLayer.type === SourceLayerType.SPLITS
+	const previewByMediaId = new Map<string, SplitBoxPreviewUrls>()
 
 	const ignoreMediaAudioStatus = piece.content && piece.content.ignoreAudioFormat
 
@@ -708,28 +840,31 @@ async function checkPieceContentExpectedPackageStatus(
 					continue
 				}
 
-				if (!thumbnailUrl) {
-					const sideEffect = getSideEffect(expectedPackage, studio.packageContainerSettings)
+				const resolvedUrls = await resolveExpectedPackageAssetUrls(
+					studio,
+					expectedPackage,
+					candidatePackageId,
+					getPackageContainerPackageStatus
+				)
 
-					thumbnailUrl = await getAssetUrlFromPackageContainerStatus(
-						studio.packageContainers,
-						getPackageContainerPackageStatus,
-						candidatePackageId,
-						sideEffect.thumbnailContainerId,
-						sideEffect.thumbnailPackageSettings?.path
-					)
-				}
+				if (isSplitsLayer) {
+					const pkgMediaPath = getExpectedPackageFileName(expectedPackage)
+					if (pkgMediaPath) {
+						const mediaId = normalizeSplitBoxMediaId(pkgMediaPath)
+						const existing = previewByMediaId.get(mediaId) ?? {}
+						previewByMediaId.set(mediaId, {
+							thumbnailUrl: existing.thumbnailUrl ?? resolvedUrls.thumbnailUrl,
+							previewUrl: existing.previewUrl ?? resolvedUrls.previewUrl,
+						})
+					}
+				} else {
+					if (!thumbnailUrl) {
+						thumbnailUrl = resolvedUrls.thumbnailUrl
+					}
 
-				if (!previewUrl) {
-					const sideEffect = getSideEffect(expectedPackage, studio.packageContainerSettings)
-
-					previewUrl = await getAssetUrlFromPackageContainerStatus(
-						studio.packageContainers,
-						getPackageContainerPackageStatus,
-						candidatePackageId,
-						sideEffect.previewContainerId,
-						sideEffect.previewPackageSettings?.path
-					)
+					if (!previewUrl) {
+						previewUrl = resolvedUrls.previewUrl
+					}
 				}
 
 				progress = getPackageProgress(packageOnPackageContainer.status) ?? undefined
@@ -868,6 +1003,16 @@ async function checkPieceContentExpectedPackageStatus(
 			: messageFactory.getTranslation(msg.message, messageArgs)
 	})
 
+	let boxPreviews: SplitBoxPreviewUrls[] | undefined
+	if (isSplitsLayer) {
+		const splitsContent = piece.content as SplitsContent | undefined
+		if (splitsContent?.boxSourceConfiguration) {
+			boxPreviews = buildPublishedBoxPreviews(splitsContent.boxSourceConfiguration, previewByMediaId)
+		}
+		thumbnailUrl = undefined
+		previewUrl = undefined
+	}
+
 	return {
 		status: pieceStatus,
 		messages: _.compact(translatedMessages),
@@ -883,7 +1028,38 @@ async function checkPieceContentExpectedPackageStatus(
 		packageName,
 
 		contentDuration,
+		boxPreviews,
 	}
+}
+
+async function resolveExpectedPackageAssetUrls(
+	studio: PieceContentStatusStudio,
+	expectedPackage: ExpectedPackage.Any,
+	candidatePackageId: ExpectedPackageId,
+	getPackageContainerPackageStatus: (
+		packageContainerId: string,
+		expectedPackageId: ExpectedPackageId
+	) => Promise<PackageContainerPackageStatusLight | undefined>
+): Promise<SplitBoxPreviewUrls> {
+	const sideEffect = getSideEffect(expectedPackage, studio.packageContainerSettings)
+
+	const thumbnailUrl = await getAssetUrlFromPackageContainerStatus(
+		studio.packageContainers,
+		getPackageContainerPackageStatus,
+		candidatePackageId,
+		sideEffect.thumbnailContainerId,
+		sideEffect.thumbnailPackageSettings?.path
+	)
+
+	const previewUrl = await getAssetUrlFromPackageContainerStatus(
+		studio.packageContainers,
+		getPackageContainerPackageStatus,
+		candidatePackageId,
+		sideEffect.previewContainerId,
+		sideEffect.previewPackageSettings?.path
+	)
+
+	return { thumbnailUrl, previewUrl }
 }
 
 async function getAssetUrlFromPackageContainerStatus(

--- a/packages/corelib/src/dataModel/PieceContentStatus.ts
+++ b/packages/corelib/src/dataModel/PieceContentStatus.ts
@@ -31,6 +31,11 @@ export interface UIPieceContentStatus {
 	status: PieceContentStatusObj
 }
 
+export interface SplitBoxPreviewUrls {
+	thumbnailUrl?: string
+	previewUrl?: string
+}
+
 export interface PieceContentStatusObj {
 	status: PieceStatusCode
 	messages: ITranslatableMessage[]
@@ -47,4 +52,11 @@ export interface PieceContentStatusObj {
 	contentDuration: number | undefined
 
 	progress: number | undefined
+
+	/**
+	 * Per-box preview URLs for SPLITS pieces.
+	 * Same length and order as `SplitsContent.boxSourceConfiguration`.
+	 * Non-file boxes (camera, remote, etc.) use `{}`.
+	 */
+	boxPreviews?: SplitBoxPreviewUrls[]
 }

--- a/packages/documentation/docs/for-developers/for-blueprint-developers/splits-box-previews.md
+++ b/packages/documentation/docs/for-developers/for-blueprint-developers/splits-box-previews.md
@@ -1,0 +1,169 @@
+---
+title: SPLITS box previews
+sidebar_position: 11
+---
+
+# SPLITS box previews
+
+Sofie can show **package-manager thumbnails and preview video inside each box** of a SPLITS (multi-box / DVE) piece.
+
+Blueprints define which sources sit in each box and which media files they use. Core resolves preview URLs at runtime and publishes them on the `uiPieceContentStatuses` publication. The WebUI draws them on the dashboard shelf buttons and in hover popups.
+
+| Part      | Responsibility                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Blueprint | [`SplitsContent`](https://github.com/Sofie-Automation/sofie-core/blob/main/packages/blueprints-integration/src/content.ts) (`boxSourceConfiguration`), optional [`expectedPackages`](https://github.com/Sofie-Automation/sofie-core/blob/main/packages/blueprints-integration/src/documents/pieceGeneric.ts) (same `MEDIA_FILE` pattern as VT), optional [`popUpPreview`](https://github.com/Sofie-Automation/sofie-core/blob/main/packages/blueprints-integration/src/previews.ts) |
+| Core      | `status.boxPreviews[]` — one entry per box, same order as `boxSourceConfiguration`                                                                                                                                                                                                                                                                                                                                                                                                  |
+| WebUI     | Merges `boxPreviews` into split layouts; most inline surfaces stay colour-only                                                                                                                                                                                                                                                                                                                                                                                                      |
+
+For SPLITS pieces, piece-level `thumbnailUrl` / `previewUrl` on content status are always empty. Use `boxPreviews` only.
+
+## What to put on the piece
+
+Each SPLITS piece that should show media previews needs layout on `content` and, for VT (or other file-based) boxes, package expectations on the same [`IBlueprintPieceGeneric`](https://github.com/Sofie-Automation/sofie-core/blob/main/packages/blueprints-integration/src/documents/pieceGeneric.ts).
+
+### `boxSourceConfiguration`
+
+[`SplitsContent`](https://github.com/Sofie-Automation/sofie-core/blob/main/packages/blueprints-integration/src/content.ts) stores boxes in `boxSourceConfiguration`. Index `0` is the rearmost layer.
+
+| Box             | `SourceLayerType`                   | Blueprint must set                                                      |
+| --------------- | ----------------------------------- | ----------------------------------------------------------------------- |
+| VT clip         | `VT` (or `LIVE_SPEAK` on your show) | `fileName`, `studioLabel`, `switcherInput`, `geometry`, usual VT fields |
+| Camera          | `CAMERA`                            | `studioLabel`, `switcherInput`, `geometry`                              |
+| Remote          | `REMOTE`                            | Same as camera                                                          |
+| Graphics / Nora | `GRAPHICS` (per show)               | Your existing pattern; include `fileName` if the box uses a file        |
+
+Any VT (or file-based) box that should show a thumbnail **must** have `fileName` on that box entry. Without it, Core cannot match media and the WebUI shows only a layer-colour block.
+
+**Geometry:** `geometry.x`, `geometry.y`, and `geometry.scale` are fractions of the layout (0–1). Optional `geometry.crop` (`left`, `top`, `right`, `bottom`, also 0–1) is applied in the WebUI with CSS `clip-path` — for example a 9:16 portrait window inside a square cell.
+
+Your ingest may still use a nested `{ geometry, source }[]` shape internally. Sofie does **not** store that on the piece; map it into `SplitsContent` when building pieces.
+
+### `expectedPackages`
+
+`expectedPackages` on pieces is **not new**. The `MEDIA_FILE` shape is the same one you already use on standalone VT pieces. Some shows may already attach packages to SPLITS pieces for Package Manager / playout.
+
+What **is** new is how Core uses them for the UI:
+
+| Before split box previews                                                                              | After                                                                               |
+| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| SPLITS + `expectedPackages` → one piece-level `thumbnailUrl` / `previewUrl` (first package only)       | Per-box URLs in `status.boxPreviews[]`, matched to each VT box `fileName`           |
+| SPLITS without `expectedPackages` → content status did not read VT media from `boxSourceConfiguration` | Core resolves previews from `fileName` via MediaObjects (and packages when present) |
+
+#### Rules
+
+- Add one [`ExpectedPackage.PackageType.MEDIA_FILE`](https://github.com/Sofie-Automation/sofie-core/blob/main/packages/shared-lib/src/package-manager/package.ts) per **distinct** file in the layout.
+- `content.filePath` must match the box `fileName` (same string as playout and Package Manager).
+- Reuse your existing VT package helpers (`sources`, `version`, accessors, containers).
+- Do **not** put `thumbnailUrl` or `previewUrl` on content or packages.
+- Two boxes sharing one file → one package entry; both boxes still need that `fileName`.
+
+If VT boxes have no `expectedPackages`, Core can still fill previews from **MediaObjects** only. Prefer `expectedPackages` whenever your VT pieces already use them — routing, status, and Package Manager thumbnails stay consistent.
+
+### Source layer
+
+- `sourceLayerId` must point to a layer with `type: SPLITS` in the show-style blueprint.
+- Timeline / playout for splits is unchanged; only content status and preview UI are affected.
+
+## Optional `popUpPreview`
+
+You may set `content.popUpPreview` with [`PreviewType.Split`](https://github.com/Sofie-Automation/sofie-core/blob/main/packages/blueprints-integration/src/previews.ts) (`boxes`, optional `background` asset).
+
+Preview **URLs still come from** `UIPieceContentStatus`, not from the blueprint preview object. If `popUpPreview` is omitted, SPLITS pieces still get a default hover popup built from `SplitsContent`.
+
+## Published status: `boxPreviews`
+
+The `uiPieceContentStatuses` publication includes `status.boxPreviews` on [`PieceContentStatusObj`](https://github.com/Sofie-Automation/sofie-core/blob/main/packages/corelib/src/dataModel/PieceContentStatus.ts).
+
+| Field                                      | Description                                              |
+| ------------------------------------------ | -------------------------------------------------------- |
+| `boxPreviews`                              | Array, same length and order as `boxSourceConfiguration` |
+| `boxPreviews[i]`                           | `{}` for camera / remote / other non-file boxes          |
+| `boxPreviews[i].thumbnailUrl`              | Thumbnail for box `i` when media is ready                |
+| `boxPreviews[i].previewUrl`                | Preview video for box `i` (hover scrub)                  |
+| `thumbnailUrl`, `previewUrl` (piece-level) | Always unset for SPLITS                                  |
+
+## How Core resolves preview URLs
+
+Implementation: [`checkPieceContentStatus.ts`](https://github.com/Sofie-Automation/sofie-core/blob/main/meteor/server/publications/pieceContentStatusUI/checkPieceContentStatus.ts). Helpers: [`splitBoxMedia.ts`](https://github.com/Sofie-Automation/sofie-core/blob/main/packages/shared-lib/src/package-manager/splitBoxMedia.ts).
+
+### Via expected packages
+
+Runs when `piece.expectedPackages` is set (same entry point as other layers).
+
+1. For each `MEDIA_FILE` package, resolve thumbnail/preview URLs from Package Manager side effects on routed containers.
+2. Key URLs in memory by normalized `filePath`.
+3. Build `boxPreviews[]` with [`buildPublishedBoxPreviews`](https://github.com/Sofie-Automation/sofie-core/blob/main/packages/shared-lib/src/package-manager/splitBoxMedia.ts) (zip to box order).
+4. For any VT box still missing URLs, fill from MediaObjects by `fileName`.
+
+`contentDuration` on status comes from the package scan (same as VT pieces).
+
+### Via MediaObjects only
+
+Runs when the piece has **no** `expectedPackages` but the layer is SPLITS.
+
+1. Collect distinct media ids from VT / LIVE_SPEAK / GRAPHICS / TRANSITION boxes with `fileName`.
+2. Load each MediaObject and build `boxPreviews[]`.
+3. Set `contentDuration` from the longest stream duration found in mediainfo.
+
+Studio setting `mockPieceContentStatus` returns fake per-box URLs when `boxSourceConfiguration` is present (dev only).
+
+## Where previews appear in the WebUI
+
+| Surface                             | Component                                                                                                                                              | Notes                                                                                               |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| Dashboard / bucket / ad-lib buttons | `DashboardPieceButtonSplitPreview` (via `MediaBox`)                                                                                                    | Inline box thumbnails when the layout enables thumbnails (buttons, or list with thumbnails enabled) |
+| Hover popup                         | [`BoxLayoutPreview`](https://github.com/Sofie-Automation/sofie-core/blob/main/packages/webui/src/client/ui/PreviewPopUp/Previews/BoxLayoutPreview.tsx) | Shows box thumbnails and preview video; supports scrub when `previewUrl` exists                     |
+
+These surfaces are **colour-only inline** (no visible box thumbnails), but will still show box media in the hover popup where supported:
+
+- Storyboard thumbnails and secondary pieces
+- Segment timeline SPLITS strip
+- OPL main-piece line
+- Clock view / camera screen indicators
+
+Shared helpers: [`getSplitPreview`](https://github.com/Sofie-Automation/sofie-core/blob/main/packages/webui/src/client/lib/ui/splitPreview.ts), [`RenderSplitPreview`](https://github.com/Sofie-Automation/sofie-core/blob/main/packages/webui/src/client/lib/SplitPreviewBox.tsx).
+
+## Example piece
+
+```typescript
+import { SourceLayerType, ExpectedPackage } from '@sofie-automation/blueprints-integration'
+
+const piece = {
+	sourceLayerId: '…', // SPLITS layer
+	content: {
+		boxSourceConfiguration: [
+			{
+				type: SourceLayerType.CAMERA,
+				studioLabel: 'Cam 1',
+				switcherInput: 1,
+				geometry: { x: 0.1, y: 0.2, scale: 0.4 },
+			},
+			{
+				type: SourceLayerType.VT,
+				studioLabel: 'Snow clip',
+				switcherInput: '',
+				fileName: 'clips/head3_Snow.mp4',
+				geometry: {
+					x: 0.35,
+					y: 0.7,
+					scale: 0.3,
+					crop: { left: 7 / 32, top: 0, right: 7 / 32, bottom: 0 },
+				},
+			},
+		],
+	},
+	expectedPackages: [
+		{
+			_id: 'split_vt_clips_head3_snow',
+			type: ExpectedPackage.PackageType.MEDIA_FILE,
+			content: { filePath: 'clips/head3_Snow.mp4' },
+			version: {
+				/* same as standalone VT pieces */
+			},
+			sources: [
+				/* same as standalone VT pieces */
+			],
+		},
+	],
+}
+```

--- a/packages/shared-lib/src/package-manager/__tests__/splitBoxMedia.spec.ts
+++ b/packages/shared-lib/src/package-manager/__tests__/splitBoxMedia.spec.ts
@@ -1,0 +1,58 @@
+import { SourceLayerType } from '../../core/model/ShowStyle.js'
+import { ExpectedPackage } from '../package.js'
+import {
+	buildPublishedBoxPreviews,
+	findExpectedPackageForMediaId,
+	getMediaIdFromSplitBox,
+	normalizeSplitBoxMediaId,
+} from '../splitBoxMedia.js'
+
+describe('splitBoxMedia', () => {
+	test('normalizeSplitBoxMediaId', () => {
+		expect(normalizeSplitBoxMediaId('clips/head3_Snow.mp4')).toEqual('CLIPS/HEAD3_SNOW.MP4')
+	})
+
+	test('getMediaIdFromSplitBox', () => {
+		expect(
+			getMediaIdFromSplitBox({
+				type: SourceLayerType.VT,
+				fileName: 'clips/foo.mp4',
+			})
+		).toEqual('CLIPS/FOO.MP4')
+		expect(
+			getMediaIdFromSplitBox({
+				type: SourceLayerType.CAMERA,
+				fileName: 'ignored',
+			})
+		).toBeUndefined()
+	})
+
+	test('findExpectedPackageForMediaId case insensitive', () => {
+		const pkg: ExpectedPackage.ExpectedPackageMediaFile = {
+			_id: 'p1',
+			type: ExpectedPackage.PackageType.MEDIA_FILE,
+			content: { filePath: 'CLIPS/FOO.MP4' },
+			version: {},
+			sources: [],
+		}
+		expect(findExpectedPackageForMediaId([pkg], 'clips/foo.mp4')).toBe(pkg)
+	})
+
+	test('buildPublishedBoxPreviews index aligned', () => {
+		const previews = buildPublishedBoxPreviews(
+			[
+				{ type: SourceLayerType.CAMERA },
+				{ type: SourceLayerType.VT, fileName: 'a.mp4' },
+				{ type: SourceLayerType.VT, fileName: 'b.mp4' },
+			],
+			new Map([
+				['A.MP4', { thumbnailUrl: '/thumb-a' }],
+				['B.MP4', { thumbnailUrl: '/thumb-b' }],
+			])
+		)
+		expect(previews).toHaveLength(3)
+		expect(previews[0]).toEqual({})
+		expect(previews[1]).toEqual({ thumbnailUrl: '/thumb-a' })
+		expect(previews[2]).toEqual({ thumbnailUrl: '/thumb-b' })
+	})
+})

--- a/packages/shared-lib/src/package-manager/__tests__/splitBoxMedia.spec.ts
+++ b/packages/shared-lib/src/package-manager/__tests__/splitBoxMedia.spec.ts
@@ -31,9 +31,12 @@ describe('splitBoxMedia', () => {
 		const pkg: ExpectedPackage.ExpectedPackageMediaFile = {
 			_id: 'p1',
 			type: ExpectedPackage.PackageType.MEDIA_FILE,
+			layers: [],
 			content: { filePath: 'CLIPS/FOO.MP4' },
 			version: {},
+			contentVersionHash: 'hash_p1',
 			sources: [],
+			sideEffect: {},
 		}
 		expect(findExpectedPackageForMediaId([pkg], 'clips/foo.mp4')).toBe(pkg)
 	})

--- a/packages/shared-lib/src/package-manager/splitBoxMedia.ts
+++ b/packages/shared-lib/src/package-manager/splitBoxMedia.ts
@@ -1,0 +1,75 @@
+import { SourceLayerType } from '../core/model/ShowStyle.js'
+import { ExpectedPackage } from './package.js'
+
+export interface SplitBoxPreviewUrlsLike {
+	thumbnailUrl?: string
+	previewUrl?: string
+}
+
+/** Box entry with optional media file name (VT / graphics / live speak). */
+export interface SplitBoxWithOptionalFileName {
+	type: SourceLayerType
+	fileName?: string
+}
+
+export interface SplitsContentLike {
+	boxSourceConfiguration: SplitBoxWithOptionalFileName[]
+}
+
+/** Same normalization as MediaObject `mediaId` and VT `getMediaObjectMediaId`. */
+export function normalizeSplitBoxMediaId(filePath: string): string {
+	return filePath.toUpperCase()
+}
+
+export function getExpectedPackageMediaId(expectedPackage: ExpectedPackage.Any): string | undefined {
+	if (expectedPackage.type === ExpectedPackage.PackageType.MEDIA_FILE) {
+		return expectedPackage.content.filePath
+	}
+	return undefined
+}
+
+export function getMediaIdFromSplitBox(box: SplitBoxWithOptionalFileName): string | undefined {
+	const fileName = box.fileName
+	if (!fileName) return undefined
+
+	switch (box.type) {
+		case SourceLayerType.VT:
+		case SourceLayerType.LIVE_SPEAK:
+		case SourceLayerType.GRAPHICS:
+		case SourceLayerType.TRANSITION:
+			return normalizeSplitBoxMediaId(fileName)
+		default:
+			return undefined
+	}
+}
+
+export function getMediaIdsFromSplitsContent(content: SplitsContentLike): string[] {
+	const ids = new Set<string>()
+	for (const box of content.boxSourceConfiguration) {
+		const mediaId = getMediaIdFromSplitBox(box)
+		if (mediaId) ids.add(mediaId)
+	}
+	return [...ids]
+}
+
+export function findExpectedPackageForMediaId(
+	packages: ReadonlyArray<ExpectedPackage.Any>,
+	mediaId: string
+): ExpectedPackage.Any | undefined {
+	const normalized = normalizeSplitBoxMediaId(mediaId)
+	return packages.find((pkg) => {
+		const pkgMediaId = getExpectedPackageMediaId(pkg)
+		return pkgMediaId !== undefined && normalizeSplitBoxMediaId(pkgMediaId) === normalized
+	})
+}
+
+export function buildPublishedBoxPreviews(
+	boxes: ReadonlyArray<SplitBoxWithOptionalFileName>,
+	previewByMediaId: ReadonlyMap<string, SplitBoxPreviewUrlsLike>
+): SplitBoxPreviewUrlsLike[] {
+	return boxes.map((box) => {
+		const mediaId = getMediaIdFromSplitBox(box)
+		if (!mediaId) return {}
+		return previewByMediaId.get(mediaId) ?? {}
+	})
+}

--- a/packages/webui/src/client/lib/SplitPreviewBox.tsx
+++ b/packages/webui/src/client/lib/SplitPreviewBox.tsx
@@ -57,5 +57,5 @@ export const RenderSplitPreview = React.memo(function RenderSplitPreview({
 		return <>{boxes}</>
 	}
 
-	return <div className="video-preview">{boxes}</div>
+	return <div className="video-preview checkerboard-bg">{boxes}</div>
 })

--- a/packages/webui/src/client/lib/SplitPreviewBox.tsx
+++ b/packages/webui/src/client/lib/SplitPreviewBox.tsx
@@ -6,51 +6,56 @@ import { RundownUtils } from './rundown.js'
 export const RenderSplitPreview = React.memo(function RenderSplitPreview({
 	subItems,
 	showLabels,
+	/** When true, boxes are rendered without an outer wrapper (parent must provide layout context). */
+	flatLayout = false,
 }: {
 	subItems: ReadonlyArray<Readonly<SplitSubItem>>
 	showLabels: boolean
+	flatLayout?: boolean
 }) {
 	const reversedSubItems = subItems.slice()
 	reversedSubItems.reverse()
 
-	return (
-		<div className="video-preview">
-			{reversedSubItems.map((item, index, array) => {
-				return (
-					<div
-						className={classNames(
-							'video-preview',
-							RundownUtils.getSourceLayerClassName(item.type),
-							{
-								background: item.role === SplitRole.ART,
-								box: item.role === SplitRole.BOX,
-							},
-							{
-								second: array.length > 1 && index > 0 && item.type === array[index - 1].type,
-							},
-							{ upper: index >= array.length / 2 },
-							{ lower: index < array.length / 2 }
-						)}
-						key={item._id + '-preview'}
-						style={{
-							left: ((item.content?.x ?? 0) * 100).toString() + '%',
-							top: ((item.content?.y ?? 0) * 100).toString() + '%',
-							width: ((item.content?.scale ?? 1) * 100).toString() + '%',
-							height: ((item.content?.scale ?? 1) * 100).toString() + '%',
-							clipPath: item.content?.crop
-								? `inset(${item.content.crop.top * 100}% ${item.content.crop.right * 100}% ${
-										item.content.crop.bottom * 100
-									}% ${item.content.crop.left * 100}%)`
-								: undefined,
-						}}
-					>
-						{(item.thumbnailUrl || item.previewUrl) && (
-							<img src={item.thumbnailUrl || item.previewUrl} alt="" className="video-preview__image" />
-						)}
-						{showLabels && item.role === SplitRole.BOX && <div className="video-preview__label">{item.label}</div>}
-					</div>
-				)
-			})}
-		</div>
-	)
+	const boxes = reversedSubItems.map((item, index, array) => {
+		return (
+			<div
+				className={classNames(
+					'video-preview',
+					RundownUtils.getSourceLayerClassName(item.type),
+					{
+						background: item.role === SplitRole.ART,
+						box: item.role === SplitRole.BOX,
+					},
+					{
+						second: array.length > 1 && index > 0 && item.type === array[index - 1].type,
+					},
+					{ upper: index >= array.length / 2 },
+					{ lower: index < array.length / 2 }
+				)}
+				key={item._id + '-preview'}
+				style={{
+					left: ((item.content?.x ?? 0) * 100).toString() + '%',
+					top: ((item.content?.y ?? 0) * 100).toString() + '%',
+					width: ((item.content?.scale ?? 1) * 100).toString() + '%',
+					height: ((item.content?.scale ?? 1) * 100).toString() + '%',
+					clipPath: item.content?.crop
+						? `inset(${item.content.crop.top * 100}% ${item.content.crop.right * 100}% ${
+								item.content.crop.bottom * 100
+							}% ${item.content.crop.left * 100}%)`
+						: undefined,
+				}}
+			>
+				{(item.thumbnailUrl || item.previewUrl) && (
+					<img src={item.thumbnailUrl || item.previewUrl} alt="" className="video-preview__image" />
+				)}
+				{showLabels && item.role === SplitRole.BOX && <div className="video-preview__label">{item.label}</div>}
+			</div>
+		)
+	})
+
+	if (flatLayout) {
+		return <>{boxes}</>
+	}
+
+	return <div className="video-preview">{boxes}</div>
 })

--- a/packages/webui/src/client/lib/SplitPreviewBox.tsx
+++ b/packages/webui/src/client/lib/SplitPreviewBox.tsx
@@ -44,6 +44,9 @@ export const RenderSplitPreview = React.memo(function RenderSplitPreview({
 								: undefined,
 						}}
 					>
+						{(item.thumbnailUrl || item.previewUrl) && (
+							<img src={item.thumbnailUrl || item.previewUrl} alt="" className="video-preview__image" />
+						)}
 						{showLabels && item.role === SplitRole.BOX && <div className="video-preview__label">{item.label}</div>}
 					</div>
 				)

--- a/packages/webui/src/client/lib/SplitPreviewBox.tsx
+++ b/packages/webui/src/client/lib/SplitPreviewBox.tsx
@@ -45,9 +45,7 @@ export const RenderSplitPreview = React.memo(function RenderSplitPreview({
 						: undefined,
 				}}
 			>
-				{(item.thumbnailUrl || item.previewUrl) && (
-					<img src={item.thumbnailUrl || item.previewUrl} alt="" className="video-preview__image" />
-				)}
+				{item.thumbnailUrl && <img src={item.thumbnailUrl} alt="" className="video-preview__image" />}
 				{showLabels && item.role === SplitRole.BOX && <div className="video-preview__label">{item.label}</div>}
 			</div>
 		)

--- a/packages/webui/src/client/lib/ui/splitPreview.ts
+++ b/packages/webui/src/client/lib/ui/splitPreview.ts
@@ -1,7 +1,8 @@
-import type {
+import {
 	SourceLayerType,
-	SplitsContentBoxContent,
-	SplitsContentBoxProperties,
+	type SplitsContentBoxContent,
+	type SplitsContentBoxProperties,
+	type VTContent,
 } from '@sofie-automation/blueprints-integration'
 import type { SplitBoxPreviewUrls } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
 import { literal } from '@sofie-automation/corelib/dist/lib'
@@ -33,6 +34,8 @@ export interface SplitSubItem {
 	content?: SplitsContentBoxProperties['geometry']
 	thumbnailUrl?: string
 	previewUrl?: string
+	/** VT/LIVE_SPEAK editorial seek (ms), used for in-box hover scrub */
+	seek?: number
 }
 
 export function getSplitPreview(
@@ -43,6 +46,11 @@ export function getSplitPreview(
 ): ReadonlyArray<Readonly<SplitSubItem>> {
 	return boxSourceConfiguration.map((item, index) => {
 		const boxPreview = boxPreviews?.[index]
+		const seek =
+			item.type === SourceLayerType.VT || item.type === SourceLayerType.LIVE_SPEAK
+				? (item as VTContent).seek
+				: undefined
+
 		return literal<Readonly<SplitSubItem>>({
 			_id: item.studioLabel + '_' + index,
 			type: item.type,
@@ -51,6 +59,7 @@ export function getSplitPreview(
 			content: item.geometry || DEFAULT_POSITIONS[index],
 			thumbnailUrl: boxPreview?.thumbnailUrl,
 			previewUrl: boxPreview?.previewUrl,
+			seek,
 		})
 	})
 }

--- a/packages/webui/src/client/lib/ui/splitPreview.ts
+++ b/packages/webui/src/client/lib/ui/splitPreview.ts
@@ -3,6 +3,7 @@ import type {
 	SplitsContentBoxContent,
 	SplitsContentBoxProperties,
 } from '@sofie-automation/blueprints-integration'
+import type { SplitBoxPreviewUrls } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
 import { literal } from '@sofie-automation/corelib/dist/lib'
 import type { ReadonlyDeep } from 'type-fest'
 
@@ -28,23 +29,28 @@ export interface SplitSubItem {
 	_id: string
 	type: SourceLayerType
 	label: string
-	// TODO: To be replaced with the structure used by the Core
 	role: SplitRole
 	content?: SplitsContentBoxProperties['geometry']
+	thumbnailUrl?: string
+	previewUrl?: string
 }
 
 export function getSplitPreview(
 	boxSourceConfiguration:
 		| (SplitsContentBoxContent & SplitsContentBoxProperties)[]
-		| ReadonlyDeep<(SplitsContentBoxContent & SplitsContentBoxProperties)[]>
+		| ReadonlyDeep<(SplitsContentBoxContent & SplitsContentBoxProperties)[]>,
+	boxPreviews?: ReadonlyDeep<SplitBoxPreviewUrls[]>
 ): ReadonlyArray<Readonly<SplitSubItem>> {
 	return boxSourceConfiguration.map((item, index) => {
+		const boxPreview = boxPreviews?.[index]
 		return literal<Readonly<SplitSubItem>>({
 			_id: item.studioLabel + '_' + index,
 			type: item.type,
 			label: item.studioLabel,
 			role: SplitRole.BOX,
 			content: item.geometry || DEFAULT_POSITIONS[index],
+			thumbnailUrl: boxPreview?.thumbnailUrl,
+			previewUrl: boxPreview?.previewUrl,
 		})
 	})
 }

--- a/packages/webui/src/client/lib/ui/splitsPreviewVideo.ts
+++ b/packages/webui/src/client/lib/ui/splitsPreviewVideo.ts
@@ -1,4 +1,4 @@
-import { SourceLayerType, type SplitsContent, type VTContent } from '@sofie-automation/blueprints-integration'
+import { SourceLayerType, type SplitsContent } from '@sofie-automation/blueprints-integration'
 import type { PieceContentStatusObj } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
 import type { ReadonlyDeep } from 'type-fest'
 

--- a/packages/webui/src/client/lib/ui/splitsPreviewVideo.ts
+++ b/packages/webui/src/client/lib/ui/splitsPreviewVideo.ts
@@ -1,0 +1,47 @@
+import { SourceLayerType, type SplitsContent, type VTContent } from '@sofie-automation/blueprints-integration'
+import type { PieceContentStatusObj } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
+import type { ReadonlyDeep } from 'type-fest'
+
+export type PreviewVideoContentUI = {
+	type: 'video'
+	src: string
+	itemDuration?: number
+	seek?: number
+	loop?: boolean
+}
+
+export interface SplitsBoxLayoutScrubSettings {
+	itemDuration: number
+	loop?: boolean
+}
+
+/** True when at least one VT/LIVE_SPEAK box has a preview URL to scrub in the box layout. */
+export function getSplitsBoxLayoutScrubSettings(
+	content: ReadonlyDeep<SplitsContent>,
+	contentStatus: ReadonlyDeep<PieceContentStatusObj> | undefined
+): SplitsBoxLayoutScrubSettings | undefined {
+	const boxes = content.boxSourceConfiguration ?? []
+
+	for (let i = 0; i < boxes.length; i++) {
+		const box = boxes[i]
+		if (box.type !== SourceLayerType.VT && box.type !== SourceLayerType.LIVE_SPEAK) {
+			continue
+		}
+
+		if (contentStatus?.boxPreviews?.[i]?.previewUrl) {
+			return {
+				itemDuration: content.sourceDuration ?? contentStatus?.contentDuration ?? 0,
+				loop: content.loop,
+			}
+		}
+	}
+
+	return undefined
+}
+
+export function getPieceScrubDurationMs(
+	content: ReadonlyDeep<{ sourceDuration?: number }> | undefined,
+	contentStatus: ReadonlyDeep<PieceContentStatusObj> | undefined
+): number {
+	return content?.sourceDuration ?? contentStatus?.contentDuration ?? 0
+}

--- a/packages/webui/src/client/lib/ui/videoPreviewScrub.ts
+++ b/packages/webui/src/client/lib/ui/videoPreviewScrub.ts
@@ -1,0 +1,16 @@
+export function setVideoElementPosition(
+	vEl: HTMLVideoElement,
+	timePosition: number,
+	itemDuration: number,
+	seek: number,
+	loop: boolean
+): void {
+	let targetTime = timePosition + seek
+	if (loop && vEl.duration > 0) {
+		targetTime =
+			targetTime % ((itemDuration > 0 ? Math.min(vEl.duration * 1000, itemDuration) : vEl.duration * 1000) * 1000)
+	} else if (itemDuration > 0) {
+		targetTime = Math.min(targetTime, itemDuration)
+	}
+	vEl.currentTime = targetTime / 1000
+}

--- a/packages/webui/src/client/lib/ui/videoPreviewScrub.ts
+++ b/packages/webui/src/client/lib/ui/videoPreviewScrub.ts
@@ -7,10 +7,10 @@ export function setVideoElementPosition(
 ): void {
 	let targetTime = timePosition + seek
 	if (loop && vEl.duration > 0) {
-		targetTime =
-			targetTime % ((itemDuration > 0 ? Math.min(vEl.duration * 1000, itemDuration) : vEl.duration * 1000) * 1000)
+		const loopWindowMs = itemDuration > 0 ? Math.min(vEl.duration * 1000, itemDuration) : vEl.duration * 1000
+		targetTime = ((targetTime % loopWindowMs) + loopWindowMs) % loopWindowMs
 	} else if (itemDuration > 0) {
-		targetTime = Math.min(targetTime, itemDuration)
+		targetTime = Math.max(0, Math.min(targetTime, itemDuration))
 	}
 	vEl.currentTime = targetTime / 1000
 }

--- a/packages/webui/src/client/styles/_checkerboard.scss
+++ b/packages/webui/src/client/styles/_checkerboard.scss
@@ -1,0 +1,25 @@
+// Transparency indicator (matches origo-ui `.checkerboard-bg`).
+@mixin checkerboard-background {
+	background-color: #000;
+	background-image:
+		linear-gradient(45deg, #191919 25%, transparent 25%), linear-gradient(-45deg, #191919 25%, transparent 25%),
+		linear-gradient(45deg, transparent 75%, #191919 75%), linear-gradient(-45deg, transparent 75%, #191919 75%);
+	background-size: 10px 10px;
+	background-position:
+		0 0,
+		0 5px,
+		5px -5px,
+		-5px 0;
+}
+
+.checkerboard-bg {
+	@include checkerboard-background;
+}
+
+.checkerboard-bg .image-container {
+	background-position: center;
+	background-repeat: no-repeat;
+	background-size: contain;
+	width: 100%;
+	height: 100%;
+}

--- a/packages/webui/src/client/styles/main.scss
+++ b/packages/webui/src/client/styles/main.scss
@@ -19,6 +19,7 @@ input {
 @import 'colorScheme';
 @import '_variables';
 @import '_colorScheme';
+@import 'checkerboard';
 
 @import '_header';
 

--- a/packages/webui/src/client/styles/rundownView.scss
+++ b/packages/webui/src/client/styles/rundownView.scss
@@ -1,6 +1,7 @@
 @use 'sass:color';
 
 @import 'utils';
+@import 'checkerboard';
 
 $output-layer-group-line: 1px solid #5c5c5c;
 $output-layer-group-collapse-animation-duration: 0.3s;
@@ -3093,7 +3094,7 @@ svg.icon {
 			display: block;
 			width: 414px;
 			height: 233px;
-			background: #000;
+			@include checkerboard-background;
 		}
 
 		> .segment-timeline__mini-inspector__warnings {

--- a/packages/webui/src/client/styles/rundownView.scss
+++ b/packages/webui/src/client/styles/rundownView.scss
@@ -3156,6 +3156,16 @@ svg.icon {
 				transform: translate(-50%, -50%);
 			}
 
+			.video-preview__image {
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 100%;
+				height: 100%;
+				object-fit: cover;
+				z-index: 1;
+			}
+
 			& > * {
 				@include item-type-colors;
 			}

--- a/packages/webui/src/client/styles/shelf/dashboard.scss
+++ b/packages/webui/src/client/styles/shelf/dashboard.scss
@@ -1125,7 +1125,6 @@ $dashboard-button-height: 3.625em;
 			.dashboard-panel__panel__button__tag-container {
 				@include item-type-colors;
 				> .dashboard-panel__panel__button__tag-container--inner > .dashboard-panel__panel__button__label-container {
-					top: 50%;
 					background-color: rgba(0, 0, 0, 0.8);
 					display: flex;
 					padding: unset;

--- a/packages/webui/src/client/styles/shelf/dashboard.scss
+++ b/packages/webui/src/client/styles/shelf/dashboard.scss
@@ -610,6 +610,7 @@ $dashboard-button-height: 3.625em;
 				justify-content: center;
 				width: 100%;
 				background: #4b4b4b;
+				position: relative;
 
 				.dashboard-panel__panel__button__thumbnail__aspect {
 					width: 100%;
@@ -622,6 +623,49 @@ $dashboard-button-height: 3.625em;
 					@supports not (aspect-ratio: 1 / 1) {
 						height: 0;
 						padding-top: 56.25%;
+					}
+
+					&--splits {
+						position: absolute;
+						inset: 0;
+						width: 100%;
+						height: 100%;
+						aspect-ratio: 16 / 9;
+						flex: none;
+						background: #000;
+
+						@supports not (aspect-ratio: 1 / 1) {
+							height: 100%;
+							padding-top: 0;
+						}
+
+						> .box,
+						> .background {
+							position: absolute;
+							transform: translate(-50%, -50%);
+							overflow: hidden;
+						}
+
+						> .video-preview {
+							position: absolute;
+							transform: translate(-50%, -50%);
+							overflow: hidden;
+
+							.video-preview__image {
+								position: absolute;
+								inset: 0;
+								display: block;
+								width: 100%;
+								height: 100%;
+								object-fit: cover;
+								object-position: center;
+								z-index: 1;
+							}
+						}
+
+						& > * {
+							@include item-type-colors;
+						}
 					}
 				}
 
@@ -672,7 +716,10 @@ $dashboard-button-height: 3.625em;
 					}
 				}
 
-				img {
+				.dashboard-panel__panel__button__thumbnail__aspect:not(
+						.dashboard-panel__panel__button__thumbnail__aspect--splits
+					)
+					> img {
 					position: absolute;
 					inset: 0;
 					width: 100%;
@@ -888,6 +935,19 @@ $dashboard-button-height: 3.625em;
 				height: 100%;
 				width: auto;
 				aspect-ratio: 16 / 9;
+			}
+
+			// Split preview must stay in-flow (like VT); absolute inset collapses width in the row layout.
+			> .dashboard-panel__panel__button__content
+				> .dashboard-panel__panel__button__tag-container
+				> .dashboard-panel__panel__button__thumbnail
+				.dashboard-panel__panel__button__thumbnail__aspect--splits {
+				position: relative;
+				inset: unset;
+				flex: 0 0 auto;
+				height: 100%;
+				width: auto;
+				max-width: none;
 			}
 		}
 	}

--- a/packages/webui/src/client/styles/shelf/dashboard.scss
+++ b/packages/webui/src/client/styles/shelf/dashboard.scss
@@ -799,6 +799,16 @@ $dashboard-button-height: 3.625em;
 						transform: translate(-50%, -50%);
 					}
 
+					.video-preview__image {
+						position: absolute;
+						top: 0;
+						left: 0;
+						width: 100%;
+						height: 100%;
+						object-fit: cover;
+						z-index: 1;
+					}
+
 					& > * {
 						@include item-type-colors;
 					}

--- a/packages/webui/src/client/styles/shelf/dashboard.scss
+++ b/packages/webui/src/client/styles/shelf/dashboard.scss
@@ -1,4 +1,5 @@
 @import '../colorScheme';
+@import '../checkerboard';
 
 $dashboard-button-width: 6.40625em;
 $dashboard-button-height: 3.625em;
@@ -632,7 +633,7 @@ $dashboard-button-height: 3.625em;
 						height: 100%;
 						aspect-ratio: 16 / 9;
 						flex: none;
-						background: #000;
+						@include checkerboard-background;
 
 						@supports not (aspect-ratio: 1 / 1) {
 							height: 100%;
@@ -828,7 +829,7 @@ $dashboard-button-height: 3.625em;
 				> .dashboard-panel__panel__button__tag-container > .video-preview {
 					position: absolute;
 					overflow: hidden;
-					background: #000;
+					@include checkerboard-background;
 					height: 100%;
 					width: 67px;
 					margin-left: 4px;

--- a/packages/webui/src/client/ui/ClockView/CameraScreen/Piece.tsx
+++ b/packages/webui/src/client/ui/ClockView/CameraScreen/Piece.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { CanvasSizeContext } from './index.js'
 import { PieceElement } from '../../SegmentContainer/PieceElement.js'
 import { getSplitItems } from '../../SegmentContainer/getSplitItems.js'
+import { useContentStatusForPieceInstance } from '../../SegmentTimeline/withMediaObjectStatus.js'
 import type { PieceExtended } from '@sofie-automation/corelib/src/dataModel/Piece.js'
 
 const PIECE_TYPE_INDICATOR_BORDER_RADIUS = 11
@@ -24,6 +25,7 @@ export const Piece = React.memo(function Piece({
 	isLive: boolean
 }): JSX.Element | null {
 	const canvasWidth = useContext(CanvasSizeContext)
+	const contentStatus = useContentStatusForPieceInstance(piece.instance)
 
 	const indicatorPadding = -1 * PIECE_TYPE_INDICATOR_BORDER_RADIUS
 	let pixelLeft = Math.max(indicatorPadding, left * zoom) + PIECE_TYPE_INDICATOR_BORDER_RADIUS
@@ -58,7 +60,7 @@ export const Piece = React.memo(function Piece({
 					partId={partId}
 					style={style}
 				>
-					{getSplitItems(piece, 'camera-screen__piece-sub-background')}
+					{getSplitItems(piece, 'camera-screen__piece-sub-background', contentStatus?.boxPreviews)}
 				</PieceElement>
 			) : null}
 			<PieceElement
@@ -67,7 +69,7 @@ export const Piece = React.memo(function Piece({
 				layer={piece.sourceLayer}
 				piece={piece}
 			>
-				{getSplitItems(piece, 'camera-screen__piece-type-indicator-sub-background')}
+				{getSplitItems(piece, 'camera-screen__piece-type-indicator-sub-background', contentStatus?.boxPreviews)}
 			</PieceElement>
 			<div className="camera-screen__piece-label">{piece.instance.piece.name}</div>
 		</div>

--- a/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUp.scss
+++ b/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUp.scss
@@ -1,4 +1,5 @@
 @use '../../styles/itemTypeColors';
+@import '../../styles/checkerboard';
 
 .preview-popUp {
 	border: 1px solid var(--sofie-segment-layer-hover-popup-border);
@@ -380,7 +381,7 @@
 
 		position: relative;
 		overflow: hidden;
-		background-color: #000;
+		@include checkerboard-background;
 
 		> .background {
 			position: absolute;
@@ -400,16 +401,14 @@
 			}
 		}
 
-		> .box {
+		> .box,
+		> .video-preview {
 			position: absolute;
 			transform: translate(-50%, -50%);
 			overflow: hidden;
-		}
 
-		> .video-preview {
-			overflow: hidden;
-
-			> .video-preview__image {
+			> .video-preview__image,
+			.video-preview__image {
 				position: absolute;
 				inset: 0;
 				display: block;

--- a/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUp.scss
+++ b/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUp.scss
@@ -388,11 +388,36 @@
 			bottom: 0;
 			left: 0;
 			right: 0;
+			overflow: hidden;
+
+			> img {
+				position: absolute;
+				inset: 0;
+				width: 100%;
+				height: 100%;
+				object-fit: cover;
+				object-position: center;
+			}
 		}
 
 		> .box {
 			position: absolute;
 			transform: translate(-50%, -50%);
+			overflow: hidden;
+		}
+
+		> .video-preview {
+			overflow: hidden;
+
+			> .video-preview__image {
+				position: absolute;
+				inset: 0;
+				display: block;
+				width: 100%;
+				height: 100%;
+				object-fit: cover;
+				object-position: center;
+			}
 		}
 
 		& > * {
@@ -405,6 +430,7 @@
 			left: 0;
 			right: 0;
 			bottom: 0;
+			z-index: 2;
 			font-weight: 400;
 			text-shadow: 0 0 2px rgba(0, 0, 0, 0.75);
 			text-align: center;

--- a/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUp.tsx
+++ b/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUp.tsx
@@ -56,12 +56,24 @@ export const PreviewPopUp = React.forwardRef<
 		}),
 		[padding]
 	)
+	const getAnchorY = () => {
+		if (anchor && 'getBoundingClientRect' in anchor) {
+			return anchor.getBoundingClientRect().y
+		}
+		return 0
+	}
+
+	const initialVirtualX =
+		trackMouse && typeof initialOffsetX === 'number'
+			? initialOffsetX
+			: anchor && 'getBoundingClientRect' in anchor
+				? anchor.getBoundingClientRect().x
+				: 0
+
 	const virtualElement = useRef<VirtualElement>({
-		getBoundingClientRect: generateGetBoundingClientRect(
-			initialOffsetX ?? anchor?.getBoundingClientRect().x ?? 0,
-			anchor?.getBoundingClientRect().y ?? 0
-		),
+		getBoundingClientRect: generateGetBoundingClientRect(initialVirtualX, getAnchorY()),
 	})
+
 	const { styles, attributes, update } = usePopper(
 		trackMouse ? virtualElement.current : anchor,
 		popperEl,
@@ -74,14 +86,20 @@ export const PreviewPopUp = React.forwardRef<
 		updateRef.current = update
 	}, [update])
 
+	// Re-sync virtual anchor when a new preview session starts (trackMouse + cursor X).
+	useEffect(() => {
+		if (!trackMouse) return
+		virtualElement.current.getBoundingClientRect = generateGetBoundingClientRect(
+			typeof initialOffsetX === 'number' ? initialOffsetX : 0,
+			getAnchorY()
+		)
+		updateRef.current?.().catch(console.error)
+	}, [trackMouse, initialOffsetX, anchor])
+
 	useEffect(() => {
 		if (trackMouse) {
 			const listener = ({ clientX: x }: MouseEvent) => {
-				virtualElement.current.getBoundingClientRect = generateGetBoundingClientRect(
-					x,
-					anchor?.getBoundingClientRect().y ?? 0
-				)
-				// If update is available, call it to reposition the popper:
+				virtualElement.current.getBoundingClientRect = generateGetBoundingClientRect(x, getAnchorY())
 				if (updateRef.current) {
 					updateRef.current().catch((e) => console.error(e))
 				}

--- a/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUp.tsx
+++ b/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUp.tsx
@@ -21,11 +21,20 @@ export const PreviewPopUp = React.forwardRef<
 	ref
 ): React.JSX.Element {
 	const [popperEl, setPopperEl] = useState<HTMLDivElement | null>(null)
+	const popperWidthPx = size === 'large' ? 482 : 322
+
 	const popperOptions = useMemo(
 		() => ({
 			placement: placement ?? 'top',
 			strategy: 'fixed' as const,
 			modifiers: [
+				{
+					name: 'computeStyles',
+					options: {
+						// Do not shrink the popup to the (zero-width) virtual mouse anchor when trackMouse is on.
+						adaptive: false,
+					},
+				},
 				{
 					name: 'flip',
 					options: {
@@ -56,6 +65,7 @@ export const PreviewPopUp = React.forwardRef<
 		}),
 		[padding]
 	)
+
 	const getAnchorY = () => {
 		if (anchor && 'getBoundingClientRect' in anchor) {
 			return anchor.getBoundingClientRect().y
@@ -78,6 +88,14 @@ export const PreviewPopUp = React.forwardRef<
 		trackMouse ? virtualElement.current : anchor,
 		popperEl,
 		popperOptions
+	)
+
+	const popperStyle = useMemo(
+		() => ({
+			...styles.popper,
+			width: popperWidthPx,
+		}),
+		[styles.popper, popperWidthPx]
 	)
 
 	const updateRef = useRef(update)
@@ -128,7 +146,7 @@ export const PreviewPopUp = React.forwardRef<
 				'preview-popUp--large': size === 'large',
 				'preview-popUp--small': size === 'small',
 			})}
-			style={styles.popper}
+			style={popperStyle}
 			{...attributes.popper}
 		>
 			{children && <div className="preview-popUp__preview">{children}</div>}

--- a/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUpContent.tsx
+++ b/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUpContent.tsx
@@ -64,7 +64,7 @@ export function PreviewPopUpContent({ content, time }: PreviewPopUpContentProps)
 		case 'separationLine':
 			return <hr className="preview-popup__separation-line" />
 		case 'boxLayout':
-			return <BoxLayoutPreview content={content} />
+			return <BoxLayoutPreview content={content} time={time} />
 		case 'warning':
 			return (
 				<div className="preview-popUp__warning">

--- a/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUpContext.tsx
+++ b/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUpContext.tsx
@@ -299,13 +299,14 @@ export function convertSourceLayerItemToPreview(
 		}
 	} else if (sourceLayerType === SourceLayerType.SPLITS) {
 		const content = item.content as SplitsContent
+		const splitScrub = getSplitsBoxLayoutScrubSettings(content, contentStatus)
 		return {
 			contents: [
 				{
 					type: 'boxLayout',
 					boxSourceConfiguration: content.boxSourceConfiguration,
 					boxPreviews: contentStatus?.boxPreviews,
-					scrub: getSplitsBoxLayoutScrubSettings(content, contentStatus),
+					scrub: splitScrub,
 				},
 			],
 			options: {},

--- a/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUpContext.tsx
+++ b/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUpContext.tsx
@@ -23,6 +23,12 @@ import _ from 'underscore'
 import type { IAdLibListItem } from '../Shelf/AdLibListItem.js'
 import type { PieceInstancePiece } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
 import { createPrivateApiPath } from '../../url.js'
+import {
+	getPieceScrubDurationMs,
+	getSplitsBoxLayoutScrubSettings,
+	type PreviewVideoContentUI,
+	type SplitsBoxLayoutScrubSettings,
+} from '../../lib/ui/splitsPreviewVideo.js'
 
 type VirtualElement = {
 	getBoundingClientRect: () => DOMRect
@@ -78,14 +84,20 @@ export function convertSourceLayerItemToPreview(
 						lastModified: popupPreview.preview.lastModified,
 					})
 					break
-				case PreviewType.Split:
+				case PreviewType.Split: {
+					const splitScrub = getSplitsBoxLayoutScrubSettings(
+						{ boxSourceConfiguration: popupPreview.preview.boxes },
+						contentStatus
+					)
 					contents.push({
 						type: 'boxLayout',
 						boxSourceConfiguration: popupPreview.preview.boxes,
 						boxPreviews: contentStatus?.boxPreviews,
+						scrub: splitScrub,
 						backgroundArtSrc: createPrivateApiPath('blueprints/assets/' + popupPreview.preview.background),
 					})
 					break
+				}
 				case PreviewType.Table:
 					contents.push({
 						type: 'data',
@@ -160,6 +172,9 @@ export function convertSourceLayerItemToPreview(
 					? {
 							type: 'video',
 							src: contentStatus.previewUrl,
+							itemDuration: getPieceScrubDurationMs(content, contentStatus),
+							seek: content.seek,
+							loop: content.loop,
 						}
 					: contentStatus?.thumbnailUrl
 						? {
@@ -290,6 +305,7 @@ export function convertSourceLayerItemToPreview(
 					type: 'boxLayout',
 					boxSourceConfiguration: content.boxSourceConfiguration,
 					boxPreviews: contentStatus?.boxPreviews,
+					scrub: getSplitsBoxLayoutScrubSettings(content, contentStatus),
 				},
 			],
 			options: {},
@@ -308,12 +324,16 @@ export function convertSourceLayerItemToPreview(
 /* PreviewContentUI is an extension of PreviewContent with some additional types used in the UI
  * These additional types are added to support some extra UI features that are not relevant for blueprints
  */
+export type { PreviewVideoContentUI } from '../../lib/ui/splitsPreviewVideo.js'
+
 export type PreviewContentUI =
-	| PreviewContent
+	| Exclude<PreviewContent, { type: 'video' }>
+	| PreviewVideoContentUI
 	| {
 			type: 'boxLayout'
 			boxSourceConfiguration: ReadonlyDeep<(SplitsContentBoxContent & SplitsContentBoxProperties)[]>
 			boxPreviews?: ReadonlyDeep<PieceContentStatusObj['boxPreviews']>
+			scrub?: SplitsBoxLayoutScrubSettings
 			showLabels?: boolean
 			backgroundArtSrc?: string
 	  }
@@ -407,7 +427,7 @@ export function PreviewPopUpContextProvider({ children }: React.PropsWithChildre
 
 	const context: IPreviewPopUpContext = {
 		requestPreview: (anchor, content, opts) => {
-			if (opts?.time) {
+			if (typeof opts?.time === 'number') {
 				setTime(opts.time)
 			} else {
 				setTime(null)

--- a/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUpContext.tsx
+++ b/packages/webui/src/client/ui/PreviewPopUp/PreviewPopUpContext.tsx
@@ -82,6 +82,7 @@ export function convertSourceLayerItemToPreview(
 					contents.push({
 						type: 'boxLayout',
 						boxSourceConfiguration: popupPreview.preview.boxes,
+						boxPreviews: contentStatus?.boxPreviews,
 						backgroundArtSrc: createPrivateApiPath('blueprints/assets/' + popupPreview.preview.background),
 					})
 					break
@@ -283,7 +284,16 @@ export function convertSourceLayerItemToPreview(
 		}
 	} else if (sourceLayerType === SourceLayerType.SPLITS) {
 		const content = item.content as SplitsContent
-		return { contents: [{ type: 'boxLayout', boxSourceConfiguration: content.boxSourceConfiguration }], options: {} }
+		return {
+			contents: [
+				{
+					type: 'boxLayout',
+					boxSourceConfiguration: content.boxSourceConfiguration,
+					boxPreviews: contentStatus?.boxPreviews,
+				},
+			],
+			options: {},
+		}
 	} else if (sourceLayerType === SourceLayerType.TRANSITION) {
 		const content = item.content as TransitionContent
 		if (content.preview)
@@ -303,6 +313,7 @@ export type PreviewContentUI =
 	| {
 			type: 'boxLayout'
 			boxSourceConfiguration: ReadonlyDeep<(SplitsContentBoxContent & SplitsContentBoxProperties)[]>
+			boxPreviews?: ReadonlyDeep<PieceContentStatusObj['boxPreviews']>
 			showLabels?: boolean
 			backgroundArtSrc?: string
 	  }

--- a/packages/webui/src/client/ui/PreviewPopUp/Previews/BoxLayoutPreview.tsx
+++ b/packages/webui/src/client/ui/PreviewPopUp/Previews/BoxLayoutPreview.tsx
@@ -1,4 +1,5 @@
 import type { SplitsContentBoxContent, SplitsContentBoxProperties } from '@sofie-automation/blueprints-integration'
+import type { SplitBoxPreviewUrls } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
 import classNames from 'classnames'
 import { useMemo } from 'react'
 import { getSplitPreview, SplitRole } from '../../../lib/ui/splitPreview.js'
@@ -9,6 +10,7 @@ interface BoxLayoutPreviewProps {
 	content: {
 		type: 'boxLayout'
 		boxSourceConfiguration: ReadonlyDeep<(SplitsContentBoxContent & SplitsContentBoxProperties)[]>
+		boxPreviews?: ReadonlyDeep<SplitBoxPreviewUrls[]>
 		showLabels?: boolean
 		backgroundArtSrc?: string
 	}
@@ -16,8 +18,11 @@ interface BoxLayoutPreviewProps {
 
 export function BoxLayoutPreview({ content }: BoxLayoutPreviewProps): React.ReactElement {
 	const reversedItems = useMemo(
-		() => (content.boxSourceConfiguration ? getSplitPreview(content.boxSourceConfiguration).slice().reverse() : []),
-		[content.boxSourceConfiguration]
+		() =>
+			content.boxSourceConfiguration
+				? getSplitPreview(content.boxSourceConfiguration, content.boxPreviews).slice().reverse()
+				: [],
+		[content.boxSourceConfiguration, content.boxPreviews]
 	)
 
 	return (
@@ -55,6 +60,9 @@ export function BoxLayoutPreview({ content }: BoxLayoutPreviewProps): React.Reac
 							: undefined,
 					}}
 				>
+					{(item.thumbnailUrl || item.previewUrl) && (
+						<img src={item.thumbnailUrl || item.previewUrl} alt="" className="video-preview__image" />
+					)}
 					{content.showLabels && item.role === SplitRole.BOX && (
 						<div className="video-preview__label">{item.label}</div>
 					)}

--- a/packages/webui/src/client/ui/PreviewPopUp/Previews/BoxLayoutPreview.tsx
+++ b/packages/webui/src/client/ui/PreviewPopUp/Previews/BoxLayoutPreview.tsx
@@ -1,8 +1,10 @@
 import type { SplitsContentBoxContent, SplitsContentBoxProperties } from '@sofie-automation/blueprints-integration'
 import type { SplitBoxPreviewUrls } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
+import type { SplitsBoxLayoutScrubSettings } from '../../../lib/ui/splitsPreviewVideo.js'
+import { setVideoElementPosition } from '../../../lib/ui/videoPreviewScrub.js'
 import classNames from 'classnames'
-import { useMemo } from 'react'
-import { getSplitPreview, SplitRole } from '../../../lib/ui/splitPreview.js'
+import { useEffect, useMemo, useRef } from 'react'
+import { getSplitPreview, SplitRole, type SplitSubItem } from '../../../lib/ui/splitPreview.js'
 import type { ReadonlyDeep } from 'type-fest'
 import { RundownUtils } from '../../../lib/rundown.js'
 
@@ -11,12 +13,52 @@ interface BoxLayoutPreviewProps {
 		type: 'boxLayout'
 		boxSourceConfiguration: ReadonlyDeep<(SplitsContentBoxContent & SplitsContentBoxProperties)[]>
 		boxPreviews?: ReadonlyDeep<SplitBoxPreviewUrls[]>
+		scrub?: SplitsBoxLayoutScrubSettings
 		showLabels?: boolean
 		backgroundArtSrc?: string
 	}
+	time: number | null
 }
 
-export function BoxLayoutPreview({ content }: BoxLayoutPreviewProps): React.ReactElement {
+function SplitBoxMedia({
+	item,
+	time,
+	scrub,
+}: {
+	item: Readonly<SplitSubItem>
+	time: number | null
+	scrub: SplitsBoxLayoutScrubSettings | undefined
+}): React.ReactElement | null {
+	const videoRef = useRef<HTMLVideoElement>(null)
+
+	useEffect(() => {
+		const el = videoRef.current
+		if (!el || !item.previewUrl) return
+
+		setVideoElementPosition(el, time ?? 0, scrub?.itemDuration ?? 0, item.seek ?? 0, scrub?.loop ?? false)
+	}, [time, scrub?.itemDuration, scrub?.loop, item.previewUrl, item.seek])
+
+	if (item.previewUrl) {
+		return (
+			<video
+				ref={videoRef}
+				src={item.previewUrl}
+				className="video-preview__image"
+				crossOrigin="anonymous"
+				playsInline
+				muted
+			/>
+		)
+	}
+
+	if (item.thumbnailUrl) {
+		return <img src={item.thumbnailUrl} alt="" className="video-preview__image" />
+	}
+
+	return null
+}
+
+export function BoxLayoutPreview({ content, time }: BoxLayoutPreviewProps): React.ReactElement {
 	const reversedItems = useMemo(
 		() =>
 			content.boxSourceConfiguration
@@ -60,9 +102,7 @@ export function BoxLayoutPreview({ content }: BoxLayoutPreviewProps): React.Reac
 							: undefined,
 					}}
 				>
-					{(item.thumbnailUrl || item.previewUrl) && (
-						<img src={item.thumbnailUrl || item.previewUrl} alt="" className="video-preview__image" />
-					)}
+					<SplitBoxMedia item={item} time={time} scrub={content.scrub} />
 					{content.showLabels && item.role === SplitRole.BOX && (
 						<div className="video-preview__label">{item.label}</div>
 					)}

--- a/packages/webui/src/client/ui/PreviewPopUp/Previews/BoxLayoutPreview.tsx
+++ b/packages/webui/src/client/ui/PreviewPopUp/Previews/BoxLayoutPreview.tsx
@@ -68,7 +68,7 @@ export function BoxLayoutPreview({ content, time }: BoxLayoutPreviewProps): Reac
 	)
 
 	return (
-		<div className="preview-popUp__box-layout">
+		<div className="preview-popUp__box-layout checkerboard-bg">
 			{content.backgroundArtSrc && (
 				<div className="video-preview background">
 					<img src={content.backgroundArtSrc} alt="" />

--- a/packages/webui/src/client/ui/PreviewPopUp/Previews/VTPreview.tsx
+++ b/packages/webui/src/client/ui/PreviewPopUp/Previews/VTPreview.tsx
@@ -2,6 +2,7 @@ import { useContext, useEffect, useRef } from 'react'
 import { StyledTimecode } from '../../../lib/StyledTimecode.js'
 import classNames from 'classnames'
 import StudioContext from '../../RundownView/StudioContext.js'
+import { setVideoElementPosition } from '../../../lib/ui/videoPreviewScrub.js'
 
 interface VTPreviewProps {
 	content: {
@@ -12,23 +13,6 @@ interface VTPreviewProps {
 		itemDuration?: number
 	}
 	time: number | null
-}
-
-function setVideoElementPosition(
-	vEl: HTMLVideoElement,
-	timePosition: number,
-	itemDuration: number,
-	seek: number,
-	loop: boolean
-) {
-	let targetTime = timePosition + seek
-	if (loop && vEl.duration > 0) {
-		targetTime =
-			targetTime % ((itemDuration > 0 ? Math.min(vEl.duration * 1000, itemDuration) : vEl.duration * 1000) * 1000)
-	} else if (itemDuration > 0) {
-		targetTime = Math.min(timePosition, itemDuration)
-	}
-	vEl.currentTime = targetTime / 1000
 }
 
 export function VTPreviewElement({ content, time }: VTPreviewProps): React.ReactElement {

--- a/packages/webui/src/client/ui/SegmentContainer/getSplitItems.tsx
+++ b/packages/webui/src/client/ui/SegmentContainer/getSplitItems.tsx
@@ -1,24 +1,33 @@
 import classNames from 'classnames'
 import type { SplitsContent } from '@sofie-automation/blueprints-integration'
+import type { SplitBoxPreviewUrls } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
 import { getSplitPreview, SplitRole } from '../../lib/ui/splitPreview.js'
 import type { PieceUi } from '@sofie-automation/corelib/src/dataModel/Piece.js'
 import { RundownUtils } from '../../lib/rundown.js'
+import type { ReadonlyDeep } from 'type-fest'
 
-export function getSplitItems(pieceInstance: PieceUi, baseClassName: string): JSX.Element[] {
+export function getSplitItems(
+	pieceInstance: PieceUi,
+	baseClassName: string,
+	boxPreviews?: ReadonlyDeep<SplitBoxPreviewUrls[]>
+): JSX.Element[] {
 	const splitsContent = pieceInstance.instance.piece.content as SplitsContent
 
 	if (!splitsContent?.boxSourceConfiguration) return []
 
-	return getSplitPreview(splitsContent.boxSourceConfiguration)
+	return getSplitPreview(splitsContent.boxSourceConfiguration, boxPreviews)
 		.filter((i) => i.role !== SplitRole.ART)
 		.map((item, index, array) => {
+			const previewSrc = item.thumbnailUrl || item.previewUrl
 			return (
 				<div
 					key={'item-' + item._id}
 					className={classNames(baseClassName, RundownUtils.getSourceLayerClassName(item.type), {
 						second: array.length > 1 && index > 0 && item.type === array[index - 1].type,
 					})}
-				></div>
+				>
+					{previewSrc ? <img src={previewSrc} alt="" className={`${baseClassName}__image`} /> : null}
+				</div>
 			)
 		})
 }

--- a/packages/webui/src/client/ui/SegmentList/LinePartMainPiece/LinePartMainPiece.tsx
+++ b/packages/webui/src/client/ui/SegmentList/LinePartMainPiece/LinePartMainPiece.tsx
@@ -178,7 +178,7 @@ export function LinePartMainPiece({
 			return
 		}
 		const newMousePosition = Math.max(0, Math.min(1, (e.pageX - origin.left - 5) / (width - 10)))
-		setMousePosition(e.pageX - origin.left)
+		setMousePosition(newMousePosition)
 
 		previewSession.current?.setPointerTime(
 			newMousePosition * (piece.instance.piece.content.sourceDuration ?? contentStatus?.contentDuration ?? 0)

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/SplitsRenderer.tsx
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/SplitsRenderer.tsx
@@ -1,8 +1,14 @@
 import type { IDefaultRendererProps } from './DefaultRenderer.js'
 import { getSplitItems } from '../../../SegmentContainer/getSplitItems.js'
+import { useContentStatusForPieceInstance } from '../../../SegmentTimeline/withMediaObjectStatus.js'
 
 export function SplitsRenderer({ piece: pieceInstance }: Readonly<IDefaultRendererProps>): JSX.Element {
-	const splitItems = getSplitItems(pieceInstance, 'segment-storyboard__part__piece__contents__item')
+	const contentStatus = useContentStatusForPieceInstance(pieceInstance.instance)
+	const splitItems = getSplitItems(
+		pieceInstance,
+		'segment-storyboard__part__piece__contents__item',
+		contentStatus?.boxPreviews
+	)
 
 	return (
 		<>

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/StoryboardSecondaryPiece.tsx
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/StoryboardSecondaryPiece.tsx
@@ -120,10 +120,11 @@ export function StoryboardSecondaryPiece(props: IProps): JSX.Element {
 			width,
 		})
 
-		if (previewContents.length > 0)
-			previewSession.current = previewContext.requestPreview(e.target as any, previewContents, {
+		if (previewContents.length > 0 && element.current)
+			previewSession.current = previewContext.requestPreview(element.current, previewContents, {
 				...previewOptions,
-				initialOffsetX: e.screenX,
+				initialOffsetX: e.clientX,
+				trackMouse: true,
 			})
 
 		if (onPointerEnterCallback) onPointerEnterCallback(e)

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/SplitsThumbnailRenderer.tsx
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/SplitsThumbnailRenderer.tsx
@@ -1,14 +1,21 @@
+import type { SplitsContent } from '@sofie-automation/blueprints-integration'
 import type { IProps } from './ThumbnailRendererFactory.js'
-import { getSplitItems } from '../../../SegmentContainer/getSplitItems.js'
+import { RenderSplitPreview } from '../../../../lib/SplitPreviewBox.js'
+import { getSplitPreview } from '../../../../lib/ui/splitPreview.js'
 import { useContentStatusForPieceInstance } from '../../../SegmentTimeline/withMediaObjectStatus.js'
 
 export function SplitsThumbnailRenderer({ pieceInstance }: Readonly<IProps>): JSX.Element {
 	const contentStatus = useContentStatusForPieceInstance(pieceInstance.instance)
-	const splitItems = getSplitItems(pieceInstance, 'segment-storyboard__thumbnail__item', contentStatus?.boxPreviews)
+	const subItems = getSplitPreview(
+		(pieceInstance.instance.piece.content as SplitsContent).boxSourceConfiguration,
+		contentStatus?.boxPreviews
+	)
 
 	return (
 		<>
-			<div className="segment-storyboard__thumbnail__contents">{splitItems}</div>
+			<div className="segment-storyboard__thumbnail__split-layout checkerboard-bg">
+				<RenderSplitPreview subItems={subItems} showLabels={false} flatLayout />
+			</div>
 			<div className="segment-storyboard__thumbnail__label segment-storyboard__thumbnail__label--lg">
 				{pieceInstance.instance.piece.name}
 			</div>

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/SplitsThumbnailRenderer.tsx
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/Renderers/SplitsThumbnailRenderer.tsx
@@ -1,8 +1,10 @@
 import type { IProps } from './ThumbnailRendererFactory.js'
 import { getSplitItems } from '../../../SegmentContainer/getSplitItems.js'
+import { useContentStatusForPieceInstance } from '../../../SegmentTimeline/withMediaObjectStatus.js'
 
 export function SplitsThumbnailRenderer({ pieceInstance }: Readonly<IProps>): JSX.Element {
-	const splitItems = getSplitItems(pieceInstance, 'segment-storyboard__thumbnail__item')
+	const contentStatus = useContentStatusForPieceInstance(pieceInstance.instance)
+	const splitItems = getSplitItems(pieceInstance, 'segment-storyboard__thumbnail__item', contentStatus?.boxPreviews)
 
 	return (
 		<>

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnail.scss
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnail.scss
@@ -1,6 +1,7 @@
 @use 'sass:color';
 
 @import '../../../styles/variables';
+@import '../../../styles/checkerboard';
 
 .segment-storyboard__part__thumbnail {
 	position: relative;
@@ -45,6 +46,57 @@
 
 		> .segment-storyboard__thumbnail__item {
 			flex: 1 1;
+			position: relative;
+			overflow: hidden;
+			min-height: 0;
+			@include item-type-colors();
+
+			> img,
+			.segment-storyboard__thumbnail__item__image {
+				position: absolute;
+				inset: 0;
+				width: 100%;
+				height: 100%;
+				object-fit: cover;
+				display: block;
+			}
+		}
+	}
+
+	> .segment-storyboard__thumbnail__split-layout {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		overflow: hidden;
+		@include checkerboard-background;
+
+		> .box,
+		> .background {
+			position: absolute;
+			transform: translate(-50%, -50%);
+			overflow: hidden;
+		}
+
+		> .video-preview {
+			position: absolute;
+			transform: translate(-50%, -50%);
+			overflow: hidden;
+
+			.video-preview__image {
+				position: absolute;
+				inset: 0;
+				display: block;
+				width: 100%;
+				height: 100%;
+				object-fit: cover;
+				object-position: center;
+				z-index: 1;
+			}
+		}
+
+		& > * {
 			@include item-type-colors();
 		}
 	}
@@ -77,6 +129,8 @@
 			left: 0;
 			right: 0;
 			margin: 0;
+			z-index: 2;
+			pointer-events: none;
 		}
 
 		&.segment-storyboard__thumbnail__label--sm {

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnail.scss
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnail.scss
@@ -11,7 +11,7 @@
 	overflow: hidden;
 	cursor: default;
 
-	@include item-type-colors();
+	@include item-type-colors;
 	@include missing-overlay();
 
 	// LiveSpeak needs a bit of special set up, because the thumbnail may make the dual-color setup invisible
@@ -61,7 +61,7 @@
 			position: relative;
 			overflow: hidden;
 			min-height: 0;
-			@include item-type-colors();
+			@include item-type-colors;
 
 			> img,
 			.segment-storyboard__thumbnail__item__image {
@@ -109,7 +109,7 @@
 		}
 
 		& > * {
-			@include item-type-colors();
+			@include item-type-colors;
 		}
 	}
 

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnail.scss
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnail.scss
@@ -24,6 +24,18 @@
 		background-repeat: repeat-x;
 	}
 
+	&.splits {
+		> .dashboard-panel__panel__button__layer-background {
+			z-index: 0;
+		}
+
+		> .segment-storyboard__thumbnail__split-layout,
+		> .segment-storyboard__thumbnail__label {
+			position: relative;
+			z-index: 1;
+		}
+	}
+
 	&.segment-storyboard__part__thumbnail--placeholder {
 		background: color.scale($segment-background-color, $lightness: 10%);
 	}

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnailInner.tsx
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnailInner.tsx
@@ -1,4 +1,5 @@
-import { useContext, useRef, useState } from 'react'
+import { useContext, useEffect, useRef, useState } from 'react'
+import { getPieceScrubDurationMs } from '../../../lib/ui/splitsPreviewVideo.js'
 import type { ISourceLayer } from '@sofie-automation/blueprints-integration'
 import { getElementDocumentOffset, type OffsetPosition } from '../../../utils/positions.js'
 import { getElementHeight, getElementWidth } from '../../../utils/dimensions.js'
@@ -56,31 +57,51 @@ export function StoryboardPartThumbnailInner({
 		contentStatus
 	)
 
+	const scrubDurationMs = getPieceScrubDurationMs(piece.instance.piece.content, contentStatus)
+
+	useEffect(() => {
+		if (previewSession.current && previewContents.length > 0) {
+			previewSession.current.update(previewContents)
+		}
+	}, [previewContents])
+
 	const onPointerEnter = (e: React.PointerEvent<HTMLDivElement>) => {
 		if (e.pointerType !== 'mouse') {
 			return
 		}
-		setHover(true)
 
-		const newOffset = thumbnailEl.current && getElementDocumentOffset(thumbnailEl.current)
+		const el = thumbnailEl.current
+		const newOffset = el && getElementDocumentOffset(el)
+		const newWidth = el && getElementWidth(el)
+		const newHeight = el && getElementHeight(el)
+
 		if (newOffset !== null) {
 			setOrigin(newOffset)
 		}
-		const newWidth = thumbnailEl.current && getElementWidth(thumbnailEl.current)
 		if (newWidth !== null) {
 			setWidth(newWidth)
 		}
-		const newHeight = thumbnailEl.current && getElementHeight(thumbnailEl.current)
 		if (newHeight !== null) {
 			setHeight(newHeight)
 		}
 
-		if (previewContents.length > 0)
-			previewSession.current = previewContext.requestPreview(e.target as any, previewContents, {
+		const mousePos =
+			newOffset !== null && newWidth !== null
+				? Math.max(0, Math.min(1, (e.pageX - newOffset.left - 5) / (newWidth - 10)))
+				: 0
+		const time = mousePos * scrubDurationMs
+		setMousePosition(mousePos)
+
+		if (previewContents.length > 0 && el) {
+			previewSession.current = previewContext.requestPreview(el, previewContents, {
 				...previewOptions,
-				time: mousePosition * (piece.instance.piece.content.sourceDuration || 0),
-				initialOffsetX: e.screenX,
+				time,
+				initialOffsetX: e.clientX,
+				trackMouse: true,
 			})
+		}
+
+		setHover(true)
 	}
 
 	const onPointerLeave = (e: React.PointerEvent<HTMLDivElement>) => {
@@ -101,9 +122,7 @@ export function StoryboardPartThumbnailInner({
 		}
 		const newMousePosition = Math.max(0, Math.min(1, (e.pageX - origin.left - 5) / (width - 10)))
 		setMousePosition(newMousePosition)
-		previewSession.current?.setPointerTime(
-			mousePosition * (piece.instance.piece.content.sourceDuration ?? contentStatus?.contentDuration ?? 0)
-		)
+		previewSession.current?.setPointerTime(newMousePosition * scrubDurationMs)
 	}
 
 	return (
@@ -123,7 +142,7 @@ export function StoryboardPartThumbnailInner({
 				partInstanceId={partInstanceId}
 				partAutoNext={partAutoNext}
 				partPlannedStoppedPlayback={partPlannedStoppedPlayback}
-				hoverScrubTimePosition={mousePosition * (piece.instance.piece.content.sourceDuration || 0)}
+				hoverScrubTimePosition={mousePosition * scrubDurationMs}
 				hovering={hover}
 				layer={layer}
 				height={height}

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnailInner.tsx
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnailInner.tsx
@@ -120,7 +120,11 @@ export function StoryboardPartThumbnailInner({
 		if (e.pointerType !== 'mouse') {
 			return
 		}
-		const newMousePosition = Math.max(0, Math.min(1, (e.pageX - origin.left - 5) / (width - 10)))
+		const offset = thumbnailEl.current && getElementDocumentOffset(thumbnailEl.current)
+		const thumbWidth = thumbnailEl.current && getElementWidth(thumbnailEl.current)
+		const left = offset?.left ?? origin.left
+		const w = thumbWidth ?? width
+		const newMousePosition = w > 10 ? Math.max(0, Math.min(1, (e.pageX - left - 5) / (w - 10))) : 0
 		setMousePosition(newMousePosition)
 		previewSession.current?.setPointerTime(newMousePosition * scrubDurationMs)
 	}

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnailInner.tsx
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartThumbnail/StoryboardPartThumbnailInner.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../PreviewPopUp/PreviewPopUpContext.js'
 import type { UIStudio } from '@sofie-automation/corelib/src/dataModel/Studio.js'
 import type { PieceExtended } from '@sofie-automation/corelib/src/dataModel/Piece.js'
+import { SplitButtonLayerBackground } from '../../Shelf/DashboardPieceButton/subcomponents/SplitButtonLayerBackground.js'
 
 interface IProps {
 	partId: PartId
@@ -141,6 +142,7 @@ export function StoryboardPartThumbnailInner({
 			onPointerMove={onPointerMove}
 			ref={thumbnailEl}
 		>
+			<SplitButtonLayerBackground piece={piece.instance.piece} />
 			<ThumbnailRenderer
 				partId={partId}
 				partInstanceId={partInstanceId}

--- a/packages/webui/src/client/ui/Shelf/DashboardPieceButton/DashboardPieceButton.tsx
+++ b/packages/webui/src/client/ui/Shelf/DashboardPieceButton/DashboardPieceButton.tsx
@@ -5,7 +5,7 @@ import { RundownUtils } from '../../../lib/rundown.js'
 import type { ReadonlyDeep } from 'type-fest'
 import type { PieceContentStatusObj } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
 import { PieceStatusCode } from '@sofie-automation/corelib/dist/dataModel/Piece'
-import { SourceLayerType } from '@sofie-automation/blueprints-integration'
+import { SourceLayerType, type SplitsContent } from '@sofie-automation/blueprints-integration'
 import { PreviewPopUpContext } from '../../PreviewPopUp/PreviewPopUpContext.js'
 import { useContentStatusForItem } from '../../SegmentTimeline/withMediaObjectStatus.js'
 import { DEFAULT_BUTTON_HEIGHT, DEFAULT_BUTTON_WIDTH, type IDashboardButtonProps } from './types.js'
@@ -118,33 +118,50 @@ export const DashboardPieceButton = React.forwardRef<HTMLDivElement, DashboardPi
 		const isList = displayStyle === PieceDisplayStyle.LIST
 		const hasMediaBox = useMemo(() => {
 			if (!layer) return false
-			if (!(layer.type === SourceLayerType.VT || layer.type === SourceLayerType.LIVE_SPEAK)) return false
 
 			const isButtons = displayStyle === PieceDisplayStyle.BUTTONS
 			const shouldRenderThumbnail = isButtons || (isList && showThumbnailsInList)
 			if (!shouldRenderThumbnail) return false
 
-			const chosenUrl = contentStatus?.thumbnailUrl || contentStatus?.previewUrl
-			if (chosenUrl) return true
-
-			switch (contentStatus?.status) {
-				case PieceStatusCode.SOURCE_BROKEN:
-				case PieceStatusCode.SOURCE_MISSING:
-				case PieceStatusCode.SOURCE_UNKNOWN_STATE:
-				case PieceStatusCode.SOURCE_NOT_READY:
-				case PieceStatusCode.UNKNOWN:
-				case undefined:
-					return true
-				default:
-					return false
+			const showForMissingOrUnknownStatus = () => {
+				switch (contentStatus?.status) {
+					case PieceStatusCode.SOURCE_BROKEN:
+					case PieceStatusCode.SOURCE_MISSING:
+					case PieceStatusCode.SOURCE_UNKNOWN_STATE:
+					case PieceStatusCode.SOURCE_NOT_READY:
+					case PieceStatusCode.UNKNOWN:
+					case undefined:
+						return true
+					default:
+						return false
+				}
 			}
+
+			if (layer.type === SourceLayerType.VT || layer.type === SourceLayerType.LIVE_SPEAK) {
+				const chosenUrl = contentStatus?.thumbnailUrl || contentStatus?.previewUrl
+				if (chosenUrl) return true
+				return showForMissingOrUnknownStatus()
+			}
+
+			if (layer.type === SourceLayerType.SPLITS) {
+				if (contentStatus?.boxPreviews?.some((p) => p?.thumbnailUrl || p?.previewUrl)) {
+					return true
+				}
+				const boxCount = (piece.content as SplitsContent | undefined)?.boxSourceConfiguration?.length ?? 0
+				if (boxCount > 0) return true
+				return showForMissingOrUnknownStatus()
+			}
+
+			return false
 		}, [
 			layer,
 			displayStyle,
 			isList,
 			showThumbnailsInList,
+			piece.content,
 			contentStatus?.previewUrl,
 			contentStatus?.thumbnailUrl,
+			contentStatus?.boxPreviews,
 			contentStatus?.status,
 		])
 

--- a/packages/webui/src/client/ui/Shelf/DashboardPieceButton/DashboardPieceButton.tsx
+++ b/packages/webui/src/client/ui/Shelf/DashboardPieceButton/DashboardPieceButton.tsx
@@ -13,6 +13,10 @@ import { DashboardButtonTagStrip } from './subcomponents/DashboardButtonTagStrip
 import { HotkeyBadge } from './subcomponents/HotkeyBadge.js'
 import { EditableLabel } from './subcomponents/EditableLabel.js'
 import { MediaBox } from './subcomponents/MediaBox.js'
+import {
+	getSplitsTopBoxLayerClassName,
+	SplitButtonLayerBackground,
+} from './subcomponents/SplitButtonLayerBackground.js'
 import { useDashboardButtonInteractions } from './useDashboardButtonInteractions.js'
 
 export type DashboardPieceButtonProps = React.PropsWithChildren<IDashboardButtonProps> & {
@@ -60,6 +64,16 @@ export const DashboardPieceButton = React.forwardRef<HTMLDivElement, DashboardPi
 			() => (layer ? RundownUtils.getSourceLayerClassName(layer.type) : undefined),
 			[layer]
 		)
+
+		const isSplitsLayer = layer?.type === SourceLayerType.SPLITS
+
+		const splitsTopBoxLayerClassName = useMemo(
+			() => (isSplitsLayer && !compact ? getSplitsTopBoxLayerClassName(piece) : undefined),
+			[isSplitsLayer, compact, piece]
+		)
+
+		const splitsStripesOnOuter = isSplitsLayer && Boolean(compact)
+		const splitsStripesOnInner = isSplitsLayer && !compact
 
 		const interactions = useDashboardButtonInteractions({
 			piece,
@@ -220,7 +234,8 @@ export const DashboardPieceButton = React.forwardRef<HTMLDivElement, DashboardPi
 				>
 					<div className="dashboard-panel__panel__button__content">
 						{showHotkey ? <HotkeyBadge hotkey={piece.hotkey} /> : null}
-						<DashboardButtonTagStrip className={layerTypeClassName}>
+						<DashboardButtonTagStrip className={ClassNames(layerTypeClassName, splitsTopBoxLayerClassName)}>
+							{splitsStripesOnOuter ? <SplitButtonLayerBackground piece={piece} /> : null}
 							<MediaBox
 								piece={piece}
 								layer={layer}
@@ -233,6 +248,7 @@ export const DashboardPieceButton = React.forwardRef<HTMLDivElement, DashboardPi
 							<DashboardButtonTagStrip
 								className={ClassNames(layerTypeClassName, 'dashboard-panel__panel__button__tag-container--inner')}
 							>
+								{splitsStripesOnInner ? <SplitButtonLayerBackground piece={piece} /> : null}
 								<div className="dashboard-panel__panel__button__label-container">
 									<EditableLabel
 										editable={editableName}

--- a/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/DashboardButtonTagStrip.scss
+++ b/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/DashboardButtonTagStrip.scss
@@ -15,12 +15,78 @@
 	}
 }
 
+.dashboard-panel__panel__button__layer-background {
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+	pointer-events: none;
+
+	&__preview {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		display: flex;
+		flex-direction: column-reverse;
+
+		&__item {
+			flex: 1 1;
+			min-height: 0;
+			@include item-type-colors;
+		}
+	}
+}
+
 .dashboard-panel__panel__button__tag-container--inner {
 	height: auto;
 	width: auto;
 	margin: 0;
 	padding: 0;
 	background: transparent;
+
+	&.splits {
+		background: transparent;
+	}
+}
+
+// Large DVE: stripes on label strip only (outer uses top-box solid color for preview).
+.dashboard-panel__panel__button:not(.dashboard-panel__panel__button--compact)
+	.dashboard-panel__panel__button__tag-container--inner.splits {
+	position: relative;
+	overflow: hidden;
+	flex: 0 0 auto;
+	height: auto !important;
+	min-height: 0;
+
+	> .dashboard-panel__panel__button__layer-background {
+		z-index: 0;
+	}
+
+	> .dashboard-panel__panel__button__label-container {
+		position: relative;
+		z-index: 1;
+	}
+}
+
+// Compact DVE: stripes on full button (outer tag-container); label strip stays transparent.
+.dashboard-panel__panel__button--compact
+	> .dashboard-panel__panel__button__content
+	> .dashboard-panel__panel__button__tag-container.splits:not(.dashboard-panel__panel__button__tag-container--inner) {
+	background: transparent;
+	position: relative;
+	overflow: hidden;
+
+	> .dashboard-panel__panel__button__layer-background {
+		z-index: 0;
+	}
+
+	> .dashboard-panel__panel__button__thumbnail,
+	> svg,
+	> .dashboard-panel__panel__button__tag-container--inner {
+		position: relative;
+		z-index: 1;
+	}
 }
 
 .dashboard-panel__panel__button:not(.dashboard-panel__panel__button--compact) {

--- a/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/DashboardButtonTagStrip.scss
+++ b/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/DashboardButtonTagStrip.scss
@@ -1,3 +1,4 @@
+@import './SplitButtonLayerBackground';
 @import '../../../../styles/itemTypeColors';
 
 .dashboard-panel__panel__button__tag-container {
@@ -14,8 +15,6 @@
 		margin-left: 8px;
 	}
 }
-
-@import './SplitButtonLayerBackground.scss';
 
 .dashboard-panel__panel__button__tag-container--inner {
 	height: auto;

--- a/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/DashboardButtonTagStrip.scss
+++ b/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/DashboardButtonTagStrip.scss
@@ -15,28 +15,7 @@
 	}
 }
 
-.dashboard-panel__panel__button__layer-background {
-	position: absolute;
-	inset: 0;
-	z-index: 0;
-	pointer-events: none;
-
-	&__preview {
-		position: absolute;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		display: flex;
-		flex-direction: column-reverse;
-
-		&__item {
-			flex: 1 1;
-			min-height: 0;
-			@include item-type-colors;
-		}
-	}
-}
+@import './SplitButtonLayerBackground.scss';
 
 .dashboard-panel__panel__button__tag-container--inner {
 	height: auto;

--- a/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/MediaBox.tsx
+++ b/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/MediaBox.tsx
@@ -67,11 +67,21 @@ export function MediaBox(props: Props): JSX.Element | null {
 	}
 
 	if (layer.type === SourceLayerType.SPLITS) {
-		if (isList && showThumbnailsInList) {
+		if (!shouldRenderThumbnail) {
+			return <SplitInputIcon abbreviation={layer?.abbreviation} piece={piece} hideLabel={true} />
+		}
+
+		if (isList) {
 			return <DashboardPieceButtonSplitPreview piece={piece} contentStatus={contentStatus} />
 		}
 
-		return <SplitInputIcon abbreviation={layer?.abbreviation} piece={piece} hideLabel={true} />
+		return (
+			<div className="dashboard-panel__panel__button__thumbnail">
+				<div className="dashboard-panel__panel__button__thumbnail__aspect dashboard-panel__panel__button__thumbnail__aspect--splits">
+					<DashboardPieceButtonSplitPreview piece={piece} contentStatus={contentStatus} flatLayout />
+				</div>
+			</div>
+		)
 	}
 
 	return null

--- a/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/MediaBox.tsx
+++ b/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/MediaBox.tsx
@@ -77,7 +77,7 @@ export function MediaBox(props: Props): JSX.Element | null {
 
 		return (
 			<div className="dashboard-panel__panel__button__thumbnail">
-				<div className="dashboard-panel__panel__button__thumbnail__aspect dashboard-panel__panel__button__thumbnail__aspect--splits">
+				<div className="dashboard-panel__panel__button__thumbnail__aspect dashboard-panel__panel__button__thumbnail__aspect--splits checkerboard-bg">
 					<DashboardPieceButtonSplitPreview piece={piece} contentStatus={contentStatus} flatLayout />
 				</div>
 			</div>

--- a/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/MediaBox.tsx
+++ b/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/MediaBox.tsx
@@ -68,7 +68,7 @@ export function MediaBox(props: Props): JSX.Element | null {
 
 	if (layer.type === SourceLayerType.SPLITS) {
 		if (isList && showThumbnailsInList) {
-			return <DashboardPieceButtonSplitPreview piece={piece} />
+			return <DashboardPieceButtonSplitPreview piece={piece} contentStatus={contentStatus} />
 		}
 
 		return <SplitInputIcon abbreviation={layer?.abbreviation} piece={piece} hideLabel={true} />

--- a/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/SplitButtonLayerBackground.scss
+++ b/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/SplitButtonLayerBackground.scss
@@ -1,0 +1,24 @@
+@import '../../../../styles/itemTypeColors';
+
+.dashboard-panel__panel__button__layer-background {
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+	pointer-events: none;
+
+	&__preview {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		display: flex;
+		flex-direction: column-reverse;
+
+		&__item {
+			flex: 1 1;
+			min-height: 0;
+			@include item-type-colors;
+		}
+	}
+}

--- a/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/SplitButtonLayerBackground.tsx
+++ b/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/SplitButtonLayerBackground.tsx
@@ -1,11 +1,15 @@
 import classNames from 'classnames'
+import './SplitButtonLayerBackground.scss'
 import type { SplitsContent } from '@sofie-automation/blueprints-integration'
 import type { PieceGeneric } from '@sofie-automation/corelib/dist/dataModel/Piece'
 import { getSplitPreview, SplitRole } from '../../../../lib/ui/splitPreview.js'
 import { RundownUtils } from '../../../../lib/rundown.js'
+import type { ReadonlyDeep } from 'type-fest'
 
 /** Layer class for the top DVE box (upper stripe), used as the large-button outer tag-container background. */
-export function getSplitsTopBoxLayerClassName(piece: Omit<PieceGeneric, 'timelineObjectsString'>): string | undefined {
+export function getSplitsTopBoxLayerClassName(
+	piece: ReadonlyDeep<Omit<PieceGeneric, 'timelineObjectsString'>>
+): string | undefined {
 	const boxSourceConfiguration = (piece.content as SplitsContent | undefined)?.boxSourceConfiguration
 	if (!boxSourceConfiguration?.length) return undefined
 
@@ -21,7 +25,7 @@ export function getSplitsTopBoxLayerClassName(piece: Omit<PieceGeneric, 'timelin
 export function SplitButtonLayerBackground({
 	piece,
 }: {
-	piece: Omit<PieceGeneric, 'timelineObjectsString'>
+	piece: ReadonlyDeep<Omit<PieceGeneric, 'timelineObjectsString'>>
 }): JSX.Element | null {
 	const boxSourceConfiguration = (piece.content as SplitsContent | undefined)?.boxSourceConfiguration
 	if (!boxSourceConfiguration?.length) return null

--- a/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/SplitButtonLayerBackground.tsx
+++ b/packages/webui/src/client/ui/Shelf/DashboardPieceButton/subcomponents/SplitButtonLayerBackground.tsx
@@ -1,0 +1,56 @@
+import classNames from 'classnames'
+import type { SplitsContent } from '@sofie-automation/blueprints-integration'
+import type { PieceGeneric } from '@sofie-automation/corelib/dist/dataModel/Piece'
+import { getSplitPreview, SplitRole } from '../../../../lib/ui/splitPreview.js'
+import { RundownUtils } from '../../../../lib/rundown.js'
+
+/** Layer class for the top DVE box (upper stripe), used as the large-button outer tag-container background. */
+export function getSplitsTopBoxLayerClassName(piece: Omit<PieceGeneric, 'timelineObjectsString'>): string | undefined {
+	const boxSourceConfiguration = (piece.content as SplitsContent | undefined)?.boxSourceConfiguration
+	if (!boxSourceConfiguration?.length) return undefined
+
+	const topBox = getSplitPreview(boxSourceConfiguration).find((i) => i.role !== SplitRole.ART)
+	if (!topBox) return undefined
+
+	return RundownUtils.getSourceLayerClassName(topBox.type)
+}
+
+/**
+ * Stacked layer-color stripes on the label strip (same pattern as timeline DVE preview).
+ */
+export function SplitButtonLayerBackground({
+	piece,
+}: {
+	piece: Omit<PieceGeneric, 'timelineObjectsString'>
+}): JSX.Element | null {
+	const boxSourceConfiguration = (piece.content as SplitsContent | undefined)?.boxSourceConfiguration
+	if (!boxSourceConfiguration?.length) return null
+
+	const items = getSplitPreview(boxSourceConfiguration)
+		.filter((i) => i.role !== SplitRole.ART)
+		.slice()
+		.reverse()
+
+	if (items.length === 0) return null
+
+	return (
+		<div className="dashboard-panel__panel__button__layer-background" aria-hidden>
+			<div className="dashboard-panel__panel__button__layer-background__preview">
+				{items.map((item, index, array) => (
+					<div
+						key={'layer-bg-' + item._id}
+						className={classNames(
+							'dashboard-panel__panel__button__layer-background__preview__item',
+							RundownUtils.getSourceLayerClassName(item.type),
+							{
+								second: array.length > 1 && index > 0 && item.type === array[index - 1].type,
+							},
+							{ upper: index >= array.length / 2 },
+							{ lower: index < array.length / 2 }
+						)}
+					/>
+				))}
+			</div>
+		</div>
+	)
+}

--- a/packages/webui/src/client/ui/Shelf/DashboardPieceButton/useDashboardButtonInteractions.ts
+++ b/packages/webui/src/client/ui/Shelf/DashboardPieceButton/useDashboardButtonInteractions.ts
@@ -6,7 +6,7 @@ import type { PieceContentStatusObj } from '@sofie-automation/corelib/dist/dataM
 import type { IDashboardButtonProps } from './types'
 import { usePreviewPopUpSession } from './usePreviewPopUpSession'
 import { isTouchDevice } from '../../../lib/lib.js'
-import type { VTContent } from '@sofie-automation/blueprints-integration'
+import { getPieceScrubDurationMs } from '../../../lib/ui/splitsPreviewVideo.js'
 
 export function useDashboardButtonInteractions(args: {
 	piece: IDashboardButtonProps['piece']
@@ -44,6 +44,11 @@ export function useDashboardButtonInteractions(args: {
 
 	const [timePosition, setTimePosition] = useState(0)
 
+	const scrubDurationMs = useMemo(
+		() => getPieceScrubDurationMs(args.piece.content as { sourceDuration?: number }, args.contentStatus),
+		[args.piece.content, args.contentStatus]
+	)
+
 	const { openPreview, closePreview, setPointerTime, hasPreview } = usePreviewPopUpSession({
 		previewContext: args.previewContext,
 		layerType: args.layer?.type,
@@ -64,14 +69,28 @@ export function useDashboardButtonInteractions(args: {
 		positionAndSizeRef.current = { top, left, width, height }
 	}, [])
 
+	const timeFromClientX = useCallback(
+		(clientX: number) => {
+			const rect = positionAndSizeRef.current
+			const timePercentage = Math.max(
+				0,
+				Math.min((clientX - (rect?.left || 0) - 5) / ((rect?.width || 1) - 10), 1)
+			)
+			return timePercentage * scrubDurationMs
+		},
+		[scrubDurationMs]
+	)
+
 	const onPointerEnter = useCallback(
 		(e: React.PointerEvent<HTMLDivElement>) => {
 			updatePositionAndSize()
 			if (e.pointerType === 'mouse' && hasPreview) {
-				openPreview(e.currentTarget, timePosition)
+				const time = timeFromClientX(e.clientX)
+				setTimePosition(time)
+				openPreview(e.currentTarget, time)
 			}
 		},
-		[hasPreview, openPreview, timePosition, updatePositionAndSize]
+		[hasPreview, openPreview, timeFromClientX, updatePositionAndSize]
 	)
 
 	const onPointerLeave = useCallback(() => {
@@ -129,17 +148,11 @@ export function useDashboardButtonInteractions(args: {
 
 	const onMoveClientX = useCallback(
 		(clientX: number) => {
-			const rect = positionAndSizeRef.current
-			const timePercentage = Math.max(
-				0,
-				Math.min((clientX - (rect?.left || 0) - 5) / ((rect?.width || 1) - 10), 1)
-			)
-			const sourceDuration = (args.piece.content as VTContent | undefined)?.sourceDuration || 0
-			const newTime = timePercentage * sourceDuration
+			const newTime = timeFromClientX(clientX)
 			setTimePosition(newTime)
 			setPointerTime(newTime)
 		},
-		[args.piece.content, setPointerTime]
+		[setPointerTime, timeFromClientX]
 	)
 
 	const onMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => onMoveClientX(e.clientX), [onMoveClientX])
@@ -156,9 +169,13 @@ export function useDashboardButtonInteractions(args: {
 		(e: React.TouchEvent<HTMLDivElement>) => {
 			if (args.canOverflowHorizontally) return
 			updatePositionAndSize()
-			if (hasPreview) openPreview(e.currentTarget, timePosition)
+			if (hasPreview && e.touches.length > 0) {
+				const time = timeFromClientX(e.touches[0].clientX)
+				setTimePosition(time)
+				openPreview(e.currentTarget, time)
+			}
 		},
-		[args.canOverflowHorizontally, hasPreview, openPreview, timePosition, updatePositionAndSize]
+		[args.canOverflowHorizontally, hasPreview, openPreview, timeFromClientX, updatePositionAndSize]
 	)
 
 	const onTouchEnd = useCallback(() => {

--- a/packages/webui/src/client/ui/Shelf/DashboardPieceButton/usePreviewPopUpSession.ts
+++ b/packages/webui/src/client/ui/Shelf/DashboardPieceButton/usePreviewPopUpSession.ts
@@ -43,6 +43,12 @@ export function usePreviewPopUpSession(args: {
 		return convertSourceLayerItemToPreview(args.layerType, args.piece, args.contentStatus)
 	}, [args.layerType, args.piece, args.contentStatus])
 
+	useEffect(() => {
+		if (previewSessionRef.current && previewRequest.contents.length > 0) {
+			previewSessionRef.current.update(previewRequest.contents)
+		}
+	}, [previewRequest])
+
 	const enableHoverPreview = args.enableHoverPreview ?? true
 
 	const startHoverTimeout = useCallback(() => {

--- a/packages/webui/src/client/ui/Shelf/DashboardPieceButton/usePreviewPopUpSession.ts
+++ b/packages/webui/src/client/ui/Shelf/DashboardPieceButton/usePreviewPopUpSession.ts
@@ -44,8 +44,13 @@ export function usePreviewPopUpSession(args: {
 	}, [args.layerType, args.piece, args.contentStatus])
 
 	useEffect(() => {
-		if (previewSessionRef.current && previewRequest.contents.length > 0) {
-			previewSessionRef.current.update(previewRequest.contents)
+		if (previewSessionRef.current) {
+			if (previewRequest.contents.length === 0) {
+				previewSessionRef.current.close()
+				previewSessionRef.current = null
+			} else {
+				previewSessionRef.current.update(previewRequest.contents)
+			}
 		}
 	}, [previewRequest])
 

--- a/packages/webui/src/client/ui/Shelf/DashboardPieceButtonSplitPreview.tsx
+++ b/packages/webui/src/client/ui/Shelf/DashboardPieceButtonSplitPreview.tsx
@@ -1,13 +1,16 @@
 import type { SplitsContent } from '@sofie-automation/blueprints-integration'
+import type { PieceContentStatusObj } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
 import type { PieceGeneric } from '@sofie-automation/corelib/dist/dataModel/Piece'
+import type { ReadonlyDeep } from 'type-fest'
 import { getSplitPreview } from '../../lib/ui/splitPreview.js'
 import { RenderSplitPreview } from '../../lib/SplitPreviewBox.js'
 
 interface IProps {
 	piece: Omit<PieceGeneric, 'timelineObjectsString'>
+	contentStatus?: ReadonlyDeep<PieceContentStatusObj> | undefined
 }
 
-export function DashboardPieceButtonSplitPreview({ piece }: Readonly<IProps>): JSX.Element {
-	const subItems = getSplitPreview((piece.content as SplitsContent).boxSourceConfiguration)
+export function DashboardPieceButtonSplitPreview({ piece, contentStatus }: Readonly<IProps>): JSX.Element {
+	const subItems = getSplitPreview((piece.content as SplitsContent).boxSourceConfiguration, contentStatus?.boxPreviews)
 	return <RenderSplitPreview subItems={subItems} showLabels={false} />
 }

--- a/packages/webui/src/client/ui/Shelf/DashboardPieceButtonSplitPreview.tsx
+++ b/packages/webui/src/client/ui/Shelf/DashboardPieceButtonSplitPreview.tsx
@@ -8,9 +8,15 @@ import { RenderSplitPreview } from '../../lib/SplitPreviewBox.js'
 interface IProps {
 	piece: Omit<PieceGeneric, 'timelineObjectsString'>
 	contentStatus?: ReadonlyDeep<PieceContentStatusObj> | undefined
+	/** Button thumbnails use flat layout (boxes fill the aspect container). List view uses wrapped. */
+	flatLayout?: boolean
 }
 
-export function DashboardPieceButtonSplitPreview({ piece, contentStatus }: Readonly<IProps>): JSX.Element {
+export function DashboardPieceButtonSplitPreview({
+	piece,
+	contentStatus,
+	flatLayout = false,
+}: Readonly<IProps>): JSX.Element {
 	const subItems = getSplitPreview((piece.content as SplitsContent).boxSourceConfiguration, contentStatus?.boxPreviews)
-	return <RenderSplitPreview subItems={subItems} showLabels={false} />
+	return <RenderSplitPreview subItems={subItems} showLabels={false} flatLayout={flatLayout} />
 }


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the BBC

## Type of Contribution

This is a: Feature

## Current Behavior

SPLITS pieces don't **per-box** previews/thumbnails.

Hover preview “scrub” behavior for splits is not available (or wasn’t consistently driven by per-box preview URLs).

## New Behavior

Core now publishes **`status.boxPreviews[]`** for split pieces (aligned with `boxSourceConfiguration` order), enabling **per-box** thumbnail/preview URLs. WebUI uses `boxPreviews` to render SPLITS box media where applicable (notably **dashboard shelf buttons** and **hover popups**, including scrub when `previewUrl` is present).

https://github.com/user-attachments/assets/4c718dcf-9b0e-4a25-8a34-cc7ed8a7a45f

## Testing

- [X] I have added one or more unit tests for this PR
- [X] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas


- **Core**: Split content status publishing
- **Shared-lib**: Split box media types, functions
- **WebUI**:
  - Split preview rendering
  - Hover popup Split box layout + scrub
  - Dashboard buttons Split preview rendering + styling

## Time Frame

Not urgent, but we would like to get this merged into the in-development release.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [X] PR is ready to be reviewed.
- [X] The functionality has been tested by the author.
- [X] Relevant unit tests has been added / updated.
- [X] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
