### PR TITLE
feat: insert partinstance anywhere

### DIFF
--- a/packages/blueprints-integration/src/context/onTakeContext.ts
+++ b/packages/blueprints-integration/src/context/onTakeContext.ts
@@ -24,10 +24,16 @@ export interface IOnTakeContext
 	abortTake(): void
 	/**
 	 * Insert an adlibbed part into the rundown after the take completes and set it as next.
-	 * @param insertBeforePartOrInstanceId When omitted, inserts immediately after the taken part.
-	 * When provided, inserts before the given PartId or PartInstanceId (PartInstanceId is checked first).
+	 * @param targetPartOrInstanceId When omitted, inserts immediately after the taken part.
+	 * When provided, inserts relative to the given PartId or PartInstanceId (PartInstanceId is checked first).
+	 * @param insertBefore When targetPartOrInstanceId is set, true (default) inserts before the target, false inserts after it.
 	 * The target must exist and must not be in an orphaned segment.
 	 * The inserted part always becomes next via setNextPart, even when the target is far ahead — intervening scripted parts are skipped.
 	 */
-	queuePartAfterTake(part: IBlueprintPart, pieces: IBlueprintPiece[], insertBeforePartOrInstanceId?: string): void
+	queuePartAfterTake(
+		part: IBlueprintPart,
+		pieces: IBlueprintPiece[],
+		targetPartOrInstanceId?: string,
+		insertBefore?: boolean
+	): void
 }

--- a/packages/blueprints-integration/src/context/onTakeContext.ts
+++ b/packages/blueprints-integration/src/context/onTakeContext.ts
@@ -22,6 +22,12 @@ export interface IOnTakeContext
 	 * but the next part will not be taken.
 	 */
 	abortTake(): void
-	/** Insert a queued part to follow the taken part */
-	queuePartAfterTake(part: IBlueprintPart, pieces: IBlueprintPiece[]): void
+	/**
+	 * Insert an adlibbed part into the rundown after the take completes and set it as next.
+	 * @param insertBeforePartOrInstanceId When omitted, inserts immediately after the taken part.
+	 * When provided, inserts before the given PartId or PartInstanceId (PartInstanceId is checked first).
+	 * The target must exist and must not be in an orphaned segment.
+	 * The inserted part always becomes next via setNextPart, even when the target is far ahead — intervening scripted parts are skipped.
+	 */
+	queuePartAfterTake(part: IBlueprintPart, pieces: IBlueprintPiece[], insertBeforePartOrInstanceId?: string): void
 }

--- a/packages/blueprints-integration/src/context/onTakeContext.ts
+++ b/packages/blueprints-integration/src/context/onTakeContext.ts
@@ -29,6 +29,8 @@ export interface IOnTakeContext
 	 * @param insertBefore When targetPartOrInstanceId is set, true (default) inserts before the target, false inserts after it.
 	 * The target must exist and must not be in an orphaned segment.
 	 * The inserted part always becomes next via setNextPart, even when the target is far ahead — intervening scripted parts are skipped.
