### PR TITLE
feat(dev): optional per-developer overrides via dev-local.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 **/yarn-error.log
 scratch/
 meteor-settings.json
+dev-local.yaml
 
 # Exclude JetBrains IDE specific files
 .idea

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -70,6 +70,20 @@ The Sofie ui (served by Vite) can be accessed at `http://localhost:3005`. The me
    yarn buildstart
    ```
 
+### Local development overrides (`dev-local.yaml`)
+
+Optional per-developer settings for `yarn dev` / `yarn start` live in a gitignored
+`dev-local.yaml` at the repository root (same idea as `meteor-settings.json`).
+
+```bash
+cp dev-local.example.yaml dev-local.yaml
+```
+
+Edit the copy to set Node heap limits per process (TSC, Meteor, Vite) and/or enable
+Vite `--host` so other devices on the LAN can reach the UI. All keys are optional;
+see `dev-local.example.yaml` for the full schema and comments. When the file is
+present, `yarn dev` logs `Found dev-local.yaml` at startup.
+
 ### Lowering memory, CPU footprint in development
 
 If you find yourself in a situation where running Sofie in development mode is too heavy, but you're not planning on modifying any of the low-level packages in the `packages` directory, you may want to run Sofie in the _UI-only mode_, in which only meteor and the ui will be rebuilt and type-checked on modification:
@@ -77,6 +91,8 @@ If you find yourself in a situation where running Sofie in development mode is t
 ```bash
 yarn dev --ui-only
 ```
+
+You can also cap per-process Node memory via [`dev-local.yaml`](#personal-development-overrides-dev-localyaml) if long sessions grow unboundedly.
 
 ### Dealing with Strange Errors
 

--- a/dev-local.example.yaml
+++ b/dev-local.example.yaml
@@ -1,0 +1,33 @@
+# Personal overrides for `yarn dev` / `yarn start`.
+#
+# Copy this file to `dev-local.yaml` and edit. That file is gitignored.
+#   cp dev-local.example.yaml dev-local.yaml
+#
+# All keys are optional. Omit a section (or the whole file) to keep defaults.
+# Values below are suggested starting points, not built-in defaults.
+
+# TypeScript watch (`packages/` — the TSC process)
+tsc:
+  # Cap the Node heap. Without a limit, tsc can grow unboundedly in long sessions.
+  # Default: no --max-old-space-size — V8 picks a heap limit from system RAM
+  # (often a few GB; machine-dependent). Shell NODE_OPTIONS is inherited if set.
+  nodeOptions: --max-old-space-size=3072
+
+# Meteor app + build tool
+meteor:
+  # Caps Meteor's build-tool Node process
+  # Default: no TOOL_NODE_FLAGS — same V8 heap-from-RAM behaviour as above.
+  # Shell TOOL_NODE_FLAGS is inherited if set.
+  toolNodeFlags: --max-old-space-size=1536
+  # Caps the Meteor app server process
+  # Default: no --max-old-space-size — V8 heap-from-RAM (shell NODE_OPTIONS if set).
+  nodeOptions: --max-old-space-size=1536
+
+# Vite UI (`packages/webui`)
+vite:
+  # Cap Vite's Node process
+  # Default: no --max-old-space-size — V8 heap-from-RAM (shell NODE_OPTIONS if set).
+  nodeOptions: --max-old-space-size=1024
+  # Listen on 0.0.0.0 so other devices on the LAN can reach the UI
+  # Default: false — Vite binds to localhost only (not reachable on the LAN).
+  host: true

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
 		"lint-staged": "^17.0.7",
 		"rimraf": "^6.1.3",
 		"semver": "^7.8.4",
-		"snyk-nodejs-lockfile-parser": "^2.8.1"
+		"snyk-nodejs-lockfile-parser": "^2.8.1",
+		"yaml": "^2.9.0"
 	},
 	"packageManager": "yarn@4.17.0"
 }

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -22,6 +22,10 @@ Options:
                        Run without --db to use the currently active database
   --db-list            List all available database directories and show which is active
 
+Local config:
+  Copy dev-local.example.yaml to dev-local.yaml for personal overrides
+  (Node memory limits, Vite --host, etc.). That file is gitignored.
+
 Examples:
   yarn start                  # Install, build, then run in dev mode
   yarn dev                    # Run in normal dev mode (requires prior build)

--- a/scripts/run.mjs
+++ b/scripts/run.mjs
@@ -2,10 +2,50 @@ import process from "process";
 import fs from "fs";
 import path from "path";
 import concurrently from "concurrently";
+import { parse as parseYaml } from "yaml";
 import { config } from "./lib.js";
+
+const DEV_LOCAL_PATH = path.join(process.cwd(), "dev-local.yaml");
+
+/**
+ * Optional personal overrides from repo-root `dev-local.yaml`
+ * (see `dev-local.example.yaml`).
+ *
+ * @returns {{
+ *   tsc?: { nodeOptions?: string },
+ *   meteor?: { toolNodeFlags?: string, nodeOptions?: string },
+ *   vite?: { nodeOptions?: string, host?: boolean },
+ * }}
+ */
+function loadDevLocalConfig() {
+	if (!fs.existsSync(DEV_LOCAL_PATH)) {
+		return {};
+	}
+
+	try {
+		const parsed = parseYaml(fs.readFileSync(DEV_LOCAL_PATH, "utf8"));
+		if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+			console.warn("dev-local.yaml: expected a mapping at the top level, ignoring");
+			return {};
+		}
+		console.log("Found dev-local.yaml");
+		return parsed;
+	} catch (e) {
+		console.error(`Failed to parse dev-local.yaml: ${e.message}`);
+		process.exit(1);
+	}
+}
+
+const localConfig = loadDevLocalConfig();
 
 function joinCommand(...parts) {
 	return parts.filter((part) => !!part).join(" ");
+}
+
+/** @param {Record<string, string | undefined>} env */
+function envOrUndefined(env) {
+	const cleaned = Object.fromEntries(Object.entries(env).filter(([, value]) => value != null));
+	return Object.keys(cleaned).length > 0 ? cleaned : undefined;
 }
 
 function watchPackages() {
@@ -15,6 +55,10 @@ function watchPackages() {
 			cwd: "packages",
 			name: "TSC",
 			prefixColor: "red",
+			env: envOrUndefined({
+				// Cap TypeScript compiler memory when configured in dev-local.yaml.
+				NODE_OPTIONS: localConfig.tsc?.nodeOptions,
+			}),
 		},
 	];
 }
@@ -52,15 +96,26 @@ function watchMeteor() {
 			cwd: "meteor",
 			name: "METEOR",
 			prefixColor: "cyan",
+			env: envOrUndefined({
+				// TOOL_NODE_FLAGS caps the Meteor build tool's own Node process.
+				// NODE_OPTIONS caps the Meteor app server process.
+				TOOL_NODE_FLAGS: localConfig.meteor?.toolNodeFlags,
+				NODE_OPTIONS: localConfig.meteor?.nodeOptions,
+			}),
 		},
 		{
-			command: `yarn dev`,
+			command: joinCommand(
+				"yarn dev",
+				localConfig.vite?.host ? "-- --host" : ""
+			),
 			cwd: "packages/webui",
 			name: "VITE",
 			prefixColor: "yellow",
-			env: {
+			env: envOrUndefined({
 				SOFIE_BASE_PATH: rootUrl && rootUrl.pathname.length > 1 ? rootUrl.pathname : '',
-			},
+				// Cap Vite's Node process when configured in dev-local.yaml.
+				NODE_OPTIONS: localConfig.vite?.nodeOptions,
+			}),
 		},
 	];
 }

--- a/scripts/run.mjs
+++ b/scripts/run.mjs
@@ -104,10 +104,9 @@ function watchMeteor() {
 			}),
 		},
 		{
-			command: joinCommand(
-				"yarn dev",
-				localConfig.vite?.host ? "-- --host" : ""
-			),
+			// Yarn forwards args after the script name to vite. Do not insert an extra
+			// `--` here — that ends up as `vite ... -- --host`, and Vite ignores `--host`.
+			command: joinCommand("yarn dev", localConfig.vite?.host ? "--host" : ""),
 			cwd: "packages/webui",
 			name: "VITE",
 			prefixColor: "yellow",

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,6 +382,7 @@ __metadata:
     rimraf: "npm:^6.1.3"
     semver: "npm:^7.8.4"
     snyk-nodejs-lockfile-parser: "npm:^2.8.1"
+    yaml: "npm:^2.9.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of SuperFly.tv.

## Type of Contribution

This is a:

Feature / Documentation improvement

## Current Behavior

Long `yarn dev` sessions can grow Node heaps unboundedly (especially TSC and Vite).
Developers who want LAN access to the Vite UI also have to patch tracked config or run
Vite by hand. Personal tweaks were often kept in stashes or one-off `package.json`
edits that are easy to commit by mistake.

A uniform `NODE_OPTIONS` / `TOOL_NODE_FLAGS` in the shell already works for a single
shared heap limit, but not for different per-process limits or Vite `--host`.

## New Behavior

Optional gitignored `dev-local.yaml` (same idea as `meteor-settings.json`) is loaded by
`scripts/run.mjs` when present:

- Per-process Node memory caps for TSC, Meteor (tool + app), and Vite
- Optional Vite `--host` for LAN access

Copy `dev-local.example.yaml` → `dev-local.yaml` and edit. Documented in `DEVELOPER.md`
and `yarn dev --help`.

`yaml` is declared as a root `devDependency` so we do not rely on transitive hoisting.
It was **already** present in the tree via `lint-staged` — the `yarn.lock` delta is a
single line adding it to the workspace dependency list (no new package resolution).

## Testing

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

- Local development only (`yarn dev` / `yarn start` orchestration)
- No runtime / production behaviour change when `dev-local.yaml` is absent

## Time Frame

Not urgent — quality-of-life for local development; fine for the in-development release.

## Other Information

Example:

```bash
cp dev-local.example.yaml dev-local.yaml
# edit memory limits / vite.host as needed
yarn dev
# logs: Found dev-local.yaml
```

## Status

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
