### PR TITLE
Update meteor eslint ignores rule to ignore _build directory

### DIFF
--- a/meteor/eslint.config.mjs
+++ b/meteor/eslint.config.mjs
@@ -14,7 +14,7 @@ const tmpRules = {
 
 const extendedRules = await generateEslintConfig({
 	// tsconfigName: 'tsconfig.eslint.json',
-	ignores: ['.meteor', 'public', 'scripts', 'server/_force_restart.js', '/packages/'],
+	ignores: ['.meteor', 'public', 'scripts', 'server/_force_restart.js', '/packages/', '_build'],
 
 	// disableNodeRules: true,
 })


### PR DESCRIPTION
## About the Contributor

This PR is posted on behalf of EVS Broadcast Equipment.

## Type of Contribution

This is a: Bug fix

## Current Behaviour

lint:meteor script hangs if it is run after meteor has been run up as that creates a _build directory that causes eslint to hang

## New Behaviour

lint:meteor ignores the _build directory

## Testing

- [x] No unit test changes are needed for this PR

### Affected areas

This PR affects meteor lint only

## Time Frame

Not urgent, but we would like to get this merged into the in-development release.

## Status

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
