### PR TITLE
feat: Allow blueprints to request that syncIngestUpdateToPartInstance is run

### DIFF
--- a/packages/blueprints-integration/src/context/processIngestDataContext.ts
+++ b/packages/blueprints-integration/src/context/processIngestDataContext.ts
@@ -4,6 +4,14 @@ import type { IngestDefaultChangesOptions, MutableIngestRundown, NrcsIngestChang
 
 export interface IProcessIngestDataContext extends IStudioContext {
 	/**
+	 * Request that `syncIngestUpdateToPartInstance` should be executed for the active PartInstances
+	 * in this ingest operation, even if it would otherwise be skipped.
+	 *
+	 * The request is one-shot and only applies to the current ingest operation.
+	 */
+	requestSyncIngestUpdateToPartInstance(): void
+
+	/**
 	 * Perform the default syncing of changes from the ingest data to the rundown.
 	 *
 	 * Please note that this may be overly aggressive at removing any changes made by user operations

--- a/packages/job-worker/src/blueprints/context/ProcessIngestDataContext.ts
+++ b/packages/job-worker/src/blueprints/context/ProcessIngestDataContext.ts
@@ -20,6 +20,18 @@ import {
  * Custom updates of the IngestRundown are done by calling methods on the mutableIngestRundown itself.
  */
 export class ProcessIngestDataContext extends StudioContext implements IProcessIngestDataContext {
+	#requestSyncIngestUpdateToPartInstance = false
+
+	requestSyncIngestUpdateToPartInstance(): void {
+		this.#requestSyncIngestUpdateToPartInstance = true
+	}
+
+	consumeRequestSyncIngestUpdateToPartInstance(): boolean {
+		const shouldRequest = this.#requestSyncIngestUpdateToPartInstance
+		this.#requestSyncIngestUpdateToPartInstance = false
+		return shouldRequest
+	}
+
 	defaultApplyIngestChanges<TRundownPayload, TSegmentPayload, TPartPayload>(
 		mutableIngestRundown: MutableIngestRundown<TRundownPayload, TSegmentPayload, TPartPayload>,
 		nrcsIngestRundown: IngestRundown,

--- a/packages/job-worker/src/blueprints/context/__tests__/ProcessIngestDataContext.test.ts
+++ b/packages/job-worker/src/blueprints/context/__tests__/ProcessIngestDataContext.test.ts
@@ -1,0 +1,37 @@
+import { setupDefaultJobEnvironment } from '../../../__mocks__/context.js'
+import { ProcessIngestDataContext } from '../ProcessIngestDataContext.js'
+
+describe('ProcessIngestDataContext', () => {
+	function createContext(): ProcessIngestDataContext {
+		const jobContext = setupDefaultJobEnvironment()
+
+		return new ProcessIngestDataContext(
+			{
+				name: 'test',
+				identifier: 'test',
+			},
+			jobContext.studio,
+			jobContext.getStudioBlueprintConfig()
+		)
+	}
+
+	test('requestSyncIngestUpdateToPartInstance is one-shot', () => {
+		const context = createContext()
+
+		expect(context.consumeRequestSyncIngestUpdateToPartInstance()).toBe(false)
+
+		context.requestSyncIngestUpdateToPartInstance()
+		expect(context.consumeRequestSyncIngestUpdateToPartInstance()).toBe(true)
+		expect(context.consumeRequestSyncIngestUpdateToPartInstance()).toBe(false)
+	})
+
+	test('multiple requests collapse into a single consume result', () => {
+		const context = createContext()
+
+		context.requestSyncIngestUpdateToPartInstance()
+		context.requestSyncIngestUpdateToPartInstance()
+
+		expect(context.consumeRequestSyncIngestUpdateToPartInstance()).toBe(true)
+		expect(context.consumeRequestSyncIngestUpdateToPartInstance()).toBe(false)
+	})
+})

--- a/packages/job-worker/src/ingest/commit.ts
+++ b/packages/job-worker/src/ingest/commit.ts
@@ -230,7 +230,12 @@ export async function CommitIngestOperation(
 
 			try {
 				// sync changes to the 'selected' partInstances
-				await syncChangesToPartInstances(context, playoutModel, ingestModel)
+				await syncChangesToPartInstances(
+					context,
+					playoutModel,
+					ingestModel,
+					data.forceSyncIngestUpdateToPartInstance
+				)
 
 				// update the quickloop in case we did any changes to things involving marker
 				playoutModel.updateQuickLoopState()

--- a/packages/job-worker/src/ingest/lock.ts
+++ b/packages/job-worker/src/ingest/lock.ts
@@ -25,6 +25,9 @@ export interface CommitIngestData {
 	/** Set to true if the rundown should be removed or orphaned */
 	removeRundown: boolean
 
+	/** Force execution of syncIngestUpdateToPartInstance for this commit operation */
+	forceSyncIngestUpdateToPartInstance?: boolean
+
 	/** Whether to return an error if the rundown is unable to be removed */
 	returnRemoveFailure?: boolean
 }

--- a/packages/job-worker/src/ingest/runOperation.ts
+++ b/packages/job-worker/src/ingest/runOperation.ts
@@ -53,6 +53,11 @@ export interface ComputedIngestChangeObject {
 	regenerateRundown: boolean // Future: full vs metadata?
 
 	segmentExternalIdChanges: Record<string, string> // old -> new
+
+	/**
+	 * Force an execution of syncIngestUpdateToPartInstance for this ingest operation.
+	 */
+	forceSyncIngestUpdateToPartInstance?: boolean
 }
 
 export type ComputedIngestChanges = ComputedIngestChangeObject | ComputedIngestChangeAction
@@ -335,12 +340,16 @@ async function updateSofieIngestRundown(
 
 		const ingestObjectGenerator = new SofieIngestRundownDataCacheGenerator(rundownId)
 		const resultChanges = mutableIngestRundown.intoIngestRundown(ingestObjectGenerator)
+		const forceSyncIngestUpdateToPartInstance = blueprintContext.consumeRequestSyncIngestUpdateToPartInstance()
 
 		// Sync changes to the cache
 		sofieIngestObjectCache.replaceDocuments(resultChanges.changedCacheObjects)
 		sofieIngestObjectCache.removeAllOtherDocuments(resultChanges.allCacheObjectIds)
 
-		return resultChanges.computedChanges
+		return {
+			...resultChanges.computedChanges,
+			forceSyncIngestUpdateToPartInstance,
+		}
 	}
 }
 
@@ -438,6 +447,7 @@ async function applyCalculatedIngestChangesToModel(
 		if (result) {
 			return {
 				...result,
+				forceSyncIngestUpdateToPartInstance: computedIngestChanges.forceSyncIngestUpdateToPartInstance,
 				renamedSegments,
 			}
 		} else {
@@ -445,6 +455,7 @@ async function applyCalculatedIngestChangesToModel(
 				changedSegmentIds: [],
 				removedSegmentIds: [],
 				removeRundown: false,
+				forceSyncIngestUpdateToPartInstance: computedIngestChanges.forceSyncIngestUpdateToPartInstance,
 				renamedSegments,
 			}
 		}
@@ -480,6 +491,7 @@ async function applyCalculatedIngestChangesToModel(
 				return {
 					changedSegmentIds: regeneratedSegmentIds.changedSegmentIds,
 					removedSegmentIds: regeneratedSegmentIds.removedSegmentIds,
+					forceSyncIngestUpdateToPartInstance: computedIngestChanges.forceSyncIngestUpdateToPartInstance,
 					renamedSegments: renamedSegments,
 
 					removeRundown: false,
@@ -520,6 +532,7 @@ async function applyCalculatedIngestChangesToModel(
 		return {
 			changedSegmentIds: Array.from(changedSegmentIdsSet),
 			removedSegmentIds: orphanedSegmentIds, // Only inform about the ones that werent renamed
+			forceSyncIngestUpdateToPartInstance: computedIngestChanges.forceSyncIngestUpdateToPartInstance,
 			renamedSegments: renamedSegments,
 
 			removeRundown: false,

--- a/packages/job-worker/src/ingest/syncChangesToPartInstance.ts
+++ b/packages/job-worker/src/ingest/syncChangesToPartInstance.ts
@@ -58,7 +58,8 @@ export interface PartInstanceToSync {
 export async function syncChangesToPartInstances(
 	context: JobContext,
 	playoutModel: PlayoutModel,
-	ingestModel: IngestModelReadonly
+	ingestModel: IngestModelReadonly,
+	forceSyncIngestUpdateToPartInstance = false
 ): Promise<void> {
 	if (!playoutModel.playlist.activationId) return
 
@@ -76,7 +77,13 @@ export async function syncChangesToPartInstances(
 		return
 	}
 
-	const instancesToSync = findInstancesToSync(context, playoutModel, ingestModel, playoutRundownModel)
+	const instancesToSync = findInstancesToSync(
+		context,
+		playoutModel,
+		ingestModel,
+		playoutRundownModel,
+		forceSyncIngestUpdateToPartInstance
+	)
 
 	const worker = new SyncChangesToPartInstancesWorker(context, playoutModel, ingestModel, showStyle, blueprint)
 
@@ -299,7 +306,8 @@ export function findInstancesToSync(
 	context: JobContext,
 	playoutModel: PlayoutModel,
 	ingestModel: IngestModelReadonly,
-	playoutRundownModel: PlayoutRundownModel
+	playoutRundownModel: PlayoutRundownModel,
+	_forceSyncIngestUpdateToPartInstance = false
 ): PartInstanceToSync[] {
 	const currentPartInstance = playoutModel.currentPartInstance
 	const nextPartInstance = playoutModel.nextPartInstance

--- a/packages/job-worker/src/ingest/syncChangesToPartInstance.ts
+++ b/packages/job-worker/src/ingest/syncChangesToPartInstance.ts
@@ -343,7 +343,8 @@ export function findInstancesToSync(
 							partAndPartInstance.partInstance,
 							null,
 							partAndPartInstance.part,
-							'previous'
+							'previous',
+							_forceSyncIngestUpdateToPartInstance
 						)
 					} catch (err) {
 						logger.error(
@@ -369,7 +370,8 @@ export function findInstancesToSync(
 				ingestModel,
 				currentPartInstance,
 				previousPartInstance,
-				'current'
+				'current',
+				_forceSyncIngestUpdateToPartInstance
 			)
 		} catch (err) {
 			logger.error(`Failed to prepare currentPartInstance for syncChangesToPartInstances: ${stringifyError(err)}`)
@@ -390,7 +392,8 @@ export function findInstancesToSync(
 				ingestModel,
 				nextPartInstance,
 				currentPartInstance,
-				currentPartInstance?.isTooCloseToAutonext(false) ? 'current' : 'next'
+				currentPartInstance?.isTooCloseToAutonext(false) ? 'current' : 'next',
+				_forceSyncIngestUpdateToPartInstance
 			)
 		} catch (err) {
 			logger.error(`Failed to prepare nextPartInstance for syncChangesToPartInstances: ${stringifyError(err)}`)
@@ -412,7 +415,8 @@ function insertToSyncedInstanceCandidates(
 	thisPartInstance: PlayoutPartInstanceModel,
 	previousPartInstance: PlayoutPartInstanceModel | null,
 	part: ReadonlyDeep<DBPart> | undefined,
-	playStatus: PlayStatus
+	playStatus: PlayStatus,
+	_forceSyncIngestUpdateToPartInstance = false
 ): void {
 	const partOrInstancePart = part ?? thisPartInstance.partInstance.part
 
@@ -474,7 +478,8 @@ function findPartAndInsertToSyncedInstanceCandidates(
 	ingestModel: IngestModelReadonly,
 	thisPartInstance: PlayoutPartInstanceModel,
 	previousPartInstance: PlayoutPartInstanceModel | null,
-	playStatus: PlayStatus
+	playStatus: PlayStatus,
+	forceSyncIngestUpdateToPartInstance = false
 ): void {
 	const newPart = playoutModel.findPart(thisPartInstance.partInstance.part._id)
 
@@ -487,7 +492,8 @@ function findPartAndInsertToSyncedInstanceCandidates(
 		thisPartInstance,
 		previousPartInstance,
 		newPart,
-		playStatus
+		playStatus,
+		forceSyncIngestUpdateToPartInstance
 	)
 }
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the BBC

## Type of Contribution

This is a: Feature

## Current Behavior

Ingest may not trigger a part instance sync if the current / next parts haven't changed.
If the ingest affects T-Timers these won't be updated until the next take which results in inaccurate times being shown to the user.

## New Behavior

Blueprints can manually request the current part instances be synced, and thus T-Timers can be updated.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [X] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

This PR affects blueprints ingest operations.

## Time Frame
Not urgent, but we would like to get this merged into the in-development release.

## Other Information

Written with the assistance of GitHub Copilot

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [X] PR is ready to be reviewed.
- [X] The functionality has been tested by the author.
- [X] Relevant unit tests has been added / updated.
- [X] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
