### PR TITLE
fix: Use blueprint code hash for importVersions resync checks

### DIFF
--- a/meteor/server/api/blueprints/__tests__/api.test.ts
+++ b/meteor/server/api/blueprints/__tests__/api.test.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import os from 'os'
 import { promises as fsp } from 'fs'
 import { setupDefaultStudioEnvironment, packageBlueprint } from '../../../../__mocks__/helpers/database'
-import { literal, getRandomId } from '@sofie-automation/corelib/dist/lib'
+import { literal, getRandomId, getRandomString } from '@sofie-automation/corelib/dist/lib'
 import { protectString } from '@sofie-automation/corelib/dist/protectedString'
 import { Blueprint } from '@sofie-automation/corelib/dist/dataModel/Blueprint'
 import { BlueprintManifestType } from '@sofie-automation/blueprints-integration'
@@ -53,7 +53,7 @@ describe('Test blueprint management api', () => {
 
 				blueprintId: '',
 				blueprintType: BlueprintManifestType.SYSTEM,
-				blueprintHash: getRandomId(),
+				blueprintHash: getRandomString(),
 
 				studioConfigSchema: JSONBlobStringify({}),
 				showStyleConfigSchema: JSONBlobStringify({}),
@@ -519,6 +519,47 @@ describe('Test blueprint management api', () => {
 				422,
 				`Cannot replace old blueprint "${existingBlueprint._id}" ("ss1") with new blueprint "show2"`
 			)
+		})
+		test('content hash is stable for identical code and changes when code changes', async () => {
+			const BLUEPRINT_TYPE = BlueprintManifestType.SHOWSTYLE
+			const blueprintStr = packageBlueprint(
+				{
+					BLUEPRINT_TYPE,
+				},
+				() => {
+					return {
+						blueprintId: 'hash_stable',
+						blueprintType: BLUEPRINT_TYPE,
+						blueprintVersion: '0.0.1',
+						integrationVersion: '0.2.0',
+						TSRVersion: '0.3.0',
+						showStyleConfigSchema: JSON.stringify({}) as any,
+					}
+				}
+			)
+			const blueprintStrChanged = packageBlueprint(
+				{
+					BLUEPRINT_TYPE,
+				},
+				() => {
+					return {
+						blueprintId: 'hash_stable',
+						blueprintType: BLUEPRINT_TYPE,
+						blueprintVersion: '0.0.1', // same semver
+						integrationVersion: '0.2.0',
+						TSRVersion: '0.3.0',
+						showStyleConfigSchema: JSON.stringify({ changed: true }) as any,
+					}
+				}
+			)
+
+			const first = await uploadBlueprint(DEFAULT_CONNECTION, protectString('tmp_hash'), blueprintStr)
+			const second = await uploadBlueprint(DEFAULT_CONNECTION, protectString('tmp_hash'), blueprintStr)
+			expect(second.blueprintHash).toEqual(first.blueprintHash)
+
+			const third = await uploadBlueprint(DEFAULT_CONNECTION, protectString('tmp_hash'), blueprintStrChanged)
+			expect(third.blueprintHash).not.toEqual(first.blueprintHash)
+			expect(third.blueprintVersion).toEqual(first.blueprintVersion)
 		})
 		test('update - drop blueprintId', async () => {
 			const BLUEPRINT_TYPE = BlueprintManifestType.SHOWSTYLE

--- a/meteor/server/api/blueprints/__tests__/lib.ts
+++ b/meteor/server/api/blueprints/__tests__/lib.ts
@@ -1,5 +1,5 @@
 import { BlueprintManifestType, SomeBlueprintManifest } from '@sofie-automation/blueprints-integration'
-import { getRandomId, literal } from '@sofie-automation/corelib/dist/lib'
+import { getRandomString, literal } from '@sofie-automation/corelib/dist/lib'
 import { protectString } from '@sofie-automation/corelib/dist/protectedString'
 import { Blueprint } from '@sofie-automation/corelib/dist/dataModel/Blueprint'
 import { JSONBlobStringify } from '@sofie-automation/shared-lib/dist/lib/JSONBlob'
@@ -36,7 +36,7 @@ export function generateFakeBlueprint(
 
 		blueprintId: '',
 		blueprintType: type,
-		blueprintHash: getRandomId(),
+		blueprintHash: getRandomString(),
 
 		studioConfigSchema: JSONBlobStringify({}),
 		showStyleConfigSchema: JSONBlobStringify({}),

--- a/meteor/server/api/blueprints/api.ts
+++ b/meteor/server/api/blueprints/api.ts
@@ -1,7 +1,7 @@
 import _ from 'underscore'
 import path from 'path'
 import { ReadStream, createReadStream, promises as fsp } from 'fs'
-import { getRandomId } from '@sofie-automation/corelib/dist/lib'
+import { getHash, getRandomId, getRandomString } from '@sofie-automation/corelib/dist/lib'
 import { unprotectString } from '@sofie-automation/corelib/dist/protectedString'
 import { getCurrentTime } from '../../lib/lib'
 import { logger } from '../../logging'
@@ -62,7 +62,7 @@ export async function insertBlueprint(
 		integrationVersion: '',
 		TSRVersion: '',
 
-		blueprintHash: getRandomId(),
+		blueprintHash: getRandomString(),
 		hasFixUpFunction: false,
 	})
 }
@@ -177,7 +177,9 @@ async function innerUploadBlueprint(
 		TSRVersion: '',
 		disableVersionChecks: false,
 		blueprintType: undefined,
-		blueprintHash: getRandomId(),
+		// Content hash of the uploaded code so identical re-uploads keep the same hash, and any
+		// code change (even with an unchanged semver blueprintVersion) is detectable.
+		blueprintHash: body ? getHash(body) : getRandomString(),
 		hasFixUpFunction: false,
 	}
 

--- a/meteor/server/api/playout/playout.ts
+++ b/meteor/server/api/playout/playout.ts
@@ -21,7 +21,7 @@ export namespace ServerPlayoutAPI {
 			const [timeline, blueprint] = await Promise.all([
 				Timeline.findOneAsync(studio._id),
 				studio.blueprintId
-					? Blueprints.findOneAsync(studio.blueprintId, { projection: { blueprintVersion: 1 } })
+					? Blueprints.findOneAsync(studio.blueprintId, { projection: { blueprintHash: 1 } })
 					: null,
 			])
 			if (blueprint === undefined) return 'missingBlueprint'

--- a/meteor/server/api/rundown.ts
+++ b/meteor/server/api/rundown.ts
@@ -108,11 +108,11 @@ export namespace ClientRundownAPI {
 				const blueprint = (await Blueprints.findOneAsync(showStyleBase.blueprintId, {
 					projection: {
 						_id: 1,
-						blueprintVersion: 1,
+						blueprintHash: 1,
 					},
-				})) as Pick<Blueprint, '_id' | 'blueprintVersion'>
-				if (!blueprint.blueprintVersion) return 'missing blueprint'
-				if (rundown.importVersions.blueprint !== (blueprint.blueprintVersion || 0)) return 'blueprint'
+				})) as Pick<Blueprint, '_id' | 'blueprintHash'>
+				if (!blueprint.blueprintHash) return 'missing blueprint'
+				if (rundown.importVersions.blueprint !== blueprint.blueprintHash) return 'blueprint'
 
 				const studio = (await Studios.findOneAsync(rundown.studioId, {
 					projection: {

--- a/meteor/server/migration/1_49_0.ts
+++ b/meteor/server/migration/1_49_0.ts
@@ -1,6 +1,6 @@
 import { addMigrationSteps } from './databaseMigration'
 import { Blueprints, ShowStyleVariants } from '../collections'
-import { getRandomId } from '@sofie-automation/corelib/dist/lib'
+import { getRandomString } from '@sofie-automation/corelib/dist/lib'
 
 // Release 49
 
@@ -48,7 +48,7 @@ export const addSteps = addMigrationSteps('1.49.0', [
 			for (const obj of objects) {
 				await Blueprints.updateAsync(obj._id, {
 					$set: {
-						blueprintHash: getRandomId(),
+						blueprintHash: getRandomString(),
 					},
 				})
 			}

--- a/meteor/server/migration/upgrades/system.ts
+++ b/meteor/server/migration/upgrades/system.ts
@@ -40,7 +40,7 @@ export async function runUpgradeForCoreSystem(coreSystemId: CoreSystemId): Promi
 		$set: {
 			'settingsWithOverrides.defaults': coreSystemSettings,
 			lastBlueprintConfig: {
-				blueprintHash: blueprint?.blueprintHash ?? protectString('default'),
+				blueprintHash: blueprint?.blueprintHash ?? 'default',
 				blueprintId: blueprint?._id ?? protectString('default'),
 				blueprintConfigPresetId: undefined,
 				config: {},

--- a/meteor/server/publications/blueprintUpgradeStatus/checkStatus.ts
+++ b/meteor/server/publications/blueprintUpgradeStatus/checkStatus.ts
@@ -185,7 +185,7 @@ export function checkSystemUpgradeStatus(
 					newValue: defaultId,
 				})
 			)
-		} else if (doc.lastBlueprintConfig.blueprintHash !== defaultId) {
+		} else if (doc.lastBlueprintConfig.blueprintHash !== 'default') {
 			changes.push(generateTranslation('Blueprint has a new version'))
 		}
 	}

--- a/packages/corelib/src/dataModel/Blueprint.ts
+++ b/packages/corelib/src/dataModel/Blueprint.ts
@@ -6,11 +6,11 @@ import {
 } from '@sofie-automation/blueprints-integration'
 import { JSONBlob } from '@sofie-automation/shared-lib/dist/lib/JSONBlob'
 import { JSONSchema } from '@sofie-automation/shared-lib/dist/lib/JSONSchemaTypes'
-import { ProtectedString } from '../protectedString.js'
 import { BlueprintId } from './Ids.js'
 import type { PackageStatusMessage } from '@sofie-automation/shared-lib/dist/packageStatusMessages'
 
-export type BlueprintHash = ProtectedString<'BlueprintHash'>
+/** Content hash (or placeholder) for a blueprint code bundle — plain string, like blueprintVersion */
+export type BlueprintHash = string
 
 export interface Blueprint {
 	_id: BlueprintId
@@ -47,7 +47,10 @@ export interface Blueprint {
 	/** Whether version checks should be disabled for this version */
 	disableVersionChecks?: boolean
 
-	/** Hash for the blueprint, changed each time it is changed */
+	/**
+	 * Hash of the blueprint `code` string. Changes whenever the uploaded bundle content changes.
+	 * Used to detect that rundowns/baselines need regenerating after a blueprint deploy.
+	 */
 	blueprintHash: BlueprintHash
 
 	/** Whether the blueprint this wraps has a `fixUpConfig` function defined */

--- a/packages/corelib/src/dataModel/Rundown.ts
+++ b/packages/corelib/src/dataModel/Rundown.ts
@@ -26,6 +26,10 @@ export interface RundownImportVersions {
 	studio: string
 	showStyleBase: string
 	showStyleVariant: string
+	/**
+	 * Blueprint code hash (`Blueprint.blueprintHash`) at ingest time — not the semver
+	 * `blueprintVersion`. Used to detect that a reload is needed after a blueprint upload.
+	 */
 	blueprint: string
 
 	core: string

--- a/packages/corelib/src/dataModel/Timeline.ts
+++ b/packages/corelib/src/dataModel/Timeline.ts
@@ -97,6 +97,10 @@ export function updateLookaheadLayer(obj: TimelineObjRundown): void {
 export interface TimelineCompleteGenerationVersions {
 	core: string
 	blueprintId: BlueprintId | undefined
+	/**
+	 * Blueprint code hash (`Blueprint.blueprintHash`) used when generating this timeline.
+	 * Field name is historical; value is not the semver blueprintVersion.
+	 */
 	blueprintVersion: string
 	studio: string
 }

--- a/packages/corelib/src/studio/baseline.ts
+++ b/packages/corelib/src/studio/baseline.ts
@@ -8,7 +8,7 @@ export function shouldUpdateStudioBaselineInner(
 	coreVersion: string,
 	studio: Pick<DBStudio, 'blueprintId' | '_rundownVersionHash'>,
 	studioTimeline: ReadonlyDeep<TimelineComplete> | null,
-	studioBlueprint: Pick<Blueprint, 'blueprintVersion'> | null
+	studioBlueprint: Pick<Blueprint, 'blueprintHash'> | null
 ): string | false {
 	if (!studioTimeline) return 'noBaseline'
 
@@ -22,7 +22,7 @@ export function shouldUpdateStudioBaselineInner(
 	if (versionsContent.blueprintId !== unprotectString(studio.blueprintId)) return 'blueprintId'
 	if (studio.blueprintId) {
 		if (!studioBlueprint) return 'blueprintUnknown'
-		if (versionsContent.blueprintVersion !== (studioBlueprint.blueprintVersion || 0)) return 'blueprintVersion'
+		if (versionsContent.blueprintVersion !== (studioBlueprint.blueprintHash || 0)) return 'blueprintVersion'
 	}
 
 	return false

--- a/packages/job-worker/src/__mocks__/context.ts
+++ b/packages/job-worker/src/__mocks__/context.ts
@@ -243,6 +243,7 @@ export class MockJobContext implements JobContext {
 		return {
 			blueprintId: showStyle.blueprintId,
 			blueprint: this.#showStyleBlueprint,
+			blueprintHash: 'mockShowStyleBlueprintHash',
 		}
 	}
 	getShowStyleBlueprintConfig(showStyle: ReadonlyDeep<ProcessedShowStyleCompound>): ProcessedShowStyleConfig {

--- a/packages/job-worker/src/blueprints/__tests__/lib.ts
+++ b/packages/job-worker/src/blueprints/__tests__/lib.ts
@@ -1,6 +1,6 @@
 import { BlueprintManifestType, SomeBlueprintManifest } from '@sofie-automation/blueprints-integration'
 import { protectString } from '@sofie-automation/corelib/dist/protectedString'
-import { getRandomId, literal } from '@sofie-automation/corelib/dist/lib'
+import { getRandomString, literal } from '@sofie-automation/corelib/dist/lib'
 import { Blueprint } from '@sofie-automation/corelib/dist/dataModel/Blueprint'
 import { JSONBlobStringify } from '@sofie-automation/shared-lib/dist/lib/JSONBlob'
 
@@ -36,7 +36,7 @@ export function generateFakeBlueprint(
 
 		blueprintId: '',
 		blueprintType: type,
-		blueprintHash: getRandomId(),
+		blueprintHash: getRandomString(),
 
 		studioConfigSchema: JSONBlobStringify({}),
 		showStyleConfigSchema: JSONBlobStringify({}),

--- a/packages/job-worker/src/blueprints/cache.ts
+++ b/packages/job-worker/src/blueprints/cache.ts
@@ -22,6 +22,8 @@ export interface WrappedStudioBlueprint {
 export interface WrappedShowStyleBlueprint {
 	blueprintId: BlueprintId
 	blueprint: ShowStyleBlueprintManifest
+	/** Hash of the blueprint code from the Blueprint document */
+	blueprintHash: Blueprint['blueprintHash']
 }
 
 // export async function loadSystemBlueprints(system: ICoreSystem): Promise<WrappedSystemBlueprint | undefined> {

--- a/packages/job-worker/src/ingest/bucket/import.ts
+++ b/packages/job-worker/src/ingest/bucket/import.ts
@@ -167,7 +167,7 @@ async function regenerateBucketItemFromIngestInfo(
 				studio: context.studio._rundownVersionHash,
 				showStyleBase: showStyleCompound._rundownVersionHash,
 				showStyleVariant: showStyleCompound._rundownVersionHashVariant,
-				blueprint: blueprint.blueprint.blueprintVersion,
+				blueprint: blueprint.blueprintHash,
 				core: getSystemVersion(),
 			}
 

--- a/packages/job-worker/src/ingest/model/implementation/IngestModelImpl.ts
+++ b/packages/job-worker/src/ingest/model/implementation/IngestModelImpl.ts
@@ -428,7 +428,7 @@ export class IngestModelImpl implements IngestModel, IngestDatabasePersistedMode
 				studio: this.context.studio._rundownVersionHash,
 				showStyleBase: showStyleBase._rundownVersionHash,
 				showStyleVariant: showStyleVariant._rundownVersionHash,
-				blueprint: showStyleBlueprint.blueprint.blueprintVersion,
+				blueprint: showStyleBlueprint.blueprintHash,
 				core: getSystemVersion(),
 			},
 

--- a/packages/job-worker/src/ingest/mosDevice/__tests__/__snapshots__/mosIngest.test.ts.snap
+++ b/packages/job-worker/src/ingest/mosDevice/__tests__/__snapshots__/mosIngest.test.ts.snap
@@ -47,7 +47,7 @@ exports[`Test recieved mos ingest payloads mosRoCreate 2`] = `
   "created": 0,
   "externalId": "SLENPS01;P_NDSL\\W;68E40DE6-2D08-487D-aaaaa",
   "importVersions": {
-    "blueprint": "0.0.0",
+    "blueprint": "mockShowStyleBlueprintHash",
     "core": "0.0.0-test",
     "showStyleBase": "",
     "showStyleVariant": "",
@@ -359,7 +359,7 @@ exports[`Test recieved mos ingest payloads mosRoCreate: replace existing 2`] = `
   "created": 0,
   "externalId": "SLENPS01;P_NDSL\\W;68E40DE6-2D08-487D-aaaaa",
   "importVersions": {
-    "blueprint": "0.0.0",
+    "blueprint": "mockShowStyleBlueprintHash",
     "core": "0.0.0-test",
     "showStyleBase": "",
     "showStyleVariant": "",
@@ -664,7 +664,7 @@ exports[`Test recieved mos ingest payloads mosRoFullStory: Valid data 2`] = `
   "created": 0,
   "externalId": "SLENPS01;P_NDSL\\W;68E40DE6-2D08-487D-aaaaa",
   "importVersions": {
-    "blueprint": "0.0.0",
+    "blueprint": "mockShowStyleBlueprintHash",
     "core": "0.0.0-test",
     "showStyleBase": "",
     "showStyleVariant": "",
@@ -989,7 +989,7 @@ exports[`Test recieved mos ingest payloads mosRoReadyToAir: Update ro 2`] = `
   "created": 0,
   "externalId": "SLENPS01;P_NDSL\\W;68E40DE6-2D08-487D-aaaaa",
   "importVersions": {
-    "blueprint": "0.0.0",
+    "blueprint": "mockShowStyleBlueprintHash",
     "core": "0.0.0-test",
     "showStyleBase": "",
     "showStyleVariant": "",
@@ -1303,7 +1303,7 @@ exports[`Test recieved mos ingest payloads mosRoStatus: Update ro 2`] = `
   "created": 0,
   "externalId": "SLENPS01;P_NDSL\\W;68E40DE6-2D08-487D-aaaaa",
   "importVersions": {
-    "blueprint": "0.0.0",
+    "blueprint": "mockShowStyleBlueprintHash",
     "core": "0.0.0-test",
     "showStyleBase": "",
     "showStyleVariant": "",
@@ -1617,7 +1617,7 @@ exports[`Test recieved mos ingest payloads mosRoStoryDelete: Remove segment 2`] 
   "created": 0,
   "externalId": "SLENPS01;P_NDSL\\W;68E40DE6-2D08-487D-aaaaa",
   "importVersions": {
-    "blueprint": "0.0.0",
+    "blueprint": "mockShowStyleBlueprintHash",
     "core": "0.0.0-test",
     "showStyleBase": "",
     "showStyleVariant": "",
@@ -1898,7 +1898,7 @@ exports[`Test recieved mos ingest payloads mosRoStoryInsert: Into segment 2`] = 
   "created": 0,
   "externalId": "SLENPS01;P_NDSL\\W;68E40DE6-2D08-487D-aaaaa",
   "importVersions": {
-    "blueprint": "0.0.0",
+    "blueprint": "mockShowStyleBlueprintHash",
     "core": "0.0.0-test",
     "showStyleBase": "",
     "showStyleVariant": "",
@@ -2224,7 +2224,7 @@ exports[`Test recieved mos ingest payloads mosRoStoryInsert: New segment 2`] = `
   "created": 0,
   "externalId": "SLENPS01;P_NDSL\\W;68E40DE6-2D08-487D-aaaaa",
   "importVersions": {
-    "blueprint": "0.0.0",
+    "blueprint": "mockShowStyleBlueprintHash",
     "core": "0.0.0-test",
     "showStyleBase": "",
     "showStyleVariant": "",
@@ -2558,7 +2558,7 @@ exports[`Test recieved mos ingest payloads mosRoStoryMove: Move whole segment to
   "created": 0,
   "externalId": "SLENPS01;P_NDSL\\W;68E40DE6-2D08-487D-aaaaa",
   "importVersions": {
-    "blueprint": "0.0.0",
+    "blueprint": "mockShowStyleBlueprintHash",
     "core": "0.0.0-test",
     "showStyleBase": "",
     "showStyleVariant": "",
@@ -2875,7 +2875,7 @@ exports[`Test recieved mos ingest payloads mosRoStoryMove: Within segment 2`] = 
   "created": 0,
   "externalId": "SLENPS01;P_NDSL\\W;68E40DE6-2D08-487D-aaaaa",
   "importVersions": {
-    "blueprint": "0.0.0",
+    "blueprint": "mockShowStyleBlueprintHash",
     "core": "0.0.0-test",
     "showStyleBase": "",
     "showStyleVariant": "",
@@ -3192,7 +3192,7 @@ exports[`Test recieved mos ingest payloads mosRoStoryReplace: Same segment 2`] =
   "created": 0,
   "externalId": "SLENPS01;P_NDSL\\W;68E40DE6-2D08-487D-aaaaa",
   "importVersions": {
-    "blueprint": "0.0.0",
+    "blueprint": "mockShowStyleBlueprintHash",
     "core": "0.0.0-test",
     "showStyleBase": "",
     "showStyleVariant": "",
@@ -3508,7 +3508,7 @@ exports[`Test recieved mos ingest payloads mosRoStorySwap: Swap across segments 
   "created": 0,
   "externalId": "SLENPS01;P_NDSL\\W;68E40DE6-2D08-487D-aaaaa",
   "importVersions": {
-    "blueprint": "0.0.0",
+    "blueprint": "mockShowStyleBlueprintHash",
     "core": "0.0.0-test",
     "showStyleBase": "",
     "showStyleVariant": "",
@@ -3817,7 +3817,7 @@ exports[`Test recieved mos ingest payloads mosRoStorySwap: Swap across segments2
   "created": 0,
   "externalId": "SLENPS01;P_NDSL\\W;68E40DE6-2D08-487D-aaaaa",
   "importVersions": {
-    "blueprint": "0.0.0",
+    "blueprint": "mockShowStyleBlueprintHash",
     "core": "0.0.0-test",
     "showStyleBase": "",
     "showStyleVariant": "",
@@ -4158,7 +4158,7 @@ exports[`Test recieved mos ingest payloads mosRoStorySwap: With first in same se
   "created": 0,
   "externalId": "SLENPS01;P_NDSL\\W;68E40DE6-2D08-487D-aaaaa",
   "importVersions": {
-    "blueprint": "0.0.0",
+    "blueprint": "mockShowStyleBlueprintHash",
     "core": "0.0.0-test",
     "showStyleBase": "",
     "showStyleVariant": "",
@@ -4475,7 +4475,7 @@ exports[`Test recieved mos ingest payloads mosRoStorySwap: Within same segment 2
   "created": 0,
   "externalId": "SLENPS01;P_NDSL\\W;68E40DE6-2D08-487D-aaaaa",
   "importVersions": {
-    "blueprint": "0.0.0",
+    "blueprint": "mockShowStyleBlueprintHash",
     "core": "0.0.0-test",
     "showStyleBase": "",
     "showStyleVariant": "",

--- a/packages/job-worker/src/playout/__tests__/__snapshots__/playout.test.ts.snap
+++ b/packages/job-worker/src/playout/__tests__/__snapshots__/playout.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Playout API Basic rundown control 1`] = `
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "blueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "mockShowStyleBlueprintHash",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -51,7 +51,7 @@ exports[`Playout API Basic rundown control 3`] = `
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },

--- a/packages/job-worker/src/playout/__tests__/__snapshots__/timeline.test.ts.snap
+++ b/packages/job-worker/src/playout/__tests__/__snapshots__/timeline.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Timeline Multi-gateway mode In transitions inTransition with existing i
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -24,7 +24,7 @@ exports[`Timeline Multi-gateway mode Infinite Pieces Infinite Piece has stable t
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -41,7 +41,7 @@ exports[`Timeline Single-gateway mode Adlib pieces Current part with preroll 1`]
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -58,7 +58,7 @@ exports[`Timeline Single-gateway mode Adlib pieces Current part with preroll and
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -75,7 +75,7 @@ exports[`Timeline Single-gateway mode Basic rundown 1`] = `
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "blueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "mockShowStyleBlueprintHash",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -92,7 +92,7 @@ exports[`Timeline Single-gateway mode Basic rundown 2`] = `
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -109,7 +109,7 @@ exports[`Timeline Single-gateway mode In transitions Basic inTransition 1`] = `
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -126,7 +126,7 @@ exports[`Timeline Single-gateway mode In transitions Basic inTransition with con
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -143,7 +143,7 @@ exports[`Timeline Single-gateway mode In transitions Basic inTransition with con
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -160,7 +160,7 @@ exports[`Timeline Single-gateway mode In transitions Basic inTransition with pla
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -177,7 +177,7 @@ exports[`Timeline Single-gateway mode In transitions Preroll 1`] = `
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -194,7 +194,7 @@ exports[`Timeline Single-gateway mode In transitions inTransition disabled 1`] =
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -211,7 +211,7 @@ exports[`Timeline Single-gateway mode In transitions inTransition is disabled du
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -228,7 +228,7 @@ exports[`Timeline Single-gateway mode In transitions inTransition with existing 
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -245,7 +245,7 @@ exports[`Timeline Single-gateway mode In transitions inTransition with new infin
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -262,7 +262,7 @@ exports[`Timeline Single-gateway mode Infinite Pieces Infinite Piece has stable 
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -279,7 +279,7 @@ exports[`Timeline Single-gateway mode Out transitions Basic outTransition 1`] = 
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -296,7 +296,7 @@ exports[`Timeline Single-gateway mode Out transitions outTransition + inTransiti
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -313,7 +313,7 @@ exports[`Timeline Single-gateway mode Out transitions outTransition + preroll (2
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -330,7 +330,7 @@ exports[`Timeline Single-gateway mode Out transitions outTransition + preroll 1`
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },
@@ -347,7 +347,7 @@ exports[`Timeline Single-gateway mode Out transitions outTransition is disabled 
     "generated": 12345,
     "generationVersions": {
       "blueprintId": "studioBlueprint0",
-      "blueprintVersion": "0.0.0",
+      "blueprintVersion": "-",
       "core": "0.0.0-test",
       "studio": "asdf",
     },

--- a/packages/job-worker/src/playout/timeline/generate.ts
+++ b/packages/job-worker/src/playout/timeline/generate.ts
@@ -56,12 +56,12 @@ function isModelForStudio(model: StudioPlayoutModelBase): model is StudioPlayout
 function generateTimelineVersions(
 	studio: ReadonlyDeep<JobStudio>,
 	blueprintId: BlueprintId | undefined,
-	blueprintVersion: string
+	blueprintHash: string
 ): TimelineCompleteGenerationVersions {
 	return {
 		core: getSystemVersion(),
 		blueprintId: blueprintId,
-		blueprintVersion: blueprintVersion,
+		blueprintVersion: blueprintHash,
 		studio: studio._rundownVersionHash,
 	}
 }
@@ -109,7 +109,7 @@ export async function getStudioTimeline(
 	const versions = generateTimelineVersions(
 		studio,
 		studio.blueprintId,
-		studioBlueprint?.blueprint?.blueprintVersion ?? '-'
+		studioBlueprint?.blueprintDoc?.blueprintHash ?? '-'
 	)
 
 	if (studioBaseline) {
@@ -367,11 +367,7 @@ export async function getTimelineRundown(
 			if (regenerateTimelineObj) timelineObjs.push(regenerateTimelineObj.obj)
 
 			const blueprint = await context.getShowStyleBlueprint(showStyle._id)
-			timelineVersions = generateTimelineVersions(
-				context.studio,
-				showStyle.blueprintId,
-				blueprint.blueprint.blueprintVersion
-			)
+			timelineVersions = generateTimelineVersions(context.studio, showStyle.blueprintId, blueprint.blueprintHash)
 
 			if (blueprint.blueprint.onTimelineGenerate || blueprint.blueprint.getAbResolverConfiguration) {
 				const resolvedPieces = getResolvedPiecesForPartInstancesOnTimeline(

--- a/packages/job-worker/src/workers/context/StudioCacheContextImpl.ts
+++ b/packages/job-worker/src/workers/context/StudioCacheContextImpl.ts
@@ -286,8 +286,13 @@ async function loadShowStyleBlueprint(
 		)
 	}
 
+	if (!blueprintDoc?.blueprintHash) {
+		throw new Error(`Blueprint "${showStyleBase.blueprintId}" is missing blueprintHash!`)
+	}
+
 	return Object.freeze({
 		blueprintId: showStyleBase.blueprintId,
 		blueprint: blueprintManifest,
+		blueprintHash: blueprintDoc.blueprintHash,
 	})
 }

--- a/packages/openapi/openapitools.json
+++ b/packages/openapi/openapitools.json
@@ -2,6 +2,9 @@
 	"$schema": "../node_modules/@openapitools/openapi-generator-cli/config.schema.json",
 	"spaces": 2,
 	"generator-cli": {
-		"version": "6.2.0"
+		"version": "6.2.0",
+		"repository": {
+			"downloadUrl": "https://maven-central.storage-download.googleapis.com/maven2/${groupId}/${artifactId}/${versionName}/${artifactId}-${versionName}.jar"
+		}
 	}
 }


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of SuperFly.tv.

## Type of Contribution

This is a feature (or a bug fix depending on your point of view)

## Current Behaviour

When developing blueprints, my changes often don't seem to have applied, even when I have updated the database. I actually need to re-ingest the rundowns every time. When there are several it is sometimes easy to forget some. Sofie already has a mechanism to handle this and put up a "needs resync" option, but it only gets fired if the semver version of the blueprints changes but that almost never happens, especially during development.

Blueprint projects often keep the same package version across many code uploads (especially during development). Uploading new blueprint JS therefore does not change `blueprintVersion`, so Sofie does not warn operators that rundowns (or the studio baseline) were generated against an older blueprint and should be reloaded / regenerated.

`Blueprint.blueprintHash` already exists, but on upload it was assigned a new random id every time (not derived from the uploaded code), and it was not used for importVersions / baseline version checks.

## New Behaviour

- On blueprint upload, `blueprintHash` is set to a content hash of the uploaded code (stable for identical bundles; changes when the JS changes even if semver is unchanged).
- Rundown and bucket `importVersions.blueprint` store that hash (not `blueprintVersion`).
- `rundownPlaylistNeedsResync` compares against `blueprintHash`, so the existing Rundown warning with **Reload {{nrcsName}} Data** appears after a blueprint code deploy.
- Studio timeline `generationVersions.blueprintVersion` likewise stores the hash so “update studio baseline” prompts fire on code-only uploads.

Human-facing / compatibility **`blueprintVersion` (semver) is unchanged** (settings, system status, version checks).

**Migration note:** After upgrading, existing rundowns will show the resync warning once until re-ingested (stored `importVersions.blueprint` was previously a semver string). Re-ingest is intentional and typically cheap.

## Testing

- [x] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

* Blueprint upload (`blueprintHash` generation)
* Rundown importVersions / “Reload NRCS Data” warning after blueprint deploy
* Studio baseline “needs update” check when studio blueprint code changes
* Bucket adlib importVersions

## Time Frame

Not urgent, but useful for blueprint-heavy workflows (e.g. frequent `build:upload`) where semver does not change on every deploy.

## Other information

[CI failed](https://github.com/Sofie-Automation/sofie-core/actions/runs/29992314657/job/89157730444) on this PR because Maven Central blocked the shared GitHub Actions runner IP (403 for excessive/automated consumption). I've switched OpenAPI Generator’s JAR download to Google’s Maven Central mirror, which should avoid that block.

## Status

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