+	 * If the target is invalid, prepareQueueablePartAndPieces throws synchronously; executeOnTakeCallback catches and logs the error,
+	 * sets an onTake notification, and continues the take without queuing the part.
 	 */
 	queuePartAfterTake(
 		part: IBlueprintPart,

--- a/packages/blueprints-integration/src/context/playoutActionContext.ts
+++ b/packages/blueprints-integration/src/context/playoutActionContext.ts
@@ -11,8 +11,24 @@ export interface IPlayoutActionContext {
 	moveNextPart(partDelta: number, segmentDelta: number, ignoreQuickloop?: boolean): Promise<boolean>
 	/** Set flag to perform a take after the current handler completes. Returns state of the flag after each call. */
 	takeAfterExecuteAction(take: boolean): Promise<boolean>
-	/** Insert a queued part to follow the current part */
-	queuePart(part: IBlueprintPart, pieces: IBlueprintPiece[]): Promise<IBlueprintPartInstance>
-	/** Insert a queued part to follow the taken part */
-	queuePartAfterTake(part: IBlueprintPart, pieces: IBlueprintPiece[]): void
+	/**
+	 * Insert an adlibbed part into the rundown and set it as next.
+	 * @param insertBeforePartOrInstanceId When omitted, inserts immediately after the current part.
+	 * When provided, inserts before the given PartId or PartInstanceId (PartInstanceId is checked first).
+	 * The target must exist and must not be in an orphaned segment.
+	 * The inserted part always becomes next via setNextPart, even when the target is far ahead — intervening scripted parts are skipped.
+	 */
+	queuePart(
+		part: IBlueprintPart,
+		pieces: IBlueprintPiece[],
+		insertBeforePartOrInstanceId?: string
+	): Promise<IBlueprintPartInstance>
+	/**
+	 * Insert an adlibbed part into the rundown after the take completes and set it as next.
+	 * @param insertBeforePartOrInstanceId When omitted, inserts immediately after the taken part.
+	 * When provided, inserts before the given PartId or PartInstanceId (PartInstanceId is checked first).
+	 * The target must exist and must not be in an orphaned segment.
+	 * The inserted part always becomes next via setNextPart, even when the target is far ahead — intervening scripted parts are skipped.
+	 */
+	queuePartAfterTake(part: IBlueprintPart, pieces: IBlueprintPiece[], insertBeforePartOrInstanceId?: string): void
 }

--- a/packages/blueprints-integration/src/context/playoutActionContext.ts
+++ b/packages/blueprints-integration/src/context/playoutActionContext.ts
@@ -13,22 +13,30 @@ export interface IPlayoutActionContext {
 	takeAfterExecuteAction(take: boolean): Promise<boolean>
 	/**
 	 * Insert an adlibbed part into the rundown and set it as next.
-	 * @param insertBeforePartOrInstanceId When omitted, inserts immediately after the current part.
-	 * When provided, inserts before the given PartId or PartInstanceId (PartInstanceId is checked first).
+	 * @param targetPartOrInstanceId When omitted, inserts immediately after the current part.
+	 * When provided, inserts relative to the given PartId or PartInstanceId (PartInstanceId is checked first).
+	 * @param insertBefore When targetPartOrInstanceId is set, true (default) inserts before the target, false inserts after it.
 	 * The target must exist and must not be in an orphaned segment.
 	 * The inserted part always becomes next via setNextPart, even when the target is far ahead — intervening scripted parts are skipped.
 	 */
 	queuePart(
 		part: IBlueprintPart,
 		pieces: IBlueprintPiece[],
-		insertBeforePartOrInstanceId?: string
+		targetPartOrInstanceId?: string,
+		insertBefore?: boolean
 	): Promise<IBlueprintPartInstance>
 	/**
 	 * Insert an adlibbed part into the rundown after the take completes and set it as next.
-	 * @param insertBeforePartOrInstanceId When omitted, inserts immediately after the taken part.
-	 * When provided, inserts before the given PartId or PartInstanceId (PartInstanceId is checked first).
+	 * @param targetPartOrInstanceId When omitted, inserts immediately after the taken part.
+	 * When provided, inserts relative to the given PartId or PartInstanceId (PartInstanceId is checked first).
+	 * @param insertBefore When targetPartOrInstanceId is set, true (default) inserts before the target, false inserts after it.
 	 * The target must exist and must not be in an orphaned segment.
 	 * The inserted part always becomes next via setNextPart, even when the target is far ahead — intervening scripted parts are skipped.
 	 */
-	queuePartAfterTake(part: IBlueprintPart, pieces: IBlueprintPiece[], insertBeforePartOrInstanceId?: string): void
+	queuePartAfterTake(
+		part: IBlueprintPart,
+		pieces: IBlueprintPiece[],
+		targetPartOrInstanceId?: string,
+		insertBefore?: boolean
+	): void
 }

--- a/packages/job-worker/src/blueprints/__tests__/context-adlibActions.test.ts
+++ b/packages/job-worker/src/blueprints/__tests__/context-adlibActions.test.ts
@@ -136,7 +136,7 @@ describe('Test blueprint api context', () => {
 
 			await context.queuePart({ title: 'My Piece' } as IBlueprintPart<unknown>, [])
 			expect(mockActionService.queuePart).toHaveBeenCalledTimes(1)
-			expect(mockActionService.queuePart).toHaveBeenCalledWith({ title: 'My Piece' }, [], undefined)
+			expect(mockActionService.queuePart).toHaveBeenCalledWith({ title: 'My Piece' }, [], undefined, undefined)
 		})
 
 		test('stopPiecesOnLayers', async () => {

--- a/packages/job-worker/src/blueprints/__tests__/context-adlibActions.test.ts
+++ b/packages/job-worker/src/blueprints/__tests__/context-adlibActions.test.ts
@@ -136,7 +136,7 @@ describe('Test blueprint api context', () => {
 
 			await context.queuePart({ title: 'My Piece' } as IBlueprintPart<unknown>, [])
 			expect(mockActionService.queuePart).toHaveBeenCalledTimes(1)
-			expect(mockActionService.queuePart).toHaveBeenCalledWith({ title: 'My Piece' }, [])
+			expect(mockActionService.queuePart).toHaveBeenCalledWith({ title: 'My Piece' }, [], undefined)
 		})
 
 		test('stopPiecesOnLayers', async () => {

--- a/packages/job-worker/src/blueprints/context/OnTakeContext.ts
+++ b/packages/job-worker/src/blueprints/context/OnTakeContext.ts
@@ -177,16 +177,20 @@ export class OnTakeContext extends ShowStyleUserContext implements IOnTakeContex
 		return executePeripheralDeviceAction(this._context, deviceId, timeoutMs ?? null, actionId, payload)
 	}
 
-	queuePartAfterTake(rawPart: IBlueprintPart, rawPieces: IBlueprintPiece[]): void {
+	queuePartAfterTake(
+		rawPart: IBlueprintPart,
+		rawPieces: IBlueprintPiece[],
+		insertBeforePartOrInstanceId?: string
+	): void {
 		const currentPartInstance = this._playoutModel.currentPartInstance
 		if (!currentPartInstance) {
 			throw new Error('Cannot queue part when no current partInstance')
 		}
-		this.partToQueueAfterTake = this.partAndPieceInstanceService.processPartAndPiecesToQueueOrFail(
+		this.partToQueueAfterTake = this.partAndPieceInstanceService.prepareQueueablePartAndPieces(
 			rawPart,
 			rawPieces,
-			this._playoutModel.currentPartInstance.partInstance.rundownId,
-			this._playoutModel.currentPartInstance.partInstance.segmentId
+			currentPartInstance,
+			insertBeforePartOrInstanceId
 		)
 	}
 

--- a/packages/job-worker/src/blueprints/context/OnTakeContext.ts
+++ b/packages/job-worker/src/blueprints/context/OnTakeContext.ts
@@ -180,7 +180,8 @@ export class OnTakeContext extends ShowStyleUserContext implements IOnTakeContex
 	queuePartAfterTake(
 		rawPart: IBlueprintPart,
 		rawPieces: IBlueprintPiece[],
-		insertBeforePartOrInstanceId?: string
+		targetPartOrInstanceId?: string,
+		insertBefore?: boolean
 	): void {
 		const currentPartInstance = this._playoutModel.currentPartInstance
 		if (!currentPartInstance) {
@@ -190,7 +191,8 @@ export class OnTakeContext extends ShowStyleUserContext implements IOnTakeContex
 			rawPart,
 			rawPieces,
 			currentPartInstance,
-			insertBeforePartOrInstanceId
+			targetPartOrInstanceId,
+			insertBefore
 		)
 	}
 

--- a/packages/job-worker/src/blueprints/context/OnTakeContext.ts
+++ b/packages/job-worker/src/blueprints/context/OnTakeContext.ts
@@ -177,6 +177,10 @@ export class OnTakeContext extends ShowStyleUserContext implements IOnTakeContex
 		return executePeripheralDeviceAction(this._context, deviceId, timeoutMs ?? null, actionId, payload)
 	}
 
+	/**
+	 * If the target is invalid, prepareQueueablePartAndPieces throws synchronously; executeOnTakeCallback catches and logs the error,
+	 * sets an onTake notification, and continues the take without queuing the part.
+	 */
 	queuePartAfterTake(
 		rawPart: IBlueprintPart,
 		rawPieces: IBlueprintPiece[],

--- a/packages/job-worker/src/blueprints/context/adlibActions.ts
+++ b/packages/job-worker/src/blueprints/context/adlibActions.ts
@@ -190,6 +190,10 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 		return this.partAndPieceInstanceService.queuePart(rawPart, rawPieces, targetPartOrInstanceId, insertBefore)
 	}
 
+	/**
+	 * If the target is invalid, prepareQueueablePartAndPieces throws synchronously.
+	 * When called during executeAction, the error fails the action before any take occurs.
+	 */
 	queuePartAfterTake(
 		rawPart: IBlueprintPart,
 		rawPieces: IBlueprintPiece[],

--- a/packages/job-worker/src/blueprints/context/adlibActions.ts
+++ b/packages/job-worker/src/blueprints/context/adlibActions.ts
@@ -184,15 +184,17 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 	async queuePart(
 		rawPart: IBlueprintPart,
 		rawPieces: IBlueprintPiece[],
-		insertBeforePartOrInstanceId?: string
+		targetPartOrInstanceId?: string,
+		insertBefore?: boolean
 	): Promise<IBlueprintPartInstance> {
-		return this.partAndPieceInstanceService.queuePart(rawPart, rawPieces, insertBeforePartOrInstanceId)
+		return this.partAndPieceInstanceService.queuePart(rawPart, rawPieces, targetPartOrInstanceId, insertBefore)
 	}
 
 	queuePartAfterTake(
 		rawPart: IBlueprintPart,
 		rawPieces: IBlueprintPiece[],
-		insertBeforePartOrInstanceId?: string
+		targetPartOrInstanceId?: string,
+		insertBefore?: boolean
 	): void {
 		const currentPartInstance = this._playoutModel.currentPartInstance
 		if (!currentPartInstance) {
@@ -202,7 +204,8 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 			rawPart,
 			rawPieces,
 			currentPartInstance,
-			insertBeforePartOrInstanceId
+			targetPartOrInstanceId,
+			insertBefore
 		)
 	}
 

--- a/packages/job-worker/src/blueprints/context/adlibActions.ts
+++ b/packages/job-worker/src/blueprints/context/adlibActions.ts
@@ -181,20 +181,28 @@ export class ActionExecutionContext extends ShowStyleUserContext implements IAct
 		return this.partAndPieceInstanceService.updatePieceInstance(pieceInstanceId, piece)
 	}
 
-	async queuePart(rawPart: IBlueprintPart, rawPieces: IBlueprintPiece[]): Promise<IBlueprintPartInstance> {
-		return this.partAndPieceInstanceService.queuePart(rawPart, rawPieces)
+	async queuePart(
+		rawPart: IBlueprintPart,
+		rawPieces: IBlueprintPiece[],
+		insertBeforePartOrInstanceId?: string
+	): Promise<IBlueprintPartInstance> {
+		return this.partAndPieceInstanceService.queuePart(rawPart, rawPieces, insertBeforePartOrInstanceId)
 	}
 
-	queuePartAfterTake(rawPart: IBlueprintPart, rawPieces: IBlueprintPiece[]): void {
+	queuePartAfterTake(
+		rawPart: IBlueprintPart,
+		rawPieces: IBlueprintPiece[],
+		insertBeforePartOrInstanceId?: string
+	): void {
 		const currentPartInstance = this._playoutModel.currentPartInstance
 		if (!currentPartInstance) {
 			throw new Error('Cannot queue part when no current partInstance')
 		}
-		this.partToQueueAfterTake = this.partAndPieceInstanceService.processPartAndPiecesToQueueOrFail(
+		this.partToQueueAfterTake = this.partAndPieceInstanceService.prepareQueueablePartAndPieces(
 			rawPart,
 			rawPieces,
-			this._playoutModel.currentPartInstance.partInstance.rundownId,
-			this._playoutModel.currentPartInstance.partInstance.segmentId
+			currentPartInstance,
+			insertBeforePartOrInstanceId
 		)
 	}
 

--- a/packages/job-worker/src/blueprints/context/services/PartAndPieceInstanceActionService.ts
+++ b/packages/job-worker/src/blueprints/context/services/PartAndPieceInstanceActionService.ts
@@ -38,7 +38,7 @@ import {
 	innerFindLastScriptedPieceOnLayer,
 	innerStopPieces,
 	insertQueuedPartWithPieces,
-	QueuedAdlibInsertBeforeId,
+	QueuedAdlibInsertRelativeId,
 	resolveQueuedAdlibInsertTarget,
 } from '../../../playout/adlibUtils.js'
 import { assertNever, getRandomId, omit } from '@sofie-automation/corelib/dist/lib'
@@ -76,7 +76,8 @@ export interface IPartAndPieceInstanceActionContext {
 export interface QueueablePartAndPieces {
 	part: Omit<DBPart, 'segmentId' | 'rundownId' | '_rank'>
 	pieces: Piece[]
-	insertBeforeId?: QueuedAdlibInsertBeforeId
+	targetPartOrInstanceId?: QueuedAdlibInsertRelativeId
+	insertBefore?: boolean
 }
 
 export class PartAndPieceInstanceActionService {
@@ -399,7 +400,8 @@ export class PartAndPieceInstanceActionService {
 	async queuePart(
 		rawPart: IBlueprintPart,
 		rawPieces: IBlueprintPiece[],
-		insertBeforePartOrInstanceId?: string
+		targetPartOrInstanceId?: string,
+		insertBefore = true
 	): Promise<IBlueprintPartInstance> {
 		const currentPartInstance = this._playoutModel.currentPartInstance
 		if (!currentPartInstance) {
@@ -417,11 +419,16 @@ export class PartAndPieceInstanceActionService {
 			throw new Error('Too close to an autonext to queue a part')
 		}
 
-		const insertBeforeId = insertBeforePartOrInstanceId
-			? protectString<QueuedAdlibInsertBeforeId>(insertBeforePartOrInstanceId)
+		const targetId = targetPartOrInstanceId
+			? protectString<QueuedAdlibInsertRelativeId>(targetPartOrInstanceId)
 			: undefined
 
-		const insertTarget = resolveQueuedAdlibInsertTarget(this._playoutModel, currentPartInstance, insertBeforeId)
+		const insertTarget = resolveQueuedAdlibInsertTarget(
+			this._playoutModel,
+			currentPartInstance,
+			targetId,
+			insertBefore
+		)
 
 		const { part, pieces } = this.processPartAndPiecesToQueueOrFail(
 			rawPart,
@@ -438,7 +445,8 @@ export class PartAndPieceInstanceActionService {
 			part,
 			pieces,
 			undefined,
-			insertBeforeId,
+			targetId,
+			insertBefore,
 			insertTarget
 		)
 
@@ -452,13 +460,19 @@ export class PartAndPieceInstanceActionService {
 		rawPart: IBlueprintPart,
 		rawPieces: IBlueprintPiece[],
 		currentPartInstance: PlayoutPartInstanceModel,
-		insertBeforePartOrInstanceId?: string
+		targetPartOrInstanceId?: string,
+		insertBefore = true
 	): QueueablePartAndPieces {
-		const insertBeforeId = insertBeforePartOrInstanceId
-			? protectString<QueuedAdlibInsertBeforeId>(insertBeforePartOrInstanceId)
+		const targetId = targetPartOrInstanceId
+			? protectString<QueuedAdlibInsertRelativeId>(targetPartOrInstanceId)
 			: undefined
 
-		const insertTarget = resolveQueuedAdlibInsertTarget(this._playoutModel, currentPartInstance, insertBeforeId)
+		const insertTarget = resolveQueuedAdlibInsertTarget(
+			this._playoutModel,
+			currentPartInstance,
+			targetId,
+			insertBefore
+		)
 
 		const { part, pieces } = this.processPartAndPiecesToQueueOrFail(
 			rawPart,
@@ -467,7 +481,7 @@ export class PartAndPieceInstanceActionService {
 			insertTarget.targetSegment.segment._id
 		)
 
-		return { part, pieces, insertBeforeId }
+		return { part, pieces, targetPartOrInstanceId: targetId, insertBefore: targetId ? insertBefore : undefined }
 	}
 
 	public processPartAndPiecesToQueueOrFail(

--- a/packages/job-worker/src/blueprints/context/services/PartAndPieceInstanceActionService.ts
+++ b/packages/job-worker/src/blueprints/context/services/PartAndPieceInstanceActionService.ts
@@ -38,6 +38,8 @@ import {
 	innerFindLastScriptedPieceOnLayer,
 	innerStopPieces,
 	insertQueuedPartWithPieces,
+	QueuedAdlibInsertBeforeId,
+	resolveQueuedAdlibInsertTarget,
 } from '../../../playout/adlibUtils.js'
 import { assertNever, getRandomId, omit } from '@sofie-automation/corelib/dist/lib'
 import { logger } from '../../../logging.js'
@@ -59,7 +61,6 @@ import _ from 'underscore'
 import { syncPlayheadInfinitesForNextPartInstance } from '../../../playout/infinites.js'
 import { validateAdlibTestingPartInstanceProperties } from '../../../playout/adlibTesting.js'
 import { DBPart, isPartPlayable } from '@sofie-automation/corelib/dist/dataModel/Part'
-import { PlayoutRundownModel } from '../../../playout/model/PlayoutRundownModel.js'
 import { BlueprintQuickLookInfo } from '@sofie-automation/blueprints-integration/dist/context/quickLoopInfo'
 
 export enum ActionPartChange {
@@ -75,6 +76,7 @@ export interface IPartAndPieceInstanceActionContext {
 export interface QueueablePartAndPieces {
 	part: Omit<DBPart, 'segmentId' | 'rundownId' | '_rank'>
 	pieces: Piece[]
+	insertBeforeId?: QueuedAdlibInsertBeforeId
 }
 
 export class PartAndPieceInstanceActionService {
@@ -93,12 +95,7 @@ export class PartAndPieceInstanceActionService {
 
 	public queuedPartInstanceId: PartInstanceId | undefined = undefined
 
-	constructor(
-		context: JobContext,
-		playoutModel: PlayoutModel,
-		showStyle: ReadonlyDeep<ProcessedShowStyleCompound>,
-		private readonly _rundown: PlayoutRundownModel
-	) {
+	constructor(context: JobContext, playoutModel: PlayoutModel, showStyle: ReadonlyDeep<ProcessedShowStyleCompound>) {
 		this._context = context
 		this._playoutModel = playoutModel
 		this.showStyleCompound = showStyle
@@ -399,7 +396,11 @@ export class PartAndPieceInstanceActionService {
 		return convertPartInstanceToBlueprints(partInstance.partInstance)
 	}
 
-	async queuePart(rawPart: IBlueprintPart, rawPieces: IBlueprintPiece[]): Promise<IBlueprintPartInstance> {
+	async queuePart(
+		rawPart: IBlueprintPart,
+		rawPieces: IBlueprintPiece[],
+		insertBeforePartOrInstanceId?: string
+	): Promise<IBlueprintPartInstance> {
 		const currentPartInstance = this._playoutModel.currentPartInstance
 		if (!currentPartInstance) {
 			throw new Error('Cannot queue part when no current partInstance')
@@ -416,28 +417,57 @@ export class PartAndPieceInstanceActionService {
 			throw new Error('Too close to an autonext to queue a part')
 		}
 
+		const insertBeforeId = insertBeforePartOrInstanceId
+			? protectString<QueuedAdlibInsertBeforeId>(insertBeforePartOrInstanceId)
+			: undefined
+
+		const insertTarget = resolveQueuedAdlibInsertTarget(this._playoutModel, currentPartInstance, insertBeforeId)
+
 		const { part, pieces } = this.processPartAndPiecesToQueueOrFail(
 			rawPart,
 			rawPieces,
-			currentPartInstance.partInstance.rundownId,
-			currentPartInstance.partInstance.segmentId
+			insertTarget.targetRundown.rundown._id,
+			insertTarget.targetSegment.segment._id
 		)
 
 		// Do the work
 		const newPartInstance = await insertQueuedPartWithPieces(
 			this._context,
 			this._playoutModel,
-			this._rundown,
 			currentPartInstance,
 			part,
 			pieces,
-			undefined
+			undefined,
+			insertBeforeId,
+			insertTarget
 		)
 
 		this.nextPartState = ActionPartChange.SAFE_CHANGE
 		this.queuedPartInstanceId = newPartInstance.partInstance._id
 
 		return convertPartInstanceToBlueprints(newPartInstance.partInstance)
+	}
+
+	prepareQueueablePartAndPieces(
+		rawPart: IBlueprintPart,
+		rawPieces: IBlueprintPiece[],
+		currentPartInstance: PlayoutPartInstanceModel,
+		insertBeforePartOrInstanceId?: string
+	): QueueablePartAndPieces {
+		const insertBeforeId = insertBeforePartOrInstanceId
+			? protectString<QueuedAdlibInsertBeforeId>(insertBeforePartOrInstanceId)
+			: undefined
+
+		const insertTarget = resolveQueuedAdlibInsertTarget(this._playoutModel, currentPartInstance, insertBeforeId)
+
+		const { part, pieces } = this.processPartAndPiecesToQueueOrFail(
+			rawPart,
+			rawPieces,
+			insertTarget.targetRundown.rundown._id,
+			insertTarget.targetSegment.segment._id
+		)
+
+		return { part, pieces, insertBeforeId }
 	}
 
 	public processPartAndPiecesToQueueOrFail(

--- a/packages/job-worker/src/blueprints/context/services/__tests__/PartAndPieceInstanceActionService.test.ts
+++ b/packages/job-worker/src/blueprints/context/services/__tests__/PartAndPieceInstanceActionService.test.ts
@@ -1289,7 +1289,7 @@ describe('Test blueprint api context', () => {
 							],
 							'unknown_part_id'
 						)
-					).rejects.toThrow('Cannot queue part: insert before target "unknown_part_id" not found')
+					).rejects.toThrow('Cannot queue part: target "unknown_part_id" not found')
 				})
 			})
 
@@ -1400,7 +1400,7 @@ describe('Test blueprint api context', () => {
 				})
 			})
 
-			test('prepareQueueablePartAndPieces stores insertBeforeId', async () => {
+			test('prepareQueueablePartAndPieces stores targetPartOrInstanceId and insertBefore', async () => {
 				const { jobContext, playlistId, rundownId } = await setupMyDefaultRundown()
 
 				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
@@ -1445,9 +1445,163 @@ describe('Test blueprint api context', () => {
 						unprotectString(targetPart!._id)
 					)
 
-					expect(queueable.insertBeforeId).toEqual(targetPart!._id)
+					expect(queueable.targetPartOrInstanceId).toEqual(targetPart!._id)
+					expect(queueable.insertBefore).toEqual(true)
 					expect(queueable.part.title).toEqual('something')
 					expect(queueable.pieces).toHaveLength(1)
+				})
+			})
+
+			test('good with explicit insert after part id', async () => {
+				const { jobContext, playlistId, rundownId } = await setupMyDefaultRundown()
+
+				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
+					rundownId,
+					'part.externalId': 'MOCK_PART_0_0',
+				})) as DBPartInstance
+				expect(partInstance).toBeTruthy()
+				await setPartInstances(jobContext, playlistId, partInstance, undefined)
+
+				const targetPart = await jobContext.mockCollections.Parts.findOne({
+					externalId: 'MOCK_PART_1_0',
+					rundownId,
+				})
+				expect(targetPart).toBeTruthy()
+
+				const partAfterTarget = await jobContext.mockCollections.Parts.findOne({
+					externalId: 'MOCK_PART_1_1',
+					rundownId,
+				})
+				expect(partAfterTarget).toBeTruthy()
+
+				await wrapWithPlayoutModel(jobContext, playlistId, async (playoutModel) => {
+					const { service } = await getTestee(jobContext, playoutModel)
+
+					const newPiece: IBlueprintPiece = {
+						name: 'test piece',
+						sourceLayerId: 'sl1',
+						outputLayerId: 'o1',
+						externalId: '-',
+						enable: { start: 0 },
+						lifespan: PieceLifespan.OutOnRundownEnd,
+						content: {
+							timelineObjects: [],
+						},
+					}
+					const newPart: IBlueprintPart = {
+						externalId: 'nope',
+						title: 'something',
+					}
+
+					postProcessPiecesMock.mockImplementationOnce(postProcessPiecesOrig)
+					insertQueuedPartWithPiecesMock.mockImplementationOnce(insertQueuedPartWithPiecesOrig)
+					await service.queuePart(newPart, [newPiece], unprotectString(targetPart!._id), false)
+
+					const newPartInstance = playoutModel.getPartInstance(
+						playoutModel.playlist.nextPartInfo!.partInstanceId
+					)!
+					expect(newPartInstance.partInstance.part._rank).toBeGreaterThan(targetPart!._rank)
+					expect(newPartInstance.partInstance.part._rank).toBeLessThan(partAfterTarget!._rank)
+				})
+			})
+
+			test('prepareQueueablePartAndPieces stores insertBefore false', async () => {
+				const { jobContext, playlistId, rundownId } = await setupMyDefaultRundown()
+
+				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
+					rundownId,
+					'part.externalId': 'MOCK_PART_0_0',
+				})) as DBPartInstance
+				expect(partInstance).toBeTruthy()
+				await setPartInstances(jobContext, playlistId, partInstance, undefined)
+
+				const targetPart = await jobContext.mockCollections.Parts.findOne({
+					externalId: 'MOCK_PART_1_0',
+					rundownId,
+				})
+				expect(targetPart).toBeTruthy()
+
+				await wrapWithPlayoutModel(jobContext, playlistId, async (playoutModel) => {
+					const { service } = await getTestee(jobContext, playoutModel)
+
+					const currentPartInstance = playoutModel.currentPartInstance!
+					postProcessPiecesMock.mockImplementationOnce(postProcessPiecesOrig)
+
+					const queueable = service.prepareQueueablePartAndPieces(
+						{ externalId: 'nope', title: 'something' },
+						[
+							{
+								name: 'test piece',
+								sourceLayerId: 'sl1',
+								outputLayerId: 'o1',
+								externalId: '-',
+								enable: { start: 0 },
+								lifespan: PieceLifespan.OutOnRundownEnd,
+								content: {
+									timelineObjects: [],
+								},
+							},
+						],
+						currentPartInstance,
+						unprotectString(targetPart!._id),
+						false
+					)
+
+					expect(queueable.targetPartOrInstanceId).toEqual(targetPart!._id)
+					expect(queueable.insertBefore).toEqual(false)
+				})
+			})
+
+			test('good with cross-segment insert after part id', async () => {
+				const { jobContext, playlistId, rundownId } = await setupMyDefaultRundown()
+
+				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
+					rundownId,
+					'part.externalId': 'MOCK_PART_0_0',
+				})) as DBPartInstance
+				expect(partInstance).toBeTruthy()
+				await setPartInstances(jobContext, playlistId, partInstance, undefined)
+
+				const targetPart = await jobContext.mockCollections.Parts.findOne({
+					externalId: 'MOCK_PART_1_0',
+					rundownId,
+				})
+				expect(targetPart).toBeTruthy()
+
+				await wrapWithPlayoutModel(jobContext, playlistId, async (playoutModel) => {
+					const { service } = await getTestee(jobContext, playoutModel)
+
+					const currentPartInstance = playoutModel.currentPartInstance!
+					expect(currentPartInstance.partInstance.segmentId).not.toEqual(targetPart!.segmentId)
+
+					postProcessPiecesMock.mockImplementationOnce(postProcessPiecesOrig)
+					insertQueuedPartWithPiecesMock.mockImplementationOnce(insertQueuedPartWithPiecesOrig)
+					await service.queuePart(
+						{ externalId: 'nope', title: 'something' },
+						[
+							{
+								name: 'test piece',
+								sourceLayerId: 'sl1',
+								outputLayerId: 'o1',
+								externalId: '-',
+								enable: { start: 0 },
+								lifespan: PieceLifespan.OutOnRundownEnd,
+								content: {
+									timelineObjects: [],
+								},
+							},
+						],
+						unprotectString(targetPart!._id),
+						false
+					)
+
+					const newPartInstance = playoutModel.getPartInstance(
+						playoutModel.playlist.nextPartInfo!.partInstanceId
+					)!
+					expect(newPartInstance.partInstance.segmentId).toEqual(targetPart!.segmentId)
+					expect(newPartInstance.partInstance.segmentPlayoutId).not.toEqual(
+						currentPartInstance.partInstance.segmentPlayoutId
+					)
 				})
 			})
 

--- a/packages/job-worker/src/blueprints/context/services/__tests__/PartAndPieceInstanceActionService.test.ts
+++ b/packages/job-worker/src/blueprints/context/services/__tests__/PartAndPieceInstanceActionService.test.ts
@@ -161,7 +161,7 @@ describe('Test blueprint api context', () => {
 			rundown.rundown.showStyleBaseId
 		)
 
-		const service = new PartAndPieceInstanceActionService(jobContext, playoutModel, showStyle, rundown)
+		const service = new PartAndPieceInstanceActionService(jobContext, playoutModel, showStyle)
 
 		return {
 			playlist,
@@ -1098,6 +1098,7 @@ describe('Test blueprint api context', () => {
 
 				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
 					rundownId,
+					'part.externalId': 'MOCK_PART_0_0',
 				})) as DBPartInstance
 				expect(partInstance).toBeTruthy()
 				await setPartInstances(jobContext, playlistId, partInstance, undefined)
@@ -1151,6 +1152,7 @@ describe('Test blueprint api context', () => {
 
 				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
 					rundownId,
+					'part.externalId': 'MOCK_PART_0_0',
 				})) as DBPartInstance
 				expect(partInstance).toBeTruthy()
 				await setPartInstances(jobContext, playlistId, partInstance, undefined)
@@ -1195,6 +1197,7 @@ describe('Test blueprint api context', () => {
 					expect(newPartInstance.partInstance.part._rank).toBeLessThan(9000)
 					expect(newPartInstance.partInstance.part._rank).toEqual(0.5)
 					expect(newPartInstance.partInstance.orphaned).toEqual('adlib-part')
+					expect(newPartInstance.partInstance.segmentId).toEqual(partInstance.segmentId)
 
 					const newNextPieceInstances = await service.getPieceInstances('next')
 					expect(newNextPieceInstances).toHaveLength(1)
@@ -1204,6 +1207,247 @@ describe('Test blueprint api context', () => {
 
 					expect(service.nextPartState).toEqual(ActionPartChange.SAFE_CHANGE)
 					expect(service.currentPartState).toEqual(ActionPartChange.NONE)
+				})
+			})
+
+			test('good with explicit insert before part id', async () => {
+				const { jobContext, playlistId, rundownId } = await setupMyDefaultRundown()
+
+				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
+					rundownId,
+					'part.externalId': 'MOCK_PART_0_0',
+				})) as DBPartInstance
+				expect(partInstance).toBeTruthy()
+				await setPartInstances(jobContext, playlistId, partInstance, undefined)
+
+				const targetPart = await jobContext.mockCollections.Parts.findOne({
+					externalId: 'MOCK_PART_1_1',
+					rundownId,
+				})
+				expect(targetPart).toBeTruthy()
+
+				await wrapWithPlayoutModel(jobContext, playlistId, async (playoutModel) => {
+					const { service } = await getTestee(jobContext, playoutModel)
+
+					const newPiece: IBlueprintPiece = {
+						name: 'test piece',
+						sourceLayerId: 'sl1',
+						outputLayerId: 'o1',
+						externalId: '-',
+						enable: { start: 0 },
+						lifespan: PieceLifespan.OutOnRundownEnd,
+						content: {
+							timelineObjects: [],
+						},
+					}
+					const newPart: IBlueprintPart = {
+						externalId: 'nope',
+						title: 'something',
+					}
+
+					postProcessPiecesMock.mockImplementationOnce(postProcessPiecesOrig)
+					insertQueuedPartWithPiecesMock.mockImplementationOnce(insertQueuedPartWithPiecesOrig)
+					await service.queuePart(newPart, [newPiece], unprotectString(targetPart!._id))
+
+					const newPartInstance = playoutModel.getPartInstance(
+						playoutModel.playlist.nextPartInfo!.partInstanceId
+					)!
+					expect(newPartInstance.partInstance.segmentId).toEqual(targetPart!.segmentId)
+					expect(newPartInstance.partInstance.part._rank).toBeLessThan(targetPart!._rank)
+				})
+			})
+
+			test('unknown insert before part id', async () => {
+				const { jobContext, playlistId, rundownId } = await setupMyDefaultRundown()
+
+				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
+					rundownId,
+					'part.externalId': 'MOCK_PART_0_0',
+				})) as DBPartInstance
+				expect(partInstance).toBeTruthy()
+				await setPartInstances(jobContext, playlistId, partInstance, undefined)
+
+				await wrapWithPlayoutModel(jobContext, playlistId, async (playoutModel) => {
+					const { service } = await getTestee(jobContext, playoutModel)
+
+					postProcessPiecesMock.mockImplementationOnce(postProcessPiecesOrig)
+					await expect(
+						service.queuePart(
+							{ externalId: 'nope', title: 'something' },
+							[
+								{
+									name: 'test piece',
+									sourceLayerId: 'sl1',
+									outputLayerId: 'o1',
+									externalId: '-',
+									enable: { start: 0 },
+									lifespan: PieceLifespan.OutOnRundownEnd,
+									content: {
+										timelineObjects: [],
+									},
+								},
+							],
+							'unknown_part_id'
+						)
+					).rejects.toThrow('Cannot queue part: insert before target "unknown_part_id" not found')
+				})
+			})
+
+			test('good with explicit insert before part instance id', async () => {
+				const { jobContext, playlistId, rundownId } = await setupMyDefaultRundown()
+
+				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
+					rundownId,
+					'part.externalId': 'MOCK_PART_0_0',
+				})) as DBPartInstance
+				expect(partInstance).toBeTruthy()
+				await setPartInstances(jobContext, playlistId, partInstance, undefined)
+
+				const newPiece: IBlueprintPiece = {
+					name: 'test piece',
+					sourceLayerId: 'sl1',
+					outputLayerId: 'o1',
+					externalId: '-',
+					enable: { start: 0 },
+					lifespan: PieceLifespan.OutOnRundownEnd,
+					content: {
+						timelineObjects: [],
+					},
+				}
+				const newPart: IBlueprintPart = {
+					externalId: 'nope',
+					title: 'something',
+				}
+
+				await wrapWithPlayoutModel(jobContext, playlistId, async (playoutModel) => {
+					const { service } = await getTestee(jobContext, playoutModel)
+
+					postProcessPiecesMock.mockImplementation(postProcessPiecesOrig)
+					insertQueuedPartWithPiecesMock.mockImplementation(insertQueuedPartWithPiecesOrig)
+
+					await service.queuePart(newPart, [newPiece])
+					service.nextPartState = ActionPartChange.NONE
+
+					const existingAdlibPartInstanceId = playoutModel.playlist.nextPartInfo!.partInstanceId
+					const existingRank =
+						playoutModel.getPartInstance(existingAdlibPartInstanceId)!.partInstance.part._rank
+
+					const targetPart = await jobContext.mockCollections.Parts.findOne({
+						externalId: 'MOCK_PART_1_1',
+						rundownId,
+					})
+					expect(targetPart).toBeTruthy()
+
+					await service.queuePart(newPart, [newPiece], unprotectString(existingAdlibPartInstanceId))
+
+					const newPartInstance = playoutModel.getPartInstance(
+						playoutModel.playlist.nextPartInfo!.partInstanceId
+					)!
+					expect(newPartInstance.partInstance.part._rank).toBeLessThan(existingRank)
+					expect(newPartInstance.partInstance.part._rank).toBeLessThan(targetPart!._rank)
+				})
+			})
+
+			test('good with cross-segment insert before part id', async () => {
+				const { jobContext, playlistId, rundownId } = await setupMyDefaultRundown()
+
+				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
+					rundownId,
+					'part.externalId': 'MOCK_PART_0_0',
+				})) as DBPartInstance
+				expect(partInstance).toBeTruthy()
+				await setPartInstances(jobContext, playlistId, partInstance, undefined)
+
+				const targetPart = await jobContext.mockCollections.Parts.findOne({
+					externalId: 'MOCK_PART_1_1',
+					rundownId,
+				})
+				expect(targetPart).toBeTruthy()
+
+				await wrapWithPlayoutModel(jobContext, playlistId, async (playoutModel) => {
+					const { service } = await getTestee(jobContext, playoutModel)
+
+					const currentPartInstance = playoutModel.currentPartInstance!
+					expect(currentPartInstance.partInstance.segmentId).not.toEqual(targetPart!.segmentId)
+
+					const newPiece: IBlueprintPiece = {
+						name: 'test piece',
+						sourceLayerId: 'sl1',
+						outputLayerId: 'o1',
+						externalId: '-',
+						enable: { start: 0 },
+						lifespan: PieceLifespan.OutOnRundownEnd,
+						content: {
+							timelineObjects: [],
+						},
+					}
+					const newPart: IBlueprintPart = {
+						externalId: 'nope',
+						title: 'something',
+					}
+
+					postProcessPiecesMock.mockImplementationOnce(postProcessPiecesOrig)
+					insertQueuedPartWithPiecesMock.mockImplementationOnce(insertQueuedPartWithPiecesOrig)
+					await service.queuePart(newPart, [newPiece], unprotectString(targetPart!._id))
+
+					const newPartInstance = playoutModel.getPartInstance(
+						playoutModel.playlist.nextPartInfo!.partInstanceId
+					)!
+					expect(newPartInstance.partInstance.segmentId).toEqual(targetPart!.segmentId)
+					expect(newPartInstance.partInstance.segmentPlayoutId).not.toEqual(
+						currentPartInstance.partInstance.segmentPlayoutId
+					)
+				})
+			})
+
+			test('prepareQueueablePartAndPieces stores insertBeforeId', async () => {
+				const { jobContext, playlistId, rundownId } = await setupMyDefaultRundown()
+
+				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
+					rundownId,
+					'part.externalId': 'MOCK_PART_0_0',
+				})) as DBPartInstance
+				expect(partInstance).toBeTruthy()
+				await setPartInstances(jobContext, playlistId, partInstance, undefined)
+
+				const targetPart = await jobContext.mockCollections.Parts.findOne({
+					externalId: 'MOCK_PART_1_1',
+					rundownId,
+				})
+				expect(targetPart).toBeTruthy()
+
+				await wrapWithPlayoutModel(jobContext, playlistId, async (playoutModel) => {
+					const { service } = await getTestee(jobContext, playoutModel)
+
+					const currentPartInstance = playoutModel.currentPartInstance!
+					const newPiece: IBlueprintPiece = {
+						name: 'test piece',
+						sourceLayerId: 'sl1',
+						outputLayerId: 'o1',
+						externalId: '-',
+						enable: { start: 0 },
+						lifespan: PieceLifespan.OutOnRundownEnd,
+						content: {
+							timelineObjects: [],
+						},
+					}
+					const newPart: IBlueprintPart = {
+						externalId: 'nope',
+						title: 'something',
+					}
+
+					postProcessPiecesMock.mockImplementationOnce(postProcessPiecesOrig)
+
+					const queueable = service.prepareQueueablePartAndPieces(
+						newPart,
+						[newPiece],
+						currentPartInstance,
+						unprotectString(targetPart!._id)
+					)
+
+					expect(queueable.insertBeforeId).toEqual(targetPart!._id)
+					expect(queueable.part.title).toEqual('something')
+					expect(queueable.pieces).toHaveLength(1)
 				})
 			})
 
