### PR TITLE
fix: Same function signature for moveNextPart across contexts

### DIFF
--- a/packages/blueprints-integration/src/context/playoutActionContext.ts
+++ b/packages/blueprints-integration/src/context/playoutActionContext.ts
@@ -4,8 +4,11 @@ import type { IBlueprintPart, IBlueprintPartInstance, IBlueprintPiece } from '..
  * The playout-action methods shared between {@link IActionExecutionContext} and {@link IExternalEventContext}.
  */
 export interface IPlayoutActionContext {
-	/** Move the next part through the rundown. Can move by either a number of parts, or segments in either direction. */
-	moveNextPart(partDelta: number, segmentDelta: number, ignoreQuickloop?: boolean): Promise<void>
+	/**
+	 * Move the next part through the rundown. Can move by either a number of parts, or segments in either direction.
+	 * @returns Whether a new Part was found using the provided offset
+	 **/
+	moveNextPart(partDelta: number, segmentDelta: number, ignoreQuickloop?: boolean): Promise<boolean>
 	/** Set flag to perform a take after the current handler completes. Returns state of the flag after each call. */
 	takeAfterExecuteAction(take: boolean): Promise<boolean>
 	/** Insert a queued part to follow the current part */

--- a/packages/job-worker/src/blueprints/context/adlibActions.ts
+++ b/packages/job-worker/src/blueprints/context/adlibActions.ts
@@ -198,7 +198,7 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 		)
 	}
 
-	async moveNextPart(partDelta: number, segmentDelta: number, ignoreQuickloop?: boolean): Promise<void> {
+	async moveNextPart(partDelta: number, segmentDelta: number, ignoreQuickloop?: boolean): Promise<boolean> {
 		const selectedPart = selectNewPartWithOffsets(
 			this._context,
 			this._playoutModel,
@@ -206,7 +206,11 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 			segmentDelta,
 			ignoreQuickloop
 		)
-		if (selectedPart) await setNextPartFromPart(this._context, this._playoutModel, selectedPart, true)
+		if (selectedPart) {
+			await setNextPartFromPart(this._context, this._playoutModel, selectedPart, true)
+			return true
+		}
+		return false
 	}
 
 	async updatePartInstance(


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->
This pull request is posted on behalf of the BBC

## Type of Contribution

This is a: Code improvement

## Current Behavior

`onSetAsNext` and `actionExecution` contexts had slightly different method signatures.

## New Behavior

Method signatures are the same.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [X] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->
This PR affects blueprint contexts.

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->
Not urgent, but we would like to get this merged into the in-development release.

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [X] PR is ready to be reviewed.
- [X] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
