### PR TITLE
fix: adlib testing segment not retained properly during reingest

### DIFF
--- a/meteor/server/api/rest/v1/ingest.ts
+++ b/meteor/server/api/rest/v1/ingest.ts
@@ -780,17 +780,6 @@ class IngestServerAPI implements IngestRestAPI {
 				if (!segment) {
 					return
 				}
-
-				const parts = await this.findParts(segment._id)
-				return Promise.all(
-					parts.map(async (part) =>
-						runIngestOperation(studio._id, IngestJobs.RemovePart, {
-							partExternalId: part.externalId,
-							rundownExternalId: rundown.externalId,
-							segmentExternalId: segment.externalId,
-						})
-					)
-				)
 			})
 		)
 
@@ -839,17 +828,6 @@ class IngestServerAPI implements IngestRestAPI {
 		if (!segment) {
 			throw new Meteor.Error(400, `Segment '${segmentId}' does not exist`)
 		}
-		const parts = await this.findParts(segment._id)
-
-		await Promise.all(
-			parts.map(async (part) =>
-				runIngestOperation(studio._id, IngestJobs.RemovePart, {
-					partExternalId: part.externalId,
-					rundownExternalId: rundown.externalId,
-					segmentExternalId: segment.externalId,
-				})
-			)
-		)
 
 		await runIngestOperation(studio._id, IngestJobs.UpdateSegment, {
 			rundownExternalId: rundown.externalId,

--- a/packages/job-worker/src/playout/__tests__/actions.test.ts
+++ b/packages/job-worker/src/playout/__tests__/actions.test.ts
@@ -8,6 +8,7 @@ import { runWithRundownLock } from '../../ingest/lock.js'
 import { executePeripheralDeviceFunction } from '../../peripheralDevice.js'
 import { removeRundownFromDb } from '../../rundownPlaylists.js'
 import { activateRundownPlaylist } from '../activePlaylistActions.js'
+import { handleDeactivateRundownPlaylist } from '../activePlaylistJobs.js'
 import { runJobWithPlayoutModel } from '../lock.js'
 import { handleActivateAdlibTesting } from '../adlibTesting.js'
 
@@ -147,6 +148,69 @@ describe('Playout Actions', () => {
 		// AdlibTesting segment should be gone
 		await expect(getFirstSegment()).resolves.toMatchObject({
 			name: 'Segment 0',
+		})
+	})
+	test('AdlibTesting is cleared on deactivation', async () => {
+		const { playlistId: playlistId0, rundownId: rundownId0 } = await setupDefaultRundownPlaylist(
+			context,
+			undefined,
+			protectString('ro0')
+		)
+		expect(playlistId0).toBeTruthy()
+
+		const getFirstSegment = async () =>
+			await context.directCollections.Segments.findOne(
+				{
+					rundownId: rundownId0,
+				},
+				{
+					sort: {
+						_rank: 1,
+					},
+				}
+			)
+
+		const getAdlibTestingSegments = async () =>
+			context.directCollections.Segments.findFetch({
+				rundownId: rundownId0,
+				orphaned: SegmentOrphanedReason.ADLIB_TESTING,
+			})
+
+		const getPlaylist0 = async () => {
+			const playlist = (await context.directCollections.RundownPlaylists.findOne(
+				playlistId0
+			)) as DBRundownPlaylist
+			playlist.activationId = playlist.activationId ?? undefined
+			return playlist
+		}
+
+		// Activating a rundown, to rehearsal
+		await runJobWithPlayoutModel(context, { playlistId: playlistId0 }, null, async (playoutModel) =>
+			activateRundownPlaylist(context, playoutModel, true)
+		)
+
+		await handleActivateAdlibTesting(context, {
+			playlistId: playlistId0,
+			rundownId: rundownId0,
+		})
+
+		// AdlibTesting segment should be at the top
+		await expect(getFirstSegment()).resolves.toMatchObject({
+			orphaned: SegmentOrphanedReason.ADLIB_TESTING,
+		})
+		await expect(getAdlibTestingSegments()).resolves.toHaveLength(1)
+
+		// Deactivating the rundown should clear the AdlibTesting segment
+		await handleDeactivateRundownPlaylist(context, { playlistId: playlistId0 })
+
+		await expect(getFirstSegment()).resolves.toMatchObject({
+			name: 'Segment 0',
+		})
+		await expect(getAdlibTestingSegments()).resolves.toHaveLength(0)
+		await expect(getPlaylist0()).resolves.toMatchObject({
+			activationId: undefined,
+			currentPartInfo: null,
+			nextPartInfo: null,
 		})
 	})
 })

--- a/packages/job-worker/src/playout/model/implementation/LoadPlayoutModel.ts
+++ b/packages/job-worker/src/playout/model/implementation/LoadPlayoutModel.ts
@@ -213,6 +213,12 @@ async function loadRundowns(
 	const groupedBaselineObjects = groupByToMap(baselineObjects, 'rundownId')
 
 	if (ingestModel) {
+		// collect playout-owned AdlibTesting segments
+		const existingSegments = groupedSegmentsWithParts.get(ingestModel.rundownId) ?? []
+		const adlibTestingSegments = existingSegments.filter(
+			(s) => s.segment.orphaned === SegmentOrphanedReason.ADLIB_TESTING
+		)
+
 		const playoutSegments: PlayoutSegmentModelImpl[] = []
 		groupedSegmentsWithParts.set(ingestModel.rundownId, playoutSegments)
 		// Populate the collections with the in-memory data instead
@@ -224,6 +230,11 @@ async function loadRundowns(
 				)
 			)
 		}
+
+		// Re-add playout-owned AdlibTesting segments
+		playoutSegments.push(...adlibTestingSegments)
+		playoutSegments.sort((a, b) => a.segment._rank - b.segment._rank)
+
 		if (baselineTimelineFromIngest) {
 			groupedBaselineObjects.set(ingestModel.rundownId, [
 				literal<Complete<RundownBaselineObj>>({

--- a/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
@@ -566,17 +566,17 @@ export class PlayoutModelImpl extends PlayoutModelReadonlyImpl implements Playou
 	}
 
 	deactivatePlaylist(): void {
-		// Clean up segments after AdlibTesting
-		for (const rundown of this.rundowns) {
-			rundown.removeAdlibTestingSegment()
-		}
-
 		// Make sure that the part instances are marked as reset
 		for (const partInstance of this.loadedPartInstances) {
 			const segment = this.findSegment(partInstance.partInstance.segmentId)
 			if (segment?.segment.orphaned === SegmentOrphanedReason.ADLIB_TESTING) {
 				partInstance.markAsReset()
 			}
+		}
+
+		// Clean up segments after AdlibTesting
+		for (const rundown of this.rundowns) {
+			rundown.removeAdlibTestingSegment()
 		}
 
 		delete this.playlistImpl.activationId

--- a/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
@@ -82,6 +82,7 @@ import {
 } from '../../timeline/generate.js'
 import { deNowifyMultiGatewayTimeline } from '../../timeline/multi-gateway.js'
 import { validateTTimerIndex } from '../../tTimers.js'
+import { SegmentOrphanedReason } from '@sofie-automation/corelib/dist/dataModel/Segment.js'
 
 export class PlayoutModelReadonlyImpl implements PlayoutModelReadonly {
 	public readonly playlistId: RundownPlaylistId
@@ -565,6 +566,19 @@ export class PlayoutModelImpl extends PlayoutModelReadonlyImpl implements Playou
 	}
 
 	deactivatePlaylist(): void {
+		// Clean up segments after AdlibTesting
+		for (const rundown of this.rundowns) {
+			rundown.removeAdlibTestingSegment()
+		}
+
+		// Make sure that the part instances are marked as reset
+		for (const partInstance of this.loadedPartInstances) {
+			const segment = this.findSegment(partInstance.partInstance.segmentId)
+			if (segment?.segment.orphaned === SegmentOrphanedReason.ADLIB_TESTING) {
+				partInstance.markAsReset()
+			}
+		}
+
 		delete this.playlistImpl.activationId
 
 		if (this.currentPartInstance) {

--- a/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
@@ -82,7 +82,7 @@ import {
 } from '../../timeline/generate.js'
 import { deNowifyMultiGatewayTimeline } from '../../timeline/multi-gateway.js'
 import { validateTTimerIndex } from '../../tTimers.js'
-import { SegmentOrphanedReason } from '@sofie-automation/corelib/dist/dataModel/Segment.js'
+import { SegmentOrphanedReason } from '@sofie-automation/corelib/dist/dataModel/Segment'
 
 export class PlayoutModelReadonlyImpl implements PlayoutModelReadonly {
 	public readonly playlistId: RundownPlaylistId

--- a/packages/job-worker/src/playout/model/implementation/__tests__/LoadPlayoutModel.spec.ts
+++ b/packages/job-worker/src/playout/model/implementation/__tests__/LoadPlayoutModel.spec.ts
@@ -7,6 +7,7 @@ import { MockJobContext, setupDefaultJobEnvironment } from '../../../../__mocks_
 import { ProcessedShowStyleCompound } from '../../../../jobs/index.js'
 import { ReadonlyDeep } from 'type-fest'
 import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import { SegmentOrphanedReason } from '@sofie-automation/corelib/dist/dataModel/Segment'
 import { createPlayoutModelFromIngestModel, loadPlayoutModelPreInit } from '../LoadPlayoutModel.js'
 import { runWithPlaylistLock } from '../../../../playout/lock.js'
 import { loadIngestModelFromRundown } from '../../../../ingest/model/implementation/LoadIngestModel.js'
@@ -153,6 +154,63 @@ describe('LoadPlayoutModel', () => {
 				const model = await createPlayoutModelFromIngestModel(context, lock, playlist0, rundowns, ingestModel)
 
 				expect(model.rundowns.map((r) => r.rundown._id)).toMatchObject([rundownId01, rundownId02, rundownId00])
+			})
+		})
+
+		test('preserves playout-owned AdlibTesting segments during reingest', async () => {
+			const { rundownId, playlistId } = await setupDefaultRundownPlaylist(
+				context,
+				showStyleCompound,
+				protectString('rundown00')
+			)
+
+			const adlibTestingSegmentId = protectString('adlib_testing_segment')
+			await context.mockCollections.Segments.insertOne({
+				_id: adlibTestingSegmentId,
+				_rank: -1,
+				externalId: '__adlib-testing__',
+				rundownId,
+				name: '',
+				orphaned: SegmentOrphanedReason.ADLIB_TESTING,
+			})
+
+			const playlist = await context.mockCollections.RundownPlaylists.findOne(playlistId)
+			expect(playlist).toBeTruthy()
+			if (!playlist) throw new Error(`Playlist "${playlistId}" not found!`)
+
+			let ingestModel: IngestModelReadonly | undefined
+
+			await runWithRundownLock(context, rundownId, async (rundown, lock) => {
+				if (!rundown) throw new Error(`Rundown "${rundownId}" not found!`)
+
+				ingestModel = await loadIngestModelFromRundown(context, lock, rundown)
+			})
+
+			expect(ingestModel).toBeTruthy()
+			if (!ingestModel) throw new Error('Ingest model could not be created!')
+
+			// Ingest model should not include playout-owned AdlibTesting segments
+			expect(
+				ingestModel.getAllSegments().find((s) => s.segment.orphaned === SegmentOrphanedReason.ADLIB_TESTING)
+			).toBeUndefined()
+
+			await runWithPlaylistLock(context, playlistId, async (lock) => {
+				if (!ingestModel) throw new Error('Ingest model could not be created!')
+
+				const rundowns = await context.mockCollections.Rundowns.findFetch({})
+
+				const model = await createPlayoutModelFromIngestModel(context, lock, playlist, rundowns, ingestModel)
+
+				const playoutRundown = model.getRundown(rundownId)
+				expect(playoutRundown).toBeTruthy()
+
+				const adlibTestingSegment = playoutRundown?.getAdlibTestingSegment()
+				expect(adlibTestingSegment).toBeTruthy()
+				expect(adlibTestingSegment?.segment._id).toEqual(adlibTestingSegmentId)
+
+				// AdlibTesting segment should be sorted before ingest segments
+				expect(playoutRundown?.segments[0].segment.orphaned).toBe(SegmentOrphanedReason.ADLIB_TESTING)
+				expect(playoutRundown?.segments.length).toBe(ingestModel.getAllSegments().length + 1)
 			})
 		})
 	})

--- a/packages/job-worker/src/playout/setNext.ts
+++ b/packages/job-worker/src/playout/setNext.ts
@@ -38,7 +38,6 @@ import { PlayoutPartInstanceModelImpl } from './model/implementation/PlayoutPart
 import { QuickLoopService } from './model/services/QuickLoopService.js'
 import { recalculateTTimerProjections } from './tTimers.js'
 
-// TODO: Better document behavior
 /**
  * Set or clear the nexted part, from a given PartInstance, or SelectNextPartResult
  * @param context Context for the running job

--- a/packages/job-worker/src/playout/setNext.ts
+++ b/packages/job-worker/src/playout/setNext.ts
@@ -38,6 +38,7 @@ import { PlayoutPartInstanceModelImpl } from './model/implementation/PlayoutPart
 import { QuickLoopService } from './model/services/QuickLoopService.js'
 import { recalculateTTimerProjections } from './tTimers.js'
 
+// TODO: Better document behavior
 /**
  * Set or clear the nexted part, from a given PartInstance, or SelectNextPartResult
  * @param context Context for the running job


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the CBC.

## Type of Contribution

This is a: Bug fix

## Current Behavior

When Adlib Testing is active and you reingest the upcoming segments, the testing segment is not retained properly in the Playout Model, causing an error due to missing infinites and the reingest fails

Additionally, all of the segments parts are being cleared, as a result the job worker cannot properly update the parts, it has to recreate them in all cases.

Additional bug: the testing segement is not cleared when deactivating a rundown (despite it's content being cleaned up), only when activating it again.

## New Behavior

The segment is now correctly retained when the playlist is active and it's cleared when deactivating the rundown.

Updating segments through the IngestAPI no longer causes the webui to flicker.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [X] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

This PR affects the playout logic.

## Time Frame

Not urgent, but we would like to get this merged into the in-development release.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [X] PR is ready to be reviewed.
- [X] The functionality has been tested by the author.
- [X] Relevant unit tests has been added / updated.
- [X] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
