### PR TITLE
fix: add all sourcelayer properties to type conversion functions

### DIFF
--- a/meteor/server/api/rest/v1/typeConversion.ts
+++ b/meteor/server/api/rest/v1/typeConversion.ts
@@ -175,7 +175,7 @@ export async function APIShowStyleVariantFrom(
 	}
 }
 
-export function sourceLayerFrom(apiSourceLayer: APISourceLayer): ISourceLayer {
+export function sourceLayerFrom(apiSourceLayer: APISourceLayer): Complete<ISourceLayer> {
 	let layerType: SourceLayerType
 	switch (apiSourceLayer.layerType) {
 		case 'audio':
@@ -249,7 +249,7 @@ export function sourceLayerFrom(apiSourceLayer: APISourceLayer): ISourceLayer {
 	}
 }
 
-export function APISourceLayerFrom(sourceLayer: ISourceLayer): APISourceLayer {
+export function APISourceLayerFrom(sourceLayer: ISourceLayer): Complete<APISourceLayer> {
 	let layerType: APISourceLayer['layerType']
 	switch (sourceLayer.type) {
 		case SourceLayerType.AUDIO:

--- a/meteor/server/api/rest/v1/typeConversion.ts
+++ b/meteor/server/api/rest/v1/typeConversion.ts
@@ -235,6 +235,17 @@ export function sourceLayerFrom(apiSourceLayer: APISourceLayer): ISourceLayer {
 		_rank: apiSourceLayer.rank,
 		type: layerType,
 		exclusiveGroup: apiSourceLayer.exclusiveGroup,
+		isRemoteInput: apiSourceLayer.isRemoteInput,
+		isGuestInput: apiSourceLayer.isGuestInput,
+		isClearable: apiSourceLayer.isClearable,
+		isSticky: apiSourceLayer.isSticky,
+		stickyOriginalOnly: apiSourceLayer.stickyOriginalOnly,
+		isQueueable: apiSourceLayer.isQueueable,
+		isHidden: apiSourceLayer.isHidden,
+		allowDisable: apiSourceLayer.allowDisable,
+		onPresenterScreen: apiSourceLayer.onPresenterScreen,
+		onListViewColumn: apiSourceLayer.onListViewColumn,
+		onListViewAdLibColumn: apiSourceLayer.onListViewAdLibColumn,
 	}
 }
 
@@ -298,6 +309,17 @@ export function APISourceLayerFrom(sourceLayer: ISourceLayer): APISourceLayer {
 		rank: sourceLayer._rank,
 		layerType,
 		exclusiveGroup: sourceLayer.exclusiveGroup,
+		isRemoteInput: sourceLayer.isRemoteInput,
+		isGuestInput: sourceLayer.isGuestInput,
+		isClearable: sourceLayer.isClearable,
+		isSticky: sourceLayer.isSticky,
+		stickyOriginalOnly: sourceLayer.stickyOriginalOnly,
+		isQueueable: sourceLayer.isQueueable,
+		isHidden: sourceLayer.isHidden,
+		allowDisable: sourceLayer.allowDisable,
+		onPresenterScreen: sourceLayer.onPresenterScreen,
+		onListViewColumn: sourceLayer.onListViewColumn,
+		onListViewAdLibColumn: sourceLayer.onListViewAdLibColumn,
 	}
 }
 

--- a/meteor/server/lib/rest/v1/showstyles.ts
+++ b/meteor/server/lib/rest/v1/showstyles.ts
@@ -254,4 +254,15 @@ export interface APISourceLayer {
 		| 'studio-screen'
 		| 'remote-speak'
 	exclusiveGroup?: string
+	isRemoteInput?: boolean
+	isGuestInput?: boolean
+	isClearable?: boolean
+	isSticky?: boolean
+	stickyOriginalOnly?: boolean
+	isQueueable?: boolean
+	isHidden?: boolean
+	allowDisable?: boolean
+	onPresenterScreen?: boolean
+	onListViewColumn?: boolean
+	onListViewAdLibColumn?: boolean
 }

--- a/packages/openapi/api/definitions/showstyles.yaml
+++ b/packages/openapi/api/definitions/showstyles.yaml
@@ -775,12 +775,48 @@ components:
               'lower-third',
               'live-speak',
               'transition',
+              'lights',
               'local',
+              'studio-screen',
+              'remote-speak',
             ]
           description: Source layer content type.
         exclusiveGroup:
           type: string
           description: Exclusivity group the layer belongs to.
+        isRemoteInput:
+          type: boolean
+          description: Whether the source layer is used for remote.
+        isGuestInput:
+          type: boolean
+          description: Whether the source layer is used for guest inputs.
+        isClearable:
+          type: boolean
+          description: Whether pieces on the source layer can be cleared.
+        isSticky:
+          type: boolean
+          description: Whether pieces on the source layer can be sticky.
+        stickyOriginalOnly:
+          type: boolean
+          description: Whether sticky pieces on the source layer should only preserve the original piece.
+        isQueueable:
+          type: boolean
+          description: Whether pieces on the source layer can be queued.
+        isHidden:
+          type: boolean
+          description: Whether the source layer should be hidden.
+        allowDisable:
+          type: boolean
+          description: Whether the source layer can be disabled.
+        onPresenterScreen:
+          type: boolean
+          description: Whether the source layer should be shown on presenter screens.
+        onListViewColumn:
+          type: boolean
+          description: Whether the source layer should be shown in the list view column.
+        onListViewAdLibColumn:
+          type: boolean
+          description: Whether the source layer should be shown in the list view ad lib column.
       required:
         - id
         - name

--- a/packages/openapi/src/generated/openapi.yaml
+++ b/packages/openapi/src/generated/openapi.yaml
@@ -4047,11 +4047,47 @@ paths:
                           - lower-third
                           - live-speak
                           - transition
+                          - lights
                           - local
+                          - studio-screen
+                          - remote-speak
                         description: Source layer content type.
                       exclusiveGroup:
                         type: string
                         description: Exclusivity group the layer belongs to.
+                      isRemoteInput:
+                        type: boolean
+                        description: Whether the source layer is used for remote.
+                      isGuestInput:
+                        type: boolean
+                        description: Whether the source layer is used for guest inputs.
+                      isClearable:
+                        type: boolean
+                        description: Whether pieces on the source layer can be cleared.
+                      isSticky:
+                        type: boolean
+                        description: Whether pieces on the source layer can be sticky.
+                      stickyOriginalOnly:
+                        type: boolean
+                        description: Whether sticky pieces on the source layer should only preserve the original piece.
+                      isQueueable:
+                        type: boolean
+                        description: Whether pieces on the source layer can be queued.
+                      isHidden:
+                        type: boolean
+                        description: Whether the source layer should be hidden.
+                      allowDisable:
+                        type: boolean
+                        description: Whether the source layer can be disabled.
+                      onPresenterScreen:
+                        type: boolean
+                        description: Whether the source layer should be shown on presenter screens.
+                      onListViewColumn:
+                        type: boolean
+                        description: Whether the source layer should be shown in the list view column.
+                      onListViewAdLibColumn:
+                        type: boolean
+                        description: Whether the source layer should be shown in the list view ad lib column.
                     required:
                       - id
                       - name
@@ -4213,11 +4249,47 @@ paths:
                                 - lower-third
                                 - live-speak
                                 - transition
+                                - lights
                                 - local
+                                - studio-screen
+                                - remote-speak
                               description: Source layer content type.
                             exclusiveGroup:
                               type: string
                               description: Exclusivity group the layer belongs to.
+                            isRemoteInput:
+                              type: boolean
+                              description: Whether the source layer is used for remote.
+                            isGuestInput:
+                              type: boolean
+                              description: Whether the source layer is used for guest inputs.
+                            isClearable:
+                              type: boolean
+                              description: Whether pieces on the source layer can be cleared.
+                            isSticky:
+                              type: boolean
+                              description: Whether pieces on the source layer can be sticky.
+                            stickyOriginalOnly:
+                              type: boolean
+                              description: Whether sticky pieces on the source layer should only preserve the original piece.
+                            isQueueable:
+                              type: boolean
+                              description: Whether pieces on the source layer can be queued.
+                            isHidden:
+                              type: boolean
+                              description: Whether the source layer should be hidden.
+                            allowDisable:
+                              type: boolean
+                              description: Whether the source layer can be disabled.
+                            onPresenterScreen:
+                              type: boolean
+                              description: Whether the source layer should be shown on presenter screens.
+                            onListViewColumn:
+                              type: boolean
+                              description: Whether the source layer should be shown in the list view column.
+                            onListViewAdLibColumn:
+                              type: boolean
+                              description: Whether the source layer should be shown in the list view ad lib column.
                           required:
                             - id
                             - name
@@ -4352,11 +4424,47 @@ paths:
                           - lower-third
                           - live-speak
                           - transition
+                          - lights
                           - local
+                          - studio-screen
+                          - remote-speak
                         description: Source layer content type.
                       exclusiveGroup:
                         type: string
                         description: Exclusivity group the layer belongs to.
+                      isRemoteInput:
+                        type: boolean
+                        description: Whether the source layer is used for remote.
+                      isGuestInput:
+                        type: boolean
+                        description: Whether the source layer is used for guest inputs.
+                      isClearable:
+                        type: boolean
+                        description: Whether pieces on the source layer can be cleared.
+                      isSticky:
+                        type: boolean
+                        description: Whether pieces on the source layer can be sticky.
+                      stickyOriginalOnly:
+                        type: boolean
+                        description: Whether sticky pieces on the source layer should only preserve the original piece.
+                      isQueueable:
+                        type: boolean
+                        description: Whether pieces on the source layer can be queued.
+                      isHidden:
+                        type: boolean
+                        description: Whether the source layer should be hidden.
+                      allowDisable:
+                        type: boolean
+                        description: Whether the source layer can be disabled.
+                      onPresenterScreen:
+                        type: boolean
+                        description: Whether the source layer should be shown on presenter screens.
+                      onListViewColumn:
+                        type: boolean
+                        description: Whether the source layer should be shown in the list view column.
+                      onListViewAdLibColumn:
+                        type: boolean
+                        description: Whether the source layer should be shown in the list view ad lib column.
                     required:
                       - id
                       - name


### PR DESCRIPTION
## About the Contributor

This PR is posted on behalf of EVS Broadcast Equipment.

## Type of Contribution

This is a: Bug fix

## Current Behavior

The REST API v1 `sourceLayerFrom()` and `APISourceLayerFrom()` type conversion functions were incomplete. When converting between the internal `ISourceLayer` type and the REST API's `APISourceLayer` type, some source layer properties were silently dropped.

This meant:
- Reading a source layer via the REST API returned an incomplete object (missing those fields).
- Creating/updating a source layer via the REST API silently discarded those properties, losing the configuration.

## New Behavior

Both conversion functions (`sourceLayerFrom` and `APISourceLayerFrom`) now map all the missing source layer properties between `ISourceLayer` and `APISourceLayer`. The `APISourceLayer` interface has also been extended with these optional fields so the REST API contract correctly reflects the full source layer configuration.

## Testing

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

This PR affects the REST API v1 Show Style endpoints, specifically the source layer create/update/read operations.
Any consumer using the REST API to manage source layers on a Show Style Base will now correctly read and write all source layer properties that were previously silently ignored.

## Time Frame

Not urgent.

## Status

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
