### PR TITLE
feat: show media status icon on studio screen source layer piece

### DIFF
--- a/meteor/server/publications/pieceContentStatusUI/checkPieceContentStatus.ts
+++ b/meteor/server/publications/pieceContentStatusUI/checkPieceContentStatus.ts
@@ -197,6 +197,7 @@ export function getMediaObjectMediaId(
 ): string | undefined {
 	switch (sourceLayer.type) {
 		case SourceLayerType.VT:
+		case SourceLayerType.STUDIO_SCREEN:
 			return (piece.content as VTContent)?.fileName?.toUpperCase()
 		case SourceLayerType.LIVE_SPEAK:
 			return (piece.content as LiveSpeakContent)?.fileName?.toUpperCase()
@@ -507,6 +508,7 @@ async function checkPieceContentMediaObjectStatus(
 	const fileName = getMediaObjectMediaId(piece, sourceLayer)
 	switch (sourceLayer.type) {
 		case SourceLayerType.VT:
+		case SourceLayerType.STUDIO_SCREEN:
 		case SourceLayerType.LIVE_SPEAK:
 		case SourceLayerType.TRANSITION:
 			// If the fileName is not set...

--- a/packages/webui/src/client/ui/SegmentTimeline/Renderers/L3rdSourceRenderer.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/Renderers/L3rdSourceRenderer.tsx
@@ -5,8 +5,8 @@ import classNames from 'classnames'
 import { PieceMultistepChevron, getPieceSteps } from '../../SegmentContainer/PieceMultistepChevron.js'
 import { CustomLayerItemRenderer, type ICustomLayerItemProps } from './CustomLayerItemRenderer.js'
 
-import { PieceContentStatusObj } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
-import { ReadonlyDeep } from 'type-fest'
+import type { PieceContentStatusObj } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
+import type { ReadonlyDeep } from 'type-fest'
 import { getNoticeLevelForPieceStatus } from '../../../lib/notifications/notifications.js'
 import { PieceStatusIcon } from '../../../lib/ui/PieceStatusIcon.js'
 

--- a/packages/webui/src/client/ui/SegmentTimeline/Renderers/L3rdSourceRenderer.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/Renderers/L3rdSourceRenderer.tsx
@@ -5,7 +5,14 @@ import classNames from 'classnames'
 import { PieceMultistepChevron, getPieceSteps } from '../../SegmentContainer/PieceMultistepChevron.js'
 import { CustomLayerItemRenderer, type ICustomLayerItemProps } from './CustomLayerItemRenderer.js'
 
-type IProps = ICustomLayerItemProps
+import { PieceContentStatusObj } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
+import { ReadonlyDeep } from 'type-fest'
+import { getNoticeLevelForPieceStatus } from '../../../lib/notifications/notifications.js'
+import { PieceStatusIcon } from '../../../lib/ui/PieceStatusIcon.js'
+
+interface IProps extends ICustomLayerItemProps {
+	contentStatus?: ReadonlyDeep<PieceContentStatusObj>
+}
 interface IState {
 	leftLabelWidth: number
 	rightLabelWidth: number
@@ -116,8 +123,11 @@ export class L3rdSourceRenderer extends CustomLayerItemRenderer<IProps, IState> 
 	}
 
 	render(): JSX.Element {
-		const { piece, isTooSmallForText, isLiveLine } = this.props
+		const { piece, isTooSmallForText, isLiveLine, contentStatus } = this.props
 		const innerPiece = piece.instance.piece
+
+		// derive notice level for status icon (same logic as VTSourceRenderer)
+		const noticeLevel = getNoticeLevelForPieceStatus(contentStatus?.status)
 
 		const hasStepChevron = getPieceSteps(piece)
 		const multistepPill = (
@@ -141,6 +151,7 @@ export class L3rdSourceRenderer extends CustomLayerItemRenderer<IProps, IState> 
 								ref={this.setLeftLabelRef}
 								style={this.getItemLabelOffsetLeft()}
 							>
+								{noticeLevel !== null && <PieceStatusIcon noticeLevel={noticeLevel} />}
 								{multistepPill}
 								<span className="segment-timeline__piece__label">{innerPiece.name}</span>
 							</span>


### PR DESCRIPTION
## About the Contributor

This PR is posted on behalf of EVS Broadcast Equipment.

## Type of Contribution

This is a: Feature

## Current Behavior

Studio screen pieces do not participate fully in the media status flow.
Even when a studio screen piece references media by `content.fileName`, the content status lookup does not resolve it as a media object in the same way as VT/live/transition pieces, so missing/not-ready/format status remain unavailable for that piece type.
In the segment timeline, studio screen pieces are rendered through `L3rdSourceRenderer`, which does not support media status icon.

## New Behavior

Studio screen pieces now resolve their media object id from `content.fileName`, using the same media behavior as VT pieces. The piece content status check now includes `SourceLayerType.STUDIO_SCREEN` in the media-object status path.

The studio screen timeline renderer now accepts `contentStatus`, derives the notice level from the piece status, and displays `PieceStatusIcon` next to the piece name, matching the status indicator behavior already used by other source layer pieces.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

This PR affects media/content status handling for Studio Screen source-layer pieces.

## Time Frame

Not urgent.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
