### PR TITLE
fix(webui): read timeline in/out words from piece content

### DIFF
--- a/packages/webui/src/client/lib/__tests__/pieceInOutWords.test.ts
+++ b/packages/webui/src/client/lib/__tests__/pieceInOutWords.test.ts
@@ -1,0 +1,73 @@
+import { getPieceInOutWords } from '../pieceInOutWords.js'
+
+describe('getPieceInOutWords', () => {
+	test('uses content firstWords and lastWords when present', () => {
+		expect(
+			getPieceInOutWords({
+				name: 'legacy begin||legacy end',
+				content: {
+					firstWords: 'Hello',
+					lastWords: 'world',
+				},
+			})
+		).toEqual({
+			begin: 'Hello',
+			end: 'world',
+		})
+	})
+
+	test('falls back to piece name when content has no in/out words', () => {
+		expect(
+			getPieceInOutWords({
+				name: 'First words…||…last words',
+				content: {
+					fileName: 'clip.mxf',
+					path: '/media/clip.mxf',
+				},
+			})
+		).toEqual({
+			begin: 'First words…',
+			end: '…last words',
+		})
+	})
+
+	test('falls back to piece name when content is missing', () => {
+		expect(
+			getPieceInOutWords({
+				name: 'Only begin',
+			})
+		).toEqual({
+			begin: 'Only begin',
+			end: '',
+		})
+	})
+
+	test('uses empty strings from content when keys are present', () => {
+		expect(
+			getPieceInOutWords({
+				name: 'ignored||ignored',
+				content: {
+					firstWords: '',
+					lastWords: '',
+				},
+			})
+		).toEqual({
+			begin: '',
+			end: '',
+		})
+	})
+
+	test('handles partial content fields', () => {
+		expect(
+			getPieceInOutWords({
+				name: 'clip.mxf',
+				content: {
+					lastWords: '…goodbye',
+				},
+			})
+		).toEqual({
+			begin: '',
+			end: '…goodbye',
+		})
+	})
+})

--- a/packages/webui/src/client/lib/pieceInOutWords.ts
+++ b/packages/webui/src/client/lib/pieceInOutWords.ts
@@ -1,0 +1,35 @@
+export interface PieceInOutWords {
+	begin: string
+	end: string
+}
+
+export interface PieceInOutWordsSource {
+	name: string
+	content?: unknown
+}
+
+/**
+ * Resolve first/last (in/out) words for timeline and related UI labels.
+ *
+ * Prefers `content.firstWords` / `content.lastWords` when present on the piece content
+ * (e.g. ScriptContent, VTContent). Falls back to the legacy `piece.name` format where
+ * first and last words are separated by `||`.
+ */
+export function getPieceInOutWords(piece: PieceInOutWordsSource): PieceInOutWords {
+	const content = piece.content
+	if (content !== null && typeof content === 'object') {
+		if ('firstWords' in content || 'lastWords' in content) {
+			const { firstWords, lastWords } = content as { firstWords?: string; lastWords?: string }
+			return {
+				begin: firstWords ?? '',
+				end: lastWords ?? '',
+			}
+		}
+	}
+
+	const labelItems = (piece.name || '').split('||')
+	return {
+		begin: labelItems[0] || '',
+		end: labelItems[1] || '',
+	}
+}

--- a/packages/webui/src/client/ui/SegmentList/LinePartPieceIndicator/LinePartScriptPiece.tsx
+++ b/packages/webui/src/client/ui/SegmentList/LinePartPieceIndicator/LinePartScriptPiece.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../PreviewPopUp/PreviewPopUpContext.js'
 import { useContentStatusForPieceInstance } from '../../SegmentTimeline/withMediaObjectStatus.js'
 import type { PieceExtended } from '@sofie-automation/corelib/src/dataModel/Piece.js'