@@ -1239,6 +1483,7 @@ describe('Test blueprint api context', () => {
 
 				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
 					rundownId,
+					'part.externalId': 'MOCK_PART_0_0',
 				})) as DBPartInstance
 				expect(partInstance).toBeTruthy()
 				await setPartInstances(jobContext, playlistId, partInstance, undefined)
@@ -1829,6 +2074,7 @@ describe('Test blueprint api context', () => {
 
 				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
 					rundownId,
+					'part.externalId': 'MOCK_PART_0_0',
 				})) as DBPartInstance
 				expect(partInstance).toBeTruthy()
 				const partInstanceOther = (await jobContext.mockCollections.PartInstances.findOne({
@@ -1913,6 +2159,7 @@ describe('Test blueprint api context', () => {
 
 				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
 					rundownId,
+					'part.externalId': 'MOCK_PART_0_0',
 				})) as DBPartInstance
 				expect(partInstance).toBeTruthy()
 
@@ -1931,6 +2178,7 @@ describe('Test blueprint api context', () => {
 
 				const partInstance = (await jobContext.mockCollections.PartInstances.findOne({
 					rundownId,
+					'part.externalId': 'MOCK_PART_0_0',
 				})) as DBPartInstance
 				expect(partInstance).toBeTruthy()
 

--- a/packages/job-worker/src/ingest/__tests__/ingest.test.ts
+++ b/packages/job-worker/src/ingest/__tests__/ingest.test.ts
@@ -1732,7 +1732,6 @@ describe('Test ingest actions for rundowns and segments', () => {
 					const newPartInstance = await insertQueuedPartWithPieces(
 						context,
 						playoutModel,
-						rundown0,
 						currentPartInstance,
 						{
 							_id: protectString(`after_${currentPartInstance.partInstance._id}_part`),
@@ -1741,6 +1740,7 @@ describe('Test ingest actions for rundowns and segments', () => {
 							expectedDurationWithTransition: undefined,
 						},
 						[],
+						undefined,
 						undefined
 					)
 

--- a/packages/job-worker/src/playout/__tests__/adlibUtils.test.ts
+++ b/packages/job-worker/src/playout/__tests__/adlibUtils.test.ts
@@ -172,8 +172,156 @@ describe('adlibUtils', () => {
 			playoutModel.cycleSelectedPartInstances()
 
 			expect(() => resolveQueuedAdlibInsertTarget(playoutModel, currentPartInstance, targetPart._id)).toThrow(
-				'Cannot queue part: insert before target is in orphaned segment'
+				'Cannot queue part: target is in orphaned segment'
 			)
+		})
+	})
+
+	test('resolveQueuedAdlibInsertTarget inserts after explicit part id', async () => {
+		const playlistId: RundownPlaylistId = protectString('playlist0')
+		const rundownId: RundownId = getRandomId()
+		const context = await setupActivatedPlaylist(rundownId, playlistId)
+
+		await runJobWithPlayoutModel(context, { playlistId }, null, async (playoutModel) => {
+			const currentPart = playoutModel.getAllOrderedParts()[0]
+			expect(currentPart).toBeTruthy()
+
+			const targetPart = await context.mockCollections.Parts.findOne({
+				externalId: 'MOCK_PART_1_0',
+				rundownId,
+			})
+			expect(targetPart).toBeTruthy()
+			if (!targetPart) throw new Error('targetPart not found')
+
+			const partAfterTarget = await context.mockCollections.Parts.findOne({
+				externalId: 'MOCK_PART_1_1',
+				rundownId,
+			})
+			expect(partAfterTarget).toBeTruthy()
+			if (!partAfterTarget) throw new Error('partAfterTarget not found')
+
+			const currentPartInstance = playoutModel.createInstanceForPart(currentPart, [])
+			currentPartInstance.setTaken(Date.now(), 0)
+			playoutModel.cycleSelectedPartInstances()
+
+			const insertTarget = resolveQueuedAdlibInsertTarget(
+				playoutModel,
+				currentPartInstance,
+				targetPart._id,
+				false
+			)
+
+			expect(insertTarget.newRank).toBeGreaterThan(targetPart._rank)
+			expect(insertTarget.newRank).toBeLessThan(partAfterTarget._rank)
+		})
+	})
+
+	test('resolveQueuedAdlibInsertTarget inserts after explicit part instance id', async () => {
+		const playlistId: RundownPlaylistId = protectString('playlist0')
+		const rundownId: RundownId = getRandomId()
+		const context = await setupActivatedPlaylist(rundownId, playlistId)
+
+		await runJobWithPlayoutModel(context, { playlistId }, null, async (playoutModel) => {
+			const currentPart = playoutModel.getAllOrderedParts()[0]
+			expect(currentPart).toBeTruthy()
+
+			const targetPart = await context.mockCollections.Parts.findOne({
+				externalId: 'MOCK_PART_1_0',
+				rundownId,
+			})
+			expect(targetPart).toBeTruthy()
+			if (!targetPart) throw new Error('targetPart not found')
+
+			const currentPartInstance = playoutModel.createInstanceForPart(currentPart, [])
+			currentPartInstance.setTaken(Date.now(), 0)
+			playoutModel.cycleSelectedPartInstances()
+
+			const existingAdlibPart: DBPart = {
+				_id: getRandomId(),
+				segmentId: targetPart.segmentId,
+				rundownId: targetPart.rundownId,
+				_rank: 0.5,
+				externalId: 'existing_adlib',
+				title: 'Existing adlib',
+				expectedDurationWithTransition: undefined,
+			}
+			const existingAdlibPartInstance = playoutModel.createInstanceForPart(existingAdlibPart, [])
+			existingAdlibPartInstance.setOrphaned('adlib-part')
+
+			const partAfterTarget = await context.mockCollections.Parts.findOne({
+				externalId: 'MOCK_PART_1_1',
+				rundownId,
+			})
+			expect(partAfterTarget).toBeTruthy()
+			if (!partAfterTarget) throw new Error('partAfterTarget not found')
+
+			const insertTarget = resolveQueuedAdlibInsertTarget(
+				playoutModel,
+				currentPartInstance,
+				existingAdlibPartInstance.partInstance._id,
+				false
+			)
+
+			expect(insertTarget.newRank).toBeGreaterThan(existingAdlibPartInstance.partInstance.part._rank)
+			expect(insertTarget.newRank).toBeLessThan(partAfterTarget._rank)
+		})
+	})
+
+	test('resolveQueuedAdlibInsertTarget inserts after last part in segment', async () => {
+		const playlistId: RundownPlaylistId = protectString('playlist0')
+		const rundownId: RundownId = getRandomId()
+		const context = await setupActivatedPlaylist(rundownId, playlistId)
+
+		await runJobWithPlayoutModel(context, { playlistId }, null, async (playoutModel) => {
+			const currentPart = playoutModel.getAllOrderedParts()[0]
+			expect(currentPart).toBeTruthy()
+
+			const lastPartInSegment1 = playoutModel.getAllOrderedParts().find((p) => p.externalId === 'MOCK_PART_1_2')
+			expect(lastPartInSegment1).toBeTruthy()
+			if (!lastPartInSegment1) throw new Error('lastPartInSegment1 not found')
+
+			const currentPartInstance = playoutModel.createInstanceForPart(currentPart, [])
+			currentPartInstance.setTaken(Date.now(), 0)
+			playoutModel.cycleSelectedPartInstances()
+
+			const insertTarget = resolveQueuedAdlibInsertTarget(
+				playoutModel,
+				currentPartInstance,
+				lastPartInSegment1._id,
+				false
+			)
+
+			expect(insertTarget.newRank).toBeGreaterThan(lastPartInSegment1._rank)
+		})
+	})
+
+	test('resolveQueuedAdlibInsertTarget throws when insert after target is in orphaned segment', async () => {
+		const playlistId: RundownPlaylistId = protectString('playlist0')
+		const rundownId: RundownId = getRandomId()
+		const context = await setupActivatedPlaylist(rundownId, playlistId)
+
+		const targetPart = await context.mockCollections.Parts.findOne({
+			externalId: 'MOCK_PART_1_1',
+			rundownId,
+		})
+		expect(targetPart).toBeTruthy()
+		if (!targetPart) throw new Error('targetPart not found')
+
+		await context.mockCollections.Segments.update(targetPart.segmentId, {
+			$set: { orphaned: SegmentOrphanedReason.DELETED },
+		})
+
+		await runJobWithPlayoutModel(context, { playlistId }, null, async (playoutModel) => {
+			const currentPart = playoutModel.getAllOrderedParts()[0]
+			expect(currentPart).toBeTruthy()
+
+			const currentPartInstance = playoutModel.createInstanceForPart(currentPart, [])
+			currentPartInstance.setTaken(Date.now(), 0)
+			playoutModel.cycleSelectedPartInstances()
+
+			expect(() =>
+				resolveQueuedAdlibInsertTarget(playoutModel, currentPartInstance, targetPart._id, false)
+			).toThrow('Cannot queue part: target is in orphaned segment')
 		})
 	})
 })

--- a/packages/job-worker/src/playout/__tests__/adlibUtils.test.ts
+++ b/packages/job-worker/src/playout/__tests__/adlibUtils.test.ts
@@ -1,0 +1,179 @@
+import { protectString } from '@sofie-automation/corelib/dist/protectedString'
+import { RundownId, RundownPlaylistId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { setupDefaultJobEnvironment } from '../../__mocks__/context.js'
+import { setupDefaultRundown, setupMockShowStyleCompound } from '../../__mocks__/presetCollections.js'
+import { defaultRundownPlaylist } from '../../__mocks__/defaultCollectionObjects.js'
+import { getRandomId } from '@sofie-automation/corelib/dist/lib'
+import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
+import { resolveQueuedAdlibInsertTarget } from '../adlibUtils.js'
+import { runJobWithPlayoutModel } from '../lock.js'
+import { SegmentOrphanedReason } from '@sofie-automation/corelib/dist/dataModel/Segment'
+
+describe('adlibUtils', () => {
+	async function setupActivatedPlaylist(rundownId: RundownId, playlistId: RundownPlaylistId) {
+		const context = setupDefaultJobEnvironment()
+
+		await context.mockCollections.RundownPlaylists.insertOne({
+			...defaultRundownPlaylist(playlistId, context.studioId),
+			activationId: getRandomId(),
+		})
+
+		const showStyleCompound = await setupMockShowStyleCompound(context)
+		await setupDefaultRundown(context, showStyleCompound, playlistId, rundownId)
+
+		return context
+	}
+
+	test('resolveQueuedAdlibInsertTarget inserts after current part by default', async () => {
+		const playlistId: RundownPlaylistId = protectString('playlist0')
+		const rundownId: RundownId = getRandomId()
+		const context = await setupActivatedPlaylist(rundownId, playlistId)
+
+		await runJobWithPlayoutModel(context, { playlistId }, null, async (playoutModel) => {
+			const currentPart = playoutModel.getAllOrderedParts()[0]
+			expect(currentPart).toBeTruthy()
+
+			const currentPartInstance = playoutModel.createInstanceForPart(currentPart, [])
+			currentPartInstance.setTaken(Date.now(), 0)
+			playoutModel.cycleSelectedPartInstances()
+
+			const insertTarget = resolveQueuedAdlibInsertTarget(playoutModel, currentPartInstance)
+
+			expect(insertTarget.targetSegment.segment._id).toEqual(currentPart.segmentId)
+			expect(insertTarget.newRank).toEqual(0.5)
+		})
+	})
+
+	test('resolveQueuedAdlibInsertTarget inserts before explicit part id', async () => {
+		const playlistId: RundownPlaylistId = protectString('playlist0')
+		const rundownId: RundownId = getRandomId()
+		const context = await setupActivatedPlaylist(rundownId, playlistId)
+
+		await runJobWithPlayoutModel(context, { playlistId }, null, async (playoutModel) => {
+			const currentPart = playoutModel.getAllOrderedParts()[0]
+			expect(currentPart).toBeTruthy()
+
+			const targetPart = await context.mockCollections.Parts.findOne({
+				externalId: 'MOCK_PART_1_1',
+				rundownId,
+			})
+			expect(targetPart).toBeTruthy()
+			if (!targetPart) throw new Error('targetPart not found')
+
+			const partBeforeTarget = playoutModel.getAllOrderedParts().find((p) => p.externalId === 'MOCK_PART_1_0')
+			expect(partBeforeTarget).toBeTruthy()
+			if (!partBeforeTarget) throw new Error('partBeforeTarget not found')
+
+			const currentPartInstance = playoutModel.createInstanceForPart(currentPart, [])
+			currentPartInstance.setTaken(Date.now(), 0)
+			playoutModel.cycleSelectedPartInstances()
+
+			const insertTarget = resolveQueuedAdlibInsertTarget(playoutModel, currentPartInstance, targetPart._id)
+
+			expect(insertTarget.targetSegment.segment._id).toEqual(targetPart.segmentId)
+			expect(insertTarget.newRank).toBeLessThan(targetPart._rank)
+			expect(insertTarget.newRank).toBeGreaterThan(partBeforeTarget._rank)
+		})
+	})
+
+	test('resolveQueuedAdlibInsertTarget inserts before explicit part instance id', async () => {
+		const playlistId: RundownPlaylistId = protectString('playlist0')
+		const rundownId: RundownId = getRandomId()
+		const context = await setupActivatedPlaylist(rundownId, playlistId)
+
+		await runJobWithPlayoutModel(context, { playlistId }, null, async (playoutModel) => {
+			const currentPart = playoutModel.getAllOrderedParts()[0]
+			expect(currentPart).toBeTruthy()
+
+			const currentPartInstance = playoutModel.createInstanceForPart(currentPart, [])
+			currentPartInstance.setTaken(Date.now(), 0)
+			playoutModel.cycleSelectedPartInstances()
+
+			const existingAdlibPart: DBPart = {
+				_id: getRandomId(),
+				segmentId: currentPart.segmentId,
+				rundownId: currentPart.rundownId,
+				_rank: 0.5,
+				externalId: 'existing_adlib',
+				title: 'Existing adlib',
+				expectedDurationWithTransition: undefined,
+			}
+			const existingAdlibPartInstance = playoutModel.createInstanceForPart(existingAdlibPart, [])
+			existingAdlibPartInstance.setOrphaned('adlib-part')
+
+			const targetPart = await context.mockCollections.Parts.findOne({
+				externalId: 'MOCK_PART_1_1',
+				rundownId,
+			})
+			expect(targetPart).toBeTruthy()
+			if (!targetPart) throw new Error('targetPart not found')
+
+			const insertTarget = resolveQueuedAdlibInsertTarget(
+				playoutModel,
+				currentPartInstance,
+				existingAdlibPartInstance.partInstance._id
+			)
+
+			expect(insertTarget.newRank).toBeLessThan(existingAdlibPartInstance.partInstance.part._rank)
+			expect(insertTarget.newRank).toBeLessThan(targetPart._rank)
+		})
+	})
+
+	test('resolveQueuedAdlibInsertTarget inserts before first part in segment', async () => {
+		const playlistId: RundownPlaylistId = protectString('playlist0')
+		const rundownId: RundownId = getRandomId()
+		const context = await setupActivatedPlaylist(rundownId, playlistId)
+
+		await runJobWithPlayoutModel(context, { playlistId }, null, async (playoutModel) => {
+			const currentPart = playoutModel.getAllOrderedParts()[0]
+			expect(currentPart).toBeTruthy()
+
+			const firstPartInSegment1 = playoutModel.getAllOrderedParts().find((p) => p.externalId === 'MOCK_PART_1_0')
+			expect(firstPartInSegment1).toBeTruthy()
+			if (!firstPartInSegment1) throw new Error('firstPartInSegment1 not found')
+
+			const currentPartInstance = playoutModel.createInstanceForPart(currentPart, [])
+			currentPartInstance.setTaken(Date.now(), 0)
+			playoutModel.cycleSelectedPartInstances()
+
+			const insertTarget = resolveQueuedAdlibInsertTarget(
+				playoutModel,
+				currentPartInstance,
+				firstPartInSegment1._id
+			)
+
+			expect(insertTarget.targetSegment.segment._id).toEqual(firstPartInSegment1.segmentId)
+			expect(insertTarget.newRank).toBeLessThan(firstPartInSegment1._rank)
+		})
+	})
+
+	test('resolveQueuedAdlibInsertTarget throws when insert before target is in orphaned segment', async () => {
+		const playlistId: RundownPlaylistId = protectString('playlist0')
+		const rundownId: RundownId = getRandomId()
+		const context = await setupActivatedPlaylist(rundownId, playlistId)
+
+		const targetPart = await context.mockCollections.Parts.findOne({
+			externalId: 'MOCK_PART_1_1',
+			rundownId,
+		})
+		expect(targetPart).toBeTruthy()
+		if (!targetPart) throw new Error('targetPart not found')
+
+		await context.mockCollections.Segments.update(targetPart.segmentId, {
+			$set: { orphaned: SegmentOrphanedReason.DELETED },
+		})
+
+		await runJobWithPlayoutModel(context, { playlistId }, null, async (playoutModel) => {
+			const currentPart = playoutModel.getAllOrderedParts()[0]
+			expect(currentPart).toBeTruthy()
+
+			const currentPartInstance = playoutModel.createInstanceForPart(currentPart, [])
+			currentPartInstance.setTaken(Date.now(), 0)
+			playoutModel.cycleSelectedPartInstances()
+
+			expect(() => resolveQueuedAdlibInsertTarget(playoutModel, currentPartInstance, targetPart._id)).toThrow(
+				'Cannot queue part: insert before target is in orphaned segment'
+			)
+		})
+	})
+})

--- a/packages/job-worker/src/playout/__tests__/take.test.ts
+++ b/packages/job-worker/src/playout/__tests__/take.test.ts
@@ -1,0 +1,107 @@
+import { PieceLifespan } from '@sofie-automation/blueprints-integration'
+import { unprotectString } from '@sofie-automation/corelib/dist/protectedString'
+import { wrapDefaultObject } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
+import {
+	PeripheralDeviceCategory,
+	PeripheralDeviceType,
+	PERIPHERAL_SUBTYPE_PROCESS,
+} from '@sofie-automation/corelib/dist/dataModel/PeripheralDevice'
+import { MockJobContext, setupDefaultJobEnvironment } from '../../__mocks__/context.js'
+import {
+	setupDefaultRundownPlaylist,
+	setupMockPeripheralDevice,
+	setupMockShowStyleCompound,
+} from '../../__mocks__/presetCollections.js'
+import { handleActivateRundownPlaylist } from '../activePlaylistJobs.js'
+import { performTakeToNextedPart, handleTakeNextPart } from '../take.js'
+import { runJobWithPlayoutModel } from '../lock.js'
+import { PartAndPieceInstanceActionService } from '../../blueprints/context/services/PartAndPieceInstanceActionService.js'
+import { getCurrentTime } from '../../lib/index.js'
+
+jest.mock('../../blueprints/postProcess')
+import { postProcessPieces } from '../../blueprints/postProcess.js'
+const { postProcessPieces: postProcessPiecesOrig } = jest.requireActual('../../blueprints/postProcess')
+;(postProcessPieces as jest.Mock).mockImplementation(postProcessPiecesOrig)
+
+describe('take', () => {
+	test('performTakeToNextedPart queues part after take with insertBeforeId', async () => {
+		const context: MockJobContext = setupDefaultJobEnvironment()
+
+		context.setStudio({
+			...context.rawStudio,
+			settingsWithOverrides: wrapDefaultObject({
+				...context.studio.settings,
+				minimumTakeSpan: 0,
+			}),
+		})
+
+		jest.spyOn(context, 'queueEventJob').mockImplementation(async () => Promise.resolve())
+
+		await setupMockShowStyleCompound(context)
+		await setupMockPeripheralDevice(
+			context,
+			PeripheralDeviceCategory.PLAYOUT,
+			PeripheralDeviceType.PLAYOUT,
+			PERIPHERAL_SUBTYPE_PROCESS
+		)
+
+		const { rundownId, playlistId } = await setupDefaultRundownPlaylist(context)
+
+		await handleActivateRundownPlaylist(context, { playlistId, rehearsal: false })
+		await handleTakeNextPart(context, { playlistId, fromPartInstanceId: null })
+
+		const targetPart = await context.mockCollections.Parts.findOne({
+			externalId: 'MOCK_PART_1_1',
+			rundownId,
+		})
+		expect(targetPart).toBeTruthy()
+		if (!targetPart) throw new Error('targetPart not found')
+
+		await runJobWithPlayoutModel(context, { playlistId }, null, async (playoutModel) => {
+			const currentPartInstance = playoutModel.currentPartInstance
+			expect(currentPartInstance).toBeTruthy()
+			if (!currentPartInstance) throw new Error('currentPartInstance not found')
+
+			const showStyle = await context.getShowStyleCompound(
+				playoutModel.rundowns[0].rundown.showStyleVariantId,
+				playoutModel.rundowns[0].rundown.showStyleBaseId
+			)
+			const service = new PartAndPieceInstanceActionService(context, playoutModel, showStyle)
+
+			const partToQueueAfterTake = service.prepareQueueablePartAndPieces(
+				{ externalId: 'after_take', title: 'After take part' },
+				[
+					{
+						name: 'after take piece',
+						sourceLayerId: 'sl0',
+						outputLayerId: 'o0',
+						externalId: '-',
+						enable: { start: 0 },
+						lifespan: PieceLifespan.WithinPart,
+						content: {
+							timelineObjects: [],
+						},
+					},
+				],
+				currentPartInstance,
+				unprotectString(targetPart._id)
+			)
+
+			expect(partToQueueAfterTake.insertBeforeId).toEqual(targetPart._id)
+
+			await performTakeToNextedPart(context, playoutModel, getCurrentTime(), partToQueueAfterTake)
+
+			const nextPartInstanceId = playoutModel.playlist.nextPartInfo?.partInstanceId
+			expect(nextPartInstanceId).toBeTruthy()
+			if (!nextPartInstanceId) throw new Error('nextPartInstanceId not found')
+
+			const queuedPartInstance = playoutModel.getPartInstance(nextPartInstanceId)
+			expect(queuedPartInstance).toBeTruthy()
+			if (!queuedPartInstance) throw new Error('queuedPartInstance not found')
+
+			expect(queuedPartInstance.partInstance.segmentId).toEqual(targetPart.segmentId)
+			expect(queuedPartInstance.partInstance.part._rank).toBeLessThan(targetPart._rank)
+			expect(queuedPartInstance.partInstance.part.title).toEqual('After take part')
+		})
+	})
+})

--- a/packages/job-worker/src/playout/__tests__/take.test.ts
+++ b/packages/job-worker/src/playout/__tests__/take.test.ts
@@ -24,7 +24,7 @@ const { postProcessPieces: postProcessPiecesOrig } = jest.requireActual('../../b
 ;(postProcessPieces as jest.Mock).mockImplementation(postProcessPiecesOrig)
 
 describe('take', () => {
-	test('performTakeToNextedPart queues part after take with insertBeforeId', async () => {
+	async function setupTakenPlaylist() {
 		const context: MockJobContext = setupDefaultJobEnvironment()
 
 		context.setStudio({
@@ -49,6 +49,12 @@ describe('take', () => {
 
 		await handleActivateRundownPlaylist(context, { playlistId, rehearsal: false })
 		await handleTakeNextPart(context, { playlistId, fromPartInstanceId: null })
+
+		return { context, rundownId, playlistId }
+	}
+
+	test('performTakeToNextedPart queues part after take with insert before target', async () => {
+		const { context, rundownId, playlistId } = await setupTakenPlaylist()
 
 		const targetPart = await context.mockCollections.Parts.findOne({
 			externalId: 'MOCK_PART_1_1',
@@ -87,7 +93,8 @@ describe('take', () => {
 				unprotectString(targetPart._id)
 			)
 
-			expect(partToQueueAfterTake.insertBeforeId).toEqual(targetPart._id)
+			expect(partToQueueAfterTake.targetPartOrInstanceId).toEqual(targetPart._id)
+			expect(partToQueueAfterTake.insertBefore).toEqual(true)
 
 			await performTakeToNextedPart(context, playoutModel, getCurrentTime(), partToQueueAfterTake)
 
@@ -101,6 +108,73 @@ describe('take', () => {
 
 			expect(queuedPartInstance.partInstance.segmentId).toEqual(targetPart.segmentId)
 			expect(queuedPartInstance.partInstance.part._rank).toBeLessThan(targetPart._rank)
+			expect(queuedPartInstance.partInstance.part.title).toEqual('After take part')
+		})
+	})
+
+	test('performTakeToNextedPart queues part after take with insert after target', async () => {
+		const { context, rundownId, playlistId } = await setupTakenPlaylist()
+
+		const targetPart = await context.mockCollections.Parts.findOne({
+			externalId: 'MOCK_PART_1_0',
+			rundownId,
+		})
+		expect(targetPart).toBeTruthy()
+		if (!targetPart) throw new Error('targetPart not found')
+
+		const partAfterTarget = await context.mockCollections.Parts.findOne({
+			externalId: 'MOCK_PART_1_1',
+			rundownId,
+		})
+		expect(partAfterTarget).toBeTruthy()
+		if (!partAfterTarget) throw new Error('partAfterTarget not found')
+
+		await runJobWithPlayoutModel(context, { playlistId }, null, async (playoutModel) => {
+			const currentPartInstance = playoutModel.currentPartInstance
+			expect(currentPartInstance).toBeTruthy()
+			if (!currentPartInstance) throw new Error('currentPartInstance not found')
+
+			const showStyle = await context.getShowStyleCompound(
+				playoutModel.rundowns[0].rundown.showStyleVariantId,
+				playoutModel.rundowns[0].rundown.showStyleBaseId
+			)
+			const service = new PartAndPieceInstanceActionService(context, playoutModel, showStyle)
+
+			const partToQueueAfterTake = service.prepareQueueablePartAndPieces(
+				{ externalId: 'after_take', title: 'After take part' },
+				[
+					{
+						name: 'after take piece',
+						sourceLayerId: 'sl0',
+						outputLayerId: 'o0',
+						externalId: '-',
+						enable: { start: 0 },
+						lifespan: PieceLifespan.WithinPart,
+						content: {
+							timelineObjects: [],
+						},
+					},
+				],
+				currentPartInstance,
+				unprotectString(targetPart._id),
+				false
+			)
+
+			expect(partToQueueAfterTake.targetPartOrInstanceId).toEqual(targetPart._id)
+			expect(partToQueueAfterTake.insertBefore).toEqual(false)
+
+			await performTakeToNextedPart(context, playoutModel, getCurrentTime(), partToQueueAfterTake)
+
+			const nextPartInstanceId = playoutModel.playlist.nextPartInfo?.partInstanceId
+			expect(nextPartInstanceId).toBeTruthy()
+			if (!nextPartInstanceId) throw new Error('nextPartInstanceId not found')
+
+			const queuedPartInstance = playoutModel.getPartInstance(nextPartInstanceId)
+			expect(queuedPartInstance).toBeTruthy()
+			if (!queuedPartInstance) throw new Error('queuedPartInstance not found')
+
+			expect(queuedPartInstance.partInstance.part._rank).toBeGreaterThan(targetPart._rank)
+			expect(queuedPartInstance.partInstance.part._rank).toBeLessThan(partAfterTarget._rank)
 			expect(queuedPartInstance.partInstance.part.title).toEqual('After take part')
 		})
 	})

--- a/packages/job-worker/src/playout/__tests__/timeline.test.ts
+++ b/packages/job-worker/src/playout/__tests__/timeline.test.ts
@@ -62,7 +62,6 @@ import {
 	PlayoutChangedType,
 } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
 import _ from 'underscore'
-import { PlayoutRundownModel } from '../model/PlayoutRundownModel.js'
 import { PlayoutPartInstanceModel } from '../model/PlayoutPartInstanceModel.js'
 import { PlayoutPartInstanceModelImpl } from '../model/implementation/PlayoutPartInstanceModelImpl.js'
 import { mock } from 'jest-mock-extended'
@@ -1145,19 +1144,7 @@ describe('Timeline', () => {
 					const currentPartInstance = playoutModel.currentPartInstance as PlayoutPartInstanceModel
 					expect(currentPartInstance).toBeTruthy()
 
-					const rundown = playoutModel.getRundown(
-						currentPartInstance.partInstance.rundownId
-					) as PlayoutRundownModel
-					expect(rundown).toBeTruthy()
-
-					return innerStartOrQueueAdLibPiece(
-						context,
-						playoutModel,
-						rundown,
-						false,
-						currentPartInstance,
-						adlibSource
-					)
+					return innerStartOrQueueAdLibPiece(context, playoutModel, false, currentPartInstance, adlibSource)
 				})
 			}
 

--- a/packages/job-worker/src/playout/adlibAction.ts
+++ b/packages/job-worker/src/playout/adlibAction.ts
@@ -237,7 +237,7 @@ export async function executeActionInner(
 		showStyle,
 		context.getShowStyleBlueprintConfig(showStyle),
 		watchedPackages,
-		new PartAndPieceInstanceActionService(context, playoutModel, showStyle, rundown)
+		new PartAndPieceInstanceActionService(context, playoutModel, showStyle)
 	)
 
 	// If any action cannot be done due to timings, that needs to be rejected by the context

--- a/packages/job-worker/src/playout/adlibJobs.ts
+++ b/packages/job-worker/src/playout/adlibJobs.ts
@@ -275,7 +275,7 @@ export async function handleAdLibPieceStart(context: JobContext, data: AdlibPiec
 					UserErrorMessage.AdlibUnplayable
 				)
 
-			await innerStartOrQueueAdLibPiece(context, playoutModel, rundown, !!data.queue, partInstance, adLibPiece)
+			await innerStartOrQueueAdLibPiece(context, playoutModel, !!data.queue, partInstance, adLibPiece)
 		}
 	)
 }
@@ -326,7 +326,7 @@ export async function handleStartStickyPieceOnSourceLayer(
 			}
 
 			const lastPiece = convertPieceToAdLibPiece(context, lastPieceInstance.piece)
-			await innerStartOrQueueAdLibPiece(context, playoutModel, rundown, false, currentPartInstance, lastPiece)
+			await innerStartOrQueueAdLibPiece(context, playoutModel, false, currentPartInstance, lastPiece)
 		}
 	)
 }

--- a/packages/job-worker/src/playout/adlibUtils.ts
+++ b/packages/job-worker/src/playout/adlibUtils.ts
@@ -1,6 +1,13 @@
 import { AdLibPiece } from '@sofie-automation/corelib/dist/dataModel/AdLibPiece'
 import { BucketAdLib } from '@sofie-automation/corelib/dist/dataModel/BucketAdLibPiece'
-import { BucketAdLibId, PartInstanceId, PieceId, PieceInstanceId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import {
+	BucketAdLibId,
+	PartId,
+	PartInstanceId,
+	PieceId,
+	PieceInstanceId,
+	SegmentId,
+} from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
 import { PieceInstance, PieceInstancePiece } from '@sofie-automation/corelib/dist/dataModel/PieceInstance'
 import { assertNever, getRandomId, getRank } from '@sofie-automation/corelib/dist/lib'
@@ -24,14 +31,118 @@ import { setNextPart } from './setNext.js'
 import { logger } from '../logging.js'
 import { ReadonlyDeep } from 'type-fest'
 import { PlayoutRundownModel } from './model/PlayoutRundownModel.js'
+import { PlayoutSegmentModel } from './model/PlayoutSegmentModel.js'
 import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { protectString } from '@sofie-automation/corelib/dist/protectedString'
 import { QuickLoopMarkerType } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist/RundownPlaylist'
 
+export type QueuedAdlibInsertBeforeId = PartId | PartInstanceId
+
+export type QueuedAdlibInsertTarget = {
+	targetSegment: ReadonlyDeep<PlayoutSegmentModel>
+	targetRundown: PlayoutRundownModel
+	newRank: number
+}
+
+/**
+ * Resolve the Part to insert before from a PartInstanceId or PartId.
+ * PartInstanceId is checked first, then PartId.
+ */
+function resolveBeforePart(
+	playoutModel: PlayoutModel,
+	insertBeforeId: QueuedAdlibInsertBeforeId
+): ReadonlyDeep<DBPart> {
+	const partInstance = playoutModel.getPartInstance(insertBeforeId as PartInstanceId)
+	if (partInstance) return partInstance.partInstance.part
+
+	const part = playoutModel.findPart(insertBeforeId as PartId)
+	if (part) return part
+
+	throw new Error(`Cannot queue part: insert before target "${insertBeforeId}" not found`)
+}
+
+function getRankBeforePart(playoutModel: PlayoutModel, segmentId: SegmentId, beforePart: ReadonlyDeep<DBPart>): number {
+	const partsInSegment = playoutModel.getAllOrderedParts().filter((p) => p.segmentId === segmentId)
+
+	const orphanedParts = playoutModel.loadedPartInstances
+		.filter((pi) => pi.partInstance.segmentId === segmentId && pi.partInstance.orphaned)
+		.map((pi) => pi.partInstance.part)
+
+	const allParts: ReadonlyDeep<DBPart>[] = [...partsInSegment]
+	for (const orphanedPart of orphanedParts) {
+		if (!allParts.find((p) => p._id === orphanedPart._id)) {
+			allParts.push(orphanedPart)
+		}
+	}
+	allParts.sort((a, b) => a._rank - b._rank)
+
+	const beforeIndex = allParts.findIndex((p) => p._id === beforePart._id)
+	if (beforeIndex === -1) {
+		throw new Error(`Cannot queue part: insert before target part "${beforePart._id}" not found in segment`)
+	}
+	if (beforeIndex === 0) {
+		return getRank(null, beforePart)
+	}
+	return getRank(allParts[beforeIndex - 1], beforePart)
+}
+
+/**
+ * Resolve where an adlibbed part should be inserted in the rundown.
+ * When insertBeforeId is omitted, inserts after currentPartInstance.
+ * When provided, inserts before the target part (segment/rundown taken from the target).
+ * Rank computation includes orphaned adlib part-instances in the target segment.
+ */
+export function resolveQueuedAdlibInsertTarget(
+	playoutModel: PlayoutModel,
+	currentPartInstance: PlayoutPartInstanceModel,
+	insertBeforeId?: QueuedAdlibInsertBeforeId
+): QueuedAdlibInsertTarget {
+	if (insertBeforeId) {
+		const beforePart = resolveBeforePart(playoutModel, insertBeforeId)
+		const targetSegment = playoutModel.findSegment(beforePart.segmentId)
+		if (!targetSegment) {
+			throw new Error(`Segment "${beforePart.segmentId}" not found`)
+		}
+		if (targetSegment.segment.orphaned) {
+			throw new Error(`Cannot queue part: insert before target is in orphaned segment`)
+		}
+
+		const targetRundown = playoutModel.getRundown(beforePart.rundownId)
+		if (!targetRundown) {
+			throw new Error(`Rundown "${beforePart.rundownId}" not found`)
+		}
+
+		return {
+			targetSegment,
+			targetRundown,
+			newRank: getRankBeforePart(playoutModel, beforePart.segmentId, beforePart),
+		}
+	}
+
+	const targetSegment = playoutModel.findSegment(currentPartInstance.partInstance.segmentId)
+	if (!targetSegment) {
+		throw new Error(`Segment "${currentPartInstance.partInstance.segmentId}" not found`)
+	}
+
+	const targetRundown = playoutModel.getRundown(currentPartInstance.partInstance.rundownId)
+	if (!targetRundown) {
+		throw new Error(`Rundown "${currentPartInstance.partInstance.rundownId}" not found`)
+	}
+
+	// Parts are always integers spaced by one, and orphaned PartInstances will be decimals spaced between two Parts
+	const currentRank = currentPartInstance.partInstance.part._rank
+	const newRank = getRank(currentRank, Math.floor(currentRank + 1))
+
+	return {
+		targetSegment,
+		targetRundown,
+		newRank,
+	}
+}
+
 export async function innerStartOrQueueAdLibPiece(
 	context: JobContext,
 	playoutModel: PlayoutModel,
-	rundown: PlayoutRundownModel,
 	queue: boolean,
 	currentPartInstance: PlayoutPartInstanceModel,
 	adLibPiece: AdLibPiece | BucketAdLib
@@ -51,11 +162,11 @@ export async function innerStartOrQueueAdLibPiece(
 		const newPartInstance = await insertQueuedPartWithPieces(
 			context,
 			playoutModel,
-			rundown,
 			currentPartInstance,
 			adlibbedPart,
 			[genericAdlibPiece],
-			adLibPiece._id
+			adLibPiece._id,
+			undefined
 		)
 		queuedPartInstanceId = newPartInstance.partInstance._id
 
@@ -189,25 +300,22 @@ export async function innerFindLastScriptedPieceOnLayer(
 export async function insertQueuedPartWithPieces(
 	context: JobContext,
 	playoutModel: PlayoutModel,
-	rundown: PlayoutRundownModel,
 	currentPartInstance: PlayoutPartInstanceModel,
 	newPart: Omit<DBPart, 'segmentId' | 'rundownId' | '_rank'>,
 	initialPieces: Omit<PieceInstancePiece, 'startPartId'>[],
-	fromAdlibId: PieceId | BucketAdLibId | undefined
+	fromAdlibId: PieceId | BucketAdLibId | undefined,
+	insertBeforeId?: QueuedAdlibInsertBeforeId,
+	preResolvedTarget?: QueuedAdlibInsertTarget
 ): Promise<PlayoutPartInstanceModel> {
 	const span = context.startSpan('insertQueuedPartWithPieces')
 
-	// Parts are always integers spaced by one, and orphaned PartInstances will be decimals spaced between two Part
-	// so we can predict a 'safe' rank to get the desired position with some simple maths
-	const newRank = getRank(
-		currentPartInstance.partInstance.part._rank,
-		Math.floor(currentPartInstance.partInstance.part._rank + 1)
-	)
+	const { targetSegment, targetRundown, newRank } =
+		preResolvedTarget ?? resolveQueuedAdlibInsertTarget(playoutModel, currentPartInstance, insertBeforeId)
 
 	const newPartFull: DBPart = {
 		...newPart,
-		segmentId: currentPartInstance.partInstance.segmentId,
-		rundownId: currentPartInstance.partInstance.rundownId,
+		segmentId: targetSegment.segment._id,
+		rundownId: targetRundown.rundown._id,
 		_rank: newRank,
 	}
 
@@ -217,7 +325,7 @@ export async function insertQueuedPartWithPieces(
 		context,
 		playoutModel,
 		currentPartInstance,
-		rundown,
+		targetRundown,
 		newPartFull,
 		possiblePieces,
 		protectString('') // Replaced inside playoutModel.insertAdlibbedPartInstance

--- a/packages/job-worker/src/playout/adlibUtils.ts
+++ b/packages/job-worker/src/playout/adlibUtils.ts
@@ -36,7 +36,7 @@ import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { protectString } from '@sofie-automation/corelib/dist/protectedString'
 import { QuickLoopMarkerType } from '@sofie-automation/corelib/dist/dataModel/RundownPlaylist/RundownPlaylist'
 
-export type QueuedAdlibInsertBeforeId = PartId | PartInstanceId
+export type QueuedAdlibInsertRelativeId = PartId | PartInstanceId
 
 export type QueuedAdlibInsertTarget = {
 	targetSegment: ReadonlyDeep<PlayoutSegmentModel>
@@ -45,23 +45,20 @@ export type QueuedAdlibInsertTarget = {
 }
 
 /**
- * Resolve the Part to insert before from a PartInstanceId or PartId.
+ * Resolve the target Part from a PartInstanceId or PartId.
  * PartInstanceId is checked first, then PartId.
  */
-function resolveBeforePart(
-	playoutModel: PlayoutModel,
-	insertBeforeId: QueuedAdlibInsertBeforeId
-): ReadonlyDeep<DBPart> {
-	const partInstance = playoutModel.getPartInstance(insertBeforeId as PartInstanceId)
+function resolveRelativePart(playoutModel: PlayoutModel, targetId: QueuedAdlibInsertRelativeId): ReadonlyDeep<DBPart> {
+	const partInstance = playoutModel.getPartInstance(targetId as PartInstanceId)
 	if (partInstance) return partInstance.partInstance.part
 
-	const part = playoutModel.findPart(insertBeforeId as PartId)
+	const part = playoutModel.findPart(targetId as PartId)
 	if (part) return part
 
-	throw new Error(`Cannot queue part: insert before target "${insertBeforeId}" not found`)
+	throw new Error(`Cannot queue part: target "${targetId}" not found`)
 }
 
-function getRankBeforePart(playoutModel: PlayoutModel, segmentId: SegmentId, beforePart: ReadonlyDeep<DBPart>): number {
+function getAllPartsInSegment(playoutModel: PlayoutModel, segmentId: SegmentId): ReadonlyDeep<DBPart>[] {
 	const partsInSegment = playoutModel.getAllOrderedParts().filter((p) => p.segmentId === segmentId)
 
 	const orphanedParts = playoutModel.loadedPartInstances
@@ -76,9 +73,15 @@ function getRankBeforePart(playoutModel: PlayoutModel, segmentId: SegmentId, bef
 	}
 	allParts.sort((a, b) => a._rank - b._rank)
 
+	return allParts
+}
+
+function getRankBeforePart(playoutModel: PlayoutModel, segmentId: SegmentId, beforePart: ReadonlyDeep<DBPart>): number {
+	const allParts = getAllPartsInSegment(playoutModel, segmentId)
+
 	const beforeIndex = allParts.findIndex((p) => p._id === beforePart._id)
 	if (beforeIndex === -1) {
-		throw new Error(`Cannot queue part: insert before target part "${beforePart._id}" not found in segment`)
+		throw new Error(`Cannot queue part: target part "${beforePart._id}" not found in segment`)
 	}
 	if (beforeIndex === 0) {
 		return getRank(null, beforePart)
@@ -86,36 +89,52 @@ function getRankBeforePart(playoutModel: PlayoutModel, segmentId: SegmentId, bef
 	return getRank(allParts[beforeIndex - 1], beforePart)
 }
 
+function getRankAfterPart(playoutModel: PlayoutModel, segmentId: SegmentId, afterPart: ReadonlyDeep<DBPart>): number {
+	const allParts = getAllPartsInSegment(playoutModel, segmentId)
+
+	const afterIndex = allParts.findIndex((p) => p._id === afterPart._id)
+	if (afterIndex === -1) {
+		throw new Error(`Cannot queue part: target part "${afterPart._id}" not found in segment`)
+	}
+	if (afterIndex === allParts.length - 1) {
+		return getRank(afterPart, null)
+	}
+	return getRank(afterPart, allParts[afterIndex + 1])
+}
+
 /**
  * Resolve where an adlibbed part should be inserted in the rundown.
- * When insertBeforeId is omitted, inserts after currentPartInstance.
- * When provided, inserts before the target part (segment/rundown taken from the target).
+ * When targetPartOrInstanceId is omitted, inserts after currentPartInstance.
+ * When provided, inserts before or after the target based on insertBefore.
  * Rank computation includes orphaned adlib part-instances in the target segment.
  */
 export function resolveQueuedAdlibInsertTarget(
 	playoutModel: PlayoutModel,
 	currentPartInstance: PlayoutPartInstanceModel,
-	insertBeforeId?: QueuedAdlibInsertBeforeId
+	targetPartOrInstanceId?: QueuedAdlibInsertRelativeId,
+	insertBefore = true
 ): QueuedAdlibInsertTarget {
-	if (insertBeforeId) {
-		const beforePart = resolveBeforePart(playoutModel, insertBeforeId)
-		const targetSegment = playoutModel.findSegment(beforePart.segmentId)
+	if (targetPartOrInstanceId) {
+		const targetPart = resolveRelativePart(playoutModel, targetPartOrInstanceId)
+		const targetSegment = playoutModel.findSegment(targetPart.segmentId)
 		if (!targetSegment) {
-			throw new Error(`Segment "${beforePart.segmentId}" not found`)
+			throw new Error(`Segment "${targetPart.segmentId}" not found`)
 		}
 		if (targetSegment.segment.orphaned) {
-			throw new Error(`Cannot queue part: insert before target is in orphaned segment`)
+			throw new Error(`Cannot queue part: target is in orphaned segment`)
 		}
 
-		const targetRundown = playoutModel.getRundown(beforePart.rundownId)
+		const targetRundown = playoutModel.getRundown(targetPart.rundownId)
 		if (!targetRundown) {
-			throw new Error(`Rundown "${beforePart.rundownId}" not found`)
+			throw new Error(`Rundown "${targetPart.rundownId}" not found`)
 		}
 
 		return {
 			targetSegment,
 			targetRundown,
-			newRank: getRankBeforePart(playoutModel, beforePart.segmentId, beforePart),
+			newRank: insertBefore
+				? getRankBeforePart(playoutModel, targetPart.segmentId, targetPart)
+				: getRankAfterPart(playoutModel, targetPart.segmentId, targetPart),
 		}
 	}
 
@@ -304,13 +323,15 @@ export async function insertQueuedPartWithPieces(
 	newPart: Omit<DBPart, 'segmentId' | 'rundownId' | '_rank'>,
 	initialPieces: Omit<PieceInstancePiece, 'startPartId'>[],
 	fromAdlibId: PieceId | BucketAdLibId | undefined,
-	insertBeforeId?: QueuedAdlibInsertBeforeId,
+	targetPartOrInstanceId?: QueuedAdlibInsertRelativeId,
+	insertBefore = true,
 	preResolvedTarget?: QueuedAdlibInsertTarget
 ): Promise<PlayoutPartInstanceModel> {
 	const span = context.startSpan('insertQueuedPartWithPieces')
 
 	const { targetSegment, targetRundown, newRank } =
-		preResolvedTarget ?? resolveQueuedAdlibInsertTarget(playoutModel, currentPartInstance, insertBeforeId)
+		preResolvedTarget ??
+		resolveQueuedAdlibInsertTarget(playoutModel, currentPartInstance, targetPartOrInstanceId, insertBefore)
 
 	const newPartFull: DBPart = {
 		...newPart,

--- a/packages/job-worker/src/playout/bucketAdlibJobs.ts
+++ b/packages/job-worker/src/playout/bucketAdlibJobs.ts
@@ -42,15 +42,11 @@ export async function handleExecuteBucketAdLibOrAction(
 
 			const playoutModel = await createPlayoutModelfromInitModel(context, initCache)
 
-			const fullRundown = playoutModel.getRundown(rundown._id)
-			if (!fullRundown) throw new Error(`Rundown "${rundown._id}" missing between caches`)
-
 			const partInstance = playoutModel.currentPartInstance
 			if (!partInstance) throw new Error(`PartInstance "${playlist.currentPartInfo.partInstanceId}" not found!`)
 			await innerStartOrQueueAdLibPiece(
 				context,
 				playoutModel,
-				fullRundown,
 				!!bucketAdLib.toBeQueued,
 				partInstance,
 				bucketAdLib

--- a/packages/job-worker/src/playout/externalEvents.ts
+++ b/packages/job-worker/src/playout/externalEvents.ts
@@ -98,7 +98,7 @@ async function executeOnExternalEventsForPlaylist(
 		showStyle,
 		context.getShowStyleBlueprintConfig(showStyle),
 		WatchedPackagesHelper.empty(context),
-		new PartAndPieceInstanceActionService(context, playoutModel, showStyle, currentRundown)
+		new PartAndPieceInstanceActionService(context, playoutModel, showStyle)
 	)
 
 	const persistentState = new PersistentPlayoutStateStore(

--- a/packages/job-worker/src/playout/model/PlayoutModel.ts
+++ b/packages/job-worker/src/playout/model/PlayoutModel.ts
@@ -243,7 +243,7 @@ export interface PlayoutModel extends PlayoutModelReadonly, StudioPlayoutModelBa
 	 * @returns The inserted PlayoutPartInstanceModel
 	 */
 	createAdlibbedPartInstance(
-		part: Omit<DBPart, 'segmentId' | 'rundownId'>,
+		part: DBPart,
 		pieces: Omit<PieceInstancePiece, 'startPartId'>[],
 		fromAdlibId: PieceId | BucketAdLibId | undefined,
 		infinitePieceInstances: PieceInstance[]

--- a/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutModelImpl.ts
@@ -424,7 +424,7 @@ export class PlayoutModelImpl extends PlayoutModelReadonlyImpl implements Playou
 	}
 
 	createAdlibbedPartInstance(
-		part: Omit<DBPart, 'segmentId' | 'rundownId'>,
+		part: DBPart,
 		pieces: Omit<PieceInstancePiece, 'startPartId'>[],
 		fromAdlibId: PieceId | undefined,
 		infinitePieceInstances: PieceInstance[]
@@ -432,20 +432,21 @@ export class PlayoutModelImpl extends PlayoutModelReadonlyImpl implements Playou
 		const currentPartInstance = this.currentPartInstance
 		if (!currentPartInstance) throw new Error('No currentPartInstance')
 
+		const segmentPlayoutId: SegmentPlayoutId =
+			part.segmentId === currentPartInstance.partInstance.segmentId
+				? currentPartInstance.partInstance.segmentPlayoutId
+				: getRandomId()
+
 		const newPartInstance: DBPartInstance = {
 			_id: getRandomId(),
-			rundownId: currentPartInstance.partInstance.rundownId,
-			segmentId: currentPartInstance.partInstance.segmentId,
+			rundownId: part.rundownId,
+			segmentId: part.segmentId,
 			playlistActivationId: currentPartInstance.partInstance.playlistActivationId,
-			segmentPlayoutId: currentPartInstance.partInstance.segmentPlayoutId,
+			segmentPlayoutId,
 			takeCount: currentPartInstance.partInstance.takeCount + 1,
 			rehearsal: currentPartInstance.partInstance.rehearsal,
 			orphaned: 'adlib-part',
-			part: {
-				...part,
-				rundownId: currentPartInstance.partInstance.rundownId,
-				segmentId: currentPartInstance.partInstance.segmentId,
-			},
+			part: clone<DBPart>(part),
 		}
 
 		this.#fixupPieceInstancesForPartInstance(newPartInstance, infinitePieceInstances)

--- a/packages/job-worker/src/playout/model/implementation/PlayoutSegmentModelImpl.ts
+++ b/packages/job-worker/src/playout/model/implementation/PlayoutSegmentModelImpl.ts
@@ -3,6 +3,7 @@ import { ReadonlyDeep } from 'type-fest'
 import { DBSegment, SegmentOrphanedReason } from '@sofie-automation/corelib/dist/dataModel/Segment'
 import { DBPart } from '@sofie-automation/corelib/dist/dataModel/Part'
 import { PlayoutSegmentModel } from '../PlayoutSegmentModel.js'
+import { unprotectString } from '@sofie-automation/corelib/dist/protectedString.js'
 
 export class PlayoutSegmentModelImpl implements PlayoutSegmentModel {
 	readonly #segment: DBSegment
@@ -20,7 +21,7 @@ export class PlayoutSegmentModelImpl implements PlayoutSegmentModel {
 	}
 
 	getPart(id: PartId): ReadonlyDeep<DBPart> | undefined {
-		return this.parts.find((part) => part._id === id)
+		return this.parts.find((part) => part._id === id || part.externalId === unprotectString(id))
 	}
 
 	getPartIds(): PartId[] {

--- a/packages/job-worker/src/playout/setNext.ts
+++ b/packages/job-worker/src/playout/setNext.ts
@@ -228,7 +228,7 @@ async function executeOnSetAsNextCallback(
 		playoutModel,
 		showStyle,
 		watchedPackagesHelper,
-		new PartAndPieceInstanceActionService(context, playoutModel, showStyle, rundownOfNextPart),
+		new PartAndPieceInstanceActionService(context, playoutModel, showStyle),
 		setManually
 	)
 

--- a/packages/job-worker/src/playout/take.ts
+++ b/packages/job-worker/src/playout/take.ts
@@ -308,7 +308,8 @@ export async function performTakeToNextedPart(
 			partToQueueAfterTake.part,
 			partToQueueAfterTake.pieces,
 			undefined,
-			partToQueueAfterTake.insertBeforeId
+			partToQueueAfterTake.targetPartOrInstanceId,
+			partToQueueAfterTake.insertBefore ?? true
 		)
 	} else {
 		// Once everything is synced, we can choose the next part

--- a/packages/job-worker/src/playout/take.ts
+++ b/packages/job-worker/src/playout/take.ts
@@ -304,11 +304,11 @@ export async function performTakeToNextedPart(
 		await insertQueuedPartWithPieces(
 			context,
 			playoutModel,
-			takeRundown,
 			takePartInstance,
 			partToQueueAfterTake.part,
 			partToQueueAfterTake.pieces,
-			undefined
+			undefined,
+			partToQueueAfterTake.insertBeforeId
 		)
 	} else {
 		// Once everything is synced, we can choose the next part
@@ -358,7 +358,7 @@ async function executeOnTakeCallback(
 
 		// Clear any existing notifications for this partInstance. This will clear any from the previous take
 		playoutModel.clearAllNotifications(NOTIFICATION_CATEGORY)
-		const actionService = new PartAndPieceInstanceActionService(context, playoutModel, showStyle, currentRundown)
+		const actionService = new PartAndPieceInstanceActionService(context, playoutModel, showStyle)
 
 		const watchedPackagesHelper = WatchedPackagesHelper.empty(context)
 		const onSetAsNextContext = new OnTakeContext(


### PR DESCRIPTION
## About the Contributor

This pull request is posted on behalf of the CBC.

## Type of Contribution

This is a: Feature

## Current Behavior

`queuePart` / `queuePartAfterTake` always insert after the current/taken part.

## New Behavior

Optional insert position via two new params:

```typescript
queuePart(part, pieces, target?: QueuePartTarget)
```

```typescript
type QueuePartTarget = { after?: boolean } & (
  | { targetPartId: string }
  | { targetPartInstanceId: string }
)
```

- No target → after current/taken part (unchanged)
- Target + `after: false` (default when omited) → before target
- Target + `after: true` → after target

Target is a `PartId` or `PartInstanceId`. Inserted part still always becomes next.

This allows actions from the blueprint to decide where a part gets added.

## Testing

- [X] I have added one or more unit tests for this PR
- [X] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

`queuePart`, `queuePartAfterTake`, take flow

## Time Frame

Not urgent, but we would like to get this merged into the in-development release.

## Status

- [ ] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [X] Relevant unit tests has been added / updated.
- [X] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