+import { getPieceInOutWords } from '../../../lib/pieceInOutWords.js'
 
 interface IProps {
 	pieces: PieceExtended[]
@@ -68,8 +69,8 @@ export function LinePartScriptPiece({ pieces }: IProps): JSX.Element {
 	const hasPiece = thisPieces[0]
 	let scriptLabel = ''
 	if (hasPiece) {
-		const scriptLabelSplit = hasPiece.instance.piece.name.split('||')
-		scriptLabel = scriptLabelSplit[1] || scriptLabelSplit[0]
+		const { begin, end } = getPieceInOutWords(hasPiece.instance.piece)
+		scriptLabel = end || begin
 	}
 
 	// In order to have the left-hand-side ellipsis work it's magic, we need to wrap the text in LTR non-printable,

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/ScriptRenderer.tsx
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPartSecondaryPieces/Renderers/ScriptRenderer.tsx
@@ -1,9 +1,10 @@
 import type { IDefaultRendererProps } from './DefaultRenderer.js'
+import { getPieceInOutWords } from '../../../../lib/pieceInOutWords.js'
 
 export function ScriptRenderer(props: Readonly<IDefaultRendererProps>): JSX.Element | string {
-	const labelItems = (props.piece.instance.piece.name || '').split('||')
-	const begin = (labelItems[0] || '').trim()
-	const end = (labelItems[1] || '').trim()
+	const { begin: beginRaw, end: endRaw } = getPieceInOutWords(props.piece.instance.piece)
+	const begin = beginRaw.trim()
+	const end = endRaw.trim()
 
 	if (end) {
 		return (

--- a/packages/webui/src/client/ui/SegmentTimeline/Renderers/MicSourceRenderer.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/Renderers/MicSourceRenderer.tsx
@@ -198,7 +198,11 @@ export const MicSourceRenderer: React.ComponentType<IProps> = withTranslation()(
 				this.refreshLine()
 			}
 
-			if (this.props.piece.instance.piece.name !== prevProps.piece.instance.piece.name) {
+			const prevInOutWords = getPieceInOutWords(prevProps.piece.instance.piece)
+			const inOutWords = getPieceInOutWords(this.props.piece.instance.piece)
+			const inOutWordsChanged = inOutWords.begin !== prevInOutWords.begin || inOutWords.end !== prevInOutWords.end
+
+			if (this.props.piece.instance.piece.name !== prevProps.piece.instance.piece.name || inOutWordsChanged) {
 				this.updateAnchoredElsWidths()
 			}
 		}

--- a/packages/webui/src/client/ui/SegmentTimeline/Renderers/MicSourceRenderer.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/Renderers/MicSourceRenderer.tsx
@@ -8,6 +8,7 @@ import { getElementWidth } from '../../../utils/dimensions.js'
 import { calculatePartInstanceExpectedDurationWithTransition } from '@sofie-automation/corelib/dist/playout/timings'
 import { unprotectString } from '@sofie-automation/shared-lib/dist/lib/protectedString'
 import { logger } from '../../../lib/logging.js'
+import { getPieceInOutWords } from '../../../lib/pieceInOutWords.js'
 
 type IProps = ICustomLayerItemProps
 interface IState {}
@@ -209,9 +210,7 @@ export const MicSourceRenderer: React.ComponentType<IProps> = withTranslation()(
 		}
 
 		render(): JSX.Element {
-			const labelItems = (this.props.piece.instance.piece.name || '').split('||')
-			const begin = labelItems[0] || ''
-			const end = labelItems[1] || ''
+			const { begin, end } = getPieceInOutWords(this.props.piece.instance.piece)
 
 			// function shorten (str: string, maxLen: number, separator: string = ' ') {
 			// 	if (str.length <= maxLen) return str

--- a/packages/webui/src/client/ui/SegmentTimeline/Renderers/SplitsSourceRenderer.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/Renderers/SplitsSourceRenderer.tsx
@@ -62,7 +62,11 @@ export class SplitsSourceRenderer extends CustomLayerItemRenderer<IProps, IState
 			super.componentDidUpdate(prevProps, prevState)
 		}
 
-		if (this.props.piece.instance.piece.name !== prevProps.piece.instance.piece.name) {
+		const prevInOutWords = getPieceInOutWords(prevProps.piece.instance.piece)
+		const inOutWords = getPieceInOutWords(this.props.piece.instance.piece)
+		const inOutWordsChanged = inOutWords.begin !== prevInOutWords.begin || inOutWords.end !== prevInOutWords.end
+
+		if (this.props.piece.instance.piece.name !== prevProps.piece.instance.piece.name || inOutWordsChanged) {
 			this.updateAnchoredElsWidths()
 		}
 	}

--- a/packages/webui/src/client/ui/SegmentTimeline/Renderers/SplitsSourceRenderer.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/Renderers/SplitsSourceRenderer.tsx
@@ -7,6 +7,7 @@ import { CustomLayerItemRenderer, type ICustomLayerItemProps } from './CustomLay
 import type { SplitsContent } from '@sofie-automation/blueprints-integration'
 import { getSplitPreview, SplitRole, type SplitSubItem } from '../../../lib/ui/splitPreview.js'
 import { RundownUtils } from '../../../lib/rundown.js'
+import { getPieceInOutWords } from '../../../lib/pieceInOutWords.js'
 
 type IProps = ICustomLayerItemProps
 
@@ -89,9 +90,7 @@ export class SplitsSourceRenderer extends CustomLayerItemRenderer<IProps, IState
 	}
 
 	render(): JSX.Element {
-		const labelItems = this.props.piece.instance.piece.name.split('||')
-		const begin = labelItems[0] || ''
-		const end = labelItems[1] || ''
+		const { begin, end } = getPieceInOutWords(this.props.piece.instance.piece)
 
 		return (
 			<React.Fragment>

--- a/packages/webui/src/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
@@ -252,10 +252,6 @@ class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithTranslat
 		const inOutWords = getPieceInOutWords(innerPiece)
 		const inOutWordsChanged = inOutWords.begin !== prevInOutWords.begin || inOutWords.end !== prevInOutWords.end
 
-		if (innerPiece.name !== prevProps.piece.instance.piece.name || inOutWordsChanged) {
-			this.updateAnchoredElsWidths()
-		}
-
 		let newState: Partial<IState> = {}
 		if (
 			innerPiece.name !== prevProps.piece.instance.piece.name ||
@@ -272,7 +268,12 @@ class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithTranslat
 
 		if (this.hasStateChanges(newState)) {
 			this.setState(newState as IState, () => {
-				if (newState.noticeLevel && newState.noticeLevel !== prevState.noticeLevel) {
+				if (
+					(newState.noticeLevel && newState.noticeLevel !== prevState.noticeLevel) ||
+					inOutWordsChanged ||
+					newState.begin !== prevState.begin ||
+					newState.end !== prevState.end
+				) {
 					this.updateAnchoredElsWidths()
 				}
 			})

--- a/packages/webui/src/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/Renderers/VTSourceRenderer.tsx
@@ -21,6 +21,7 @@ import { stringifyError } from '@sofie-automation/shared-lib/dist/lib/stringifyE
 import type { ReadonlyDeep } from 'type-fest'
 import type { PieceContentStatusObj } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
 import type { UIStudio } from '@sofie-automation/corelib/src/dataModel/Studio.js'
+import { getPieceInOutWords } from '../../../lib/pieceInOutWords.js'
 
 interface IProps extends ICustomLayerItemProps {
 	studio: UIStudio | undefined
@@ -48,13 +49,12 @@ class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithTranslat
 		super(props)
 
 		const innerPiece = props.piece.instance.piece
-
-		const labelItems = innerPiece.name.split('||')
+		const { begin, end } = getPieceInOutWords(innerPiece)
 
 		this.state = {
 			noticeLevel: getNoticeLevelForPieceStatus(props.contentStatus?.status),
-			begin: labelItems[0] || '',
-			end: labelItems[1] || '',
+			begin,
+			end,
 		}
 
 		this.rightLabelContainer = document.createElement('span')
@@ -248,19 +248,23 @@ class VTSourceRendererBase extends CustomLayerItemRenderer<IProps & WithTranslat
 		const { itemElement } = this.props
 		const innerPiece = this.props.piece.instance.piece
 
-		if (innerPiece.name !== prevProps.piece.instance.piece.name) {
+		const prevInOutWords = getPieceInOutWords(prevProps.piece.instance.piece)
+		const inOutWords = getPieceInOutWords(innerPiece)
+		const inOutWordsChanged = inOutWords.begin !== prevInOutWords.begin || inOutWords.end !== prevInOutWords.end
+
+		if (innerPiece.name !== prevProps.piece.instance.piece.name || inOutWordsChanged) {
 			this.updateAnchoredElsWidths()
 		}
 
 		let newState: Partial<IState> = {}
 		if (
 			innerPiece.name !== prevProps.piece.instance.piece.name ||
+			inOutWordsChanged ||
 			this.props.contentStatus?.status !== prevProps.contentStatus?.status
 		) {
-			const labelItems = innerPiece.name.split('||')
 			newState.noticeLevel = getNoticeLevelForPieceStatus(this.props.contentStatus?.status)
-			newState.begin = labelItems[0] || ''
-			newState.end = labelItems[1] || ''
+			newState.begin = inOutWords.begin
+			newState.end = inOutWords.end
 		}
 
 		newState = this.mountRightLabelContainer(this.props, prevProps, newState, itemElement)


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of SuperFly.tv.

## Type of Contribution

This is a bug fix

## Current Behavior

Timeline labels for script, VT, and related pieces resolve first/last (in/out) words by splitting `piece.name` on `||`.

Hover previews and the `VTContent` / `ScriptContent` types already support `content.firstWords` and `content.lastWords` (added in #1355), but timeline renderers ignore those fields. Blueprints that populate content only therefore show incomplete labels on the timeline (e.g. first words on the left, nothing on the right).

## New Behavior

Timeline and related UI labels use a shared `getPieceInOutWords()` helper that prefers `content.firstWords` / `content.lastWords` when present, and falls back to the legacy `piece.name.split('||')` format for older blueprints.

`VTSourceRenderer` also updates labels when content words change, not only when `piece.name` changes.

## Testing

- [x] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

* Web UI timeline labels
* Storyboard script secondary piece labels
* Segment list script indicator

## Time Frame

Not urgent, but fixes a long-standing inconsistency between timeline display and content/preview APIs.

## Other Information

Related: SuperFlyTV/SVT-project#50

## Status

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
