### PR TITLE
fix: offset resolvedEndCap when laying out Pieces on the Timeline

### DIFF
--- a/packages/corelib/src/playout/processAndPrune.ts
+++ b/packages/corelib/src/playout/processAndPrune.ts
@@ -77,7 +77,10 @@ export interface RelativeResolvedEndCap {
 
 export interface PieceInstanceWithTimings extends ReadonlyDeep<PieceInstance> {
 	/**
-	 * This is a maximum end point of the pieceInstance.
+	 * This is a maximum end point of the pieceInstance, in the same timespace as the pieceInstance.piece.enable.start,
+	 * meaning that it is relative to the start of the PartInstance, and not the start of the PartInstance's preroll and
+	 * may need to be correctly translated to the timeline timespace.
+	 *
 	 * If the pieceInstance also has a enable.duration or userDuration set then the shortest one will need to be used
 	 * This can be:
 	 *  - '100', if relative to the start of the part

--- a/packages/job-worker/src/playout/timeline/__tests__/pieceGroup.test.ts
+++ b/packages/job-worker/src/playout/timeline/__tests__/pieceGroup.test.ts
@@ -49,7 +49,7 @@ describe('Pieces', () => {
 				end: '#piece_group_control_randomId9000.end + 0',
 			},
 			id: 'piece_group_randomId9000',
-			inGroup: undefined,
+			inGroup: 'randomId9003',
 			infinitePieceInstanceId: undefined,
 			isGroup: true,
 			layer: '',
@@ -80,7 +80,7 @@ describe('Pieces', () => {
 				start: 10,
 			},
 			id: 'piece_group_control_randomId9000',
-			inGroup: undefined,
+			inGroup: 'randomId9003',
 			infinitePieceInstanceId: undefined,
 			layer: 'some-layer',
 			metaData: {
@@ -96,7 +96,14 @@ describe('Pieces', () => {
 		const partGroup = { id: 'randomId9003' } as any as TimelineObjRundown
 
 		test('Basic piece', () => {
-			const res = createPieceGroupAndCap(playlistId, simplePieceInstance, simplePieceInstance.piece.enable)
+			const res = createPieceGroupAndCap(
+				playlistId,
+				simplePieceInstance,
+				simplePieceInstance.piece.enable,
+				[],
+				undefined,
+				partGroup
+			)
 
 			expect(res.capObjs).toHaveLength(0)
 			expect(res.childGroup).toStrictEqual(simplePieceGroup)
@@ -108,6 +115,7 @@ describe('Pieces', () => {
 				simplePieceInstance,
 				simplePieceInstance.piece.enable,
 				[],
+				undefined,
 				partGroup
 			)
 
@@ -124,7 +132,7 @@ describe('Pieces', () => {
 		})
 		test('override enable', () => {
 			const enable: TimelineEnable = { start: 'abc + 3', end: 999 }
-			const res = createPieceGroupAndCap(playlistId, simplePieceInstance, enable, [], partGroup)
+			const res = createPieceGroupAndCap(playlistId, simplePieceInstance, enable, [], undefined, partGroup)
 
 			expect(res.capObjs).toHaveLength(0)
 			expect(res.childGroup).toStrictEqual({
@@ -147,7 +155,7 @@ describe('Pieces', () => {
 					...simplePieceInstance,
 					resolvedEndCap: 800,
 				}
-				const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], partGroup)
+				const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], undefined, partGroup)
 
 				expect(res.capObjs).toHaveLength(0)
 				expect(res.childGroup).toStrictEqual({
@@ -171,7 +179,7 @@ describe('Pieces', () => {
 					...simplePieceInstance,
 					resolvedEndCap: 8000,
 				}
-				const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], partGroup)
+				const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], undefined, partGroup)
 
 				expect(res.capObjs).toHaveLength(0)
 				expect(res.childGroup).toStrictEqual({
@@ -194,7 +202,7 @@ describe('Pieces', () => {
 					...simplePieceInstance,
 					resolvedEndCap: 800,
 				}
-				const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], partGroup)
+				const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], undefined, partGroup)
 
 				expect(res.capObjs).toHaveLength(0)
 				expect(res.childGroup).toStrictEqual({
@@ -219,7 +227,7 @@ describe('Pieces', () => {
 					...simplePieceInstance,
 					resolvedEndCap: 800,
 				}
-				const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], partGroup)
+				const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], undefined, partGroup)
 
 				expect(res.capObjs).toStrictEqual([
 					{
@@ -257,7 +265,7 @@ describe('Pieces', () => {
 				...simplePieceInstance,
 				resolvedEndCap: 800,
 			}
-			const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], partGroup)
+			const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], undefined, partGroup)
 
 			expect(res.capObjs).toHaveLength(0)
 			expect(res.childGroup).toStrictEqual({
@@ -282,7 +290,7 @@ describe('Pieces', () => {
 				...simplePieceInstance,
 				resolvedEndCap: { offsetFromNow: 99 },
 			}
-			const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], partGroup)
+			const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], undefined, partGroup)
 
 			expect(res.capObjs).toStrictEqual([
 				{
@@ -332,7 +340,7 @@ describe('Pieces', () => {
 				...simplePieceInstance,
 				resolvedEndCap: { offsetFromNow: 0 },
 			}
-			const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], partGroup)
+			const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], undefined, partGroup)
 
 			expect(res.capObjs).toStrictEqual([
 				{
@@ -370,7 +378,7 @@ describe('Pieces', () => {
 				...simplePieceInstance,
 				resolvedEndCap: { offsetFromNow: 0 },
 			}
-			const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], partGroup)
+			const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], undefined, partGroup)
 
 			expect(res.capObjs).toStrictEqual([
 				{
@@ -420,7 +428,7 @@ describe('Pieces', () => {
 				...simplePieceInstance,
 				resolvedEndCap: { offsetFromNow: 99 },
 			}
-			const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], partGroup)
+			const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], undefined, partGroup)
 
 			expect(res.capObjs).toStrictEqual([
 				{
@@ -470,7 +478,7 @@ describe('Pieces', () => {
 				...simplePieceInstance,
 				resolvedEndCap: { offsetFromNow: 99 },
 			}
-			const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], partGroup)
+			const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], undefined, partGroup)
 
 			expect(res.capObjs).toStrictEqual([
 				{
@@ -501,7 +509,7 @@ describe('Pieces', () => {
 			})
 		})
 
-		test('resolvedEndCap with piece start offset', () => {
+		test('resolvedEndCap with piece with a preRoll', () => {
 			const enable: TimelineEnable = { start: 0 }
 
 			const pieceInstance: PieceInstanceParam = {
@@ -510,7 +518,7 @@ describe('Pieces', () => {
 			}
 
 			// No offset
-			const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], partGroup)
+			const res = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], undefined, partGroup)
 			expect(res.capObjs).toHaveLength(0)
 			expect(res.childGroup).toStrictEqual({
 				...simplePieceGroup,
@@ -527,7 +535,21 @@ describe('Pieces', () => {
 			})
 
 			// Factor in offset
-			const res2 = createPieceGroupAndCap(playlistId, pieceInstance, enable, [], partGroup, 100)
+			const res2 = createPieceGroupAndCap(
+				playlistId,
+				pieceInstance,
+				enable,
+				[],
+				{
+					toPartDelay: 100, // this is where the piece preRoll is factored in
+					fromPartKeepalive: 0,
+					fromPartPostroll: 0,
+					toPartPostroll: 0,
+					fromPartRemaining: 0,
+					inTransitionStart: 0,
+				},
+				partGroup
+			)
 			expect(res2.capObjs).toHaveLength(0)
 			expect(res2.childGroup).toStrictEqual({
 				...simplePieceGroup,

--- a/packages/job-worker/src/playout/timeline/part.ts
+++ b/packages/job-worker/src/playout/timeline/part.ts
@@ -63,11 +63,11 @@ export function transformPartIntoTimeline(
 		timelineObjs.push(
 			...transformPieceGroupAndObjects(
 				playlistId,
+				partInfo.calculatedTimings,
 				partGroupToAddTo,
 				nowInParentGroup,
 				pieceInstance,
 				pieceEnable,
-				pieceInstance.dynamicallyInserted ? 0 : partTimings.toPartDelay,
 				pieceGroupFirstObjClasses,
 				playoutState
 			)

--- a/packages/job-worker/src/playout/timeline/piece.ts
+++ b/packages/job-worker/src/playout/timeline/piece.ts
@@ -18,12 +18,11 @@ import { hasPieceInstanceDefinitelyEnded, shouldIncludeObjectOnTimeline, Timelin
 
 export function transformPieceGroupAndObjects(
 	playlistId: RundownPlaylistId,
+	partTimings: PartCalculatedTimings | undefined,
 	partGroup: TimelineObjGroupPart & OnGenerateTimelineObjExt,
 	nowInPart: number,
 	pieceInstance: ReadonlyDeep<PieceInstanceWithTimings>,
 	pieceEnable: TSR.Timeline.TimelineEnable,
-	/** If the start of the piece has been offset inside the partgroup  */
-	pieceStartOffset: number,
 	controlObjClasses: string[],
 	playoutState: TimelinePlayoutState
 ): Array<TimelineObjRundown & OnGenerateTimelineObjExt> {
@@ -37,8 +36,8 @@ export function transformPieceGroupAndObjects(
 		pieceInstance,
 		pieceEnable,
 		controlObjClasses,
-		partGroup,
-		pieceStartOffset
+		partTimings,
+		partGroup
 	)
 	// We need all these objects so that we can resolve all the piece timings in this timeline
 	const timelineObjs: Array<TimelineObjRundown & OnGenerateTimelineObjExt> = [controlObj, childGroup, ...capObjs]

--- a/packages/job-worker/src/playout/timeline/pieceGroup.ts
+++ b/packages/job-worker/src/playout/timeline/pieceGroup.ts
@@ -14,6 +14,7 @@ import { getPieceControlObjectId, getPieceGroupId } from '@sofie-automation/core
 import { unprotectString } from '@sofie-automation/corelib/dist/protectedString'
 import { PieceInstanceWithTimings } from '@sofie-automation/corelib/dist/playout/processAndPrune'
 import { PlayoutChangedType } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
+import { PartCalculatedTimings } from '@sofie-automation/corelib/dist/playout/timings'
 
 export interface PieceTimelineMetadata {
 	/** Indicate that this is a PieceTimeline object */
@@ -38,9 +39,9 @@ export function createPieceGroupAndCap(
 		| 'dynamicallyInserted'
 	>,
 	controlObjEnable: TSR.Timeline.TimelineEnable,
-	controlObjClasses?: string[],
-	partGroup?: TimelineObjRundown,
-	pieceStartOffset?: number
+	controlObjClasses: string[],
+	partTiming: PartCalculatedTimings | undefined,
+	partGroup: TimelineObjRundown
 ): {
 	/** The 'control' object which defines the bounds of the group. This triggers the timing, and does not include and pre/postroll */
 	controlObj: TimelineObjPieceAbstract & OnGenerateTimelineObjExt<PieceTimelineMetadata>
@@ -136,7 +137,9 @@ export function createPieceGroupAndCap(
 	let resolvedEndCap: number | string | undefined
 	// If the start has been adjusted, the end needs to be updated to compensate
 	if (typeof pieceInstance.resolvedEndCap === 'number') {
-		resolvedEndCap = pieceInstance.resolvedEndCap + (pieceStartOffset ?? 0)
+		// The resolvedEndCap is in the "part-specific" timespace and it needs to be offset by Part's toPartDelay,
+		// as all timeline objects within the Part are in a "pre-preroll-adjusted timespace" (see PR#1441)
+		resolvedEndCap = pieceInstance.resolvedEndCap + (partTiming?.toPartDelay ?? 0)
 	} else if (pieceInstance.resolvedEndCap || controlObj.enable.end === 'now') {
 		// TODO - there could already be a piece with a cap of 'now' that we could use as our end time
 		// As the cap is for 'now', rather than try to get tsr to understand `end: 'now'`, we can create a 'now' object to tranlate it

--- a/packages/job-worker/src/playout/timeline/rundown.ts
+++ b/packages/job-worker/src/playout/timeline/rundown.ts
@@ -361,11 +361,11 @@ function generateCurrentInfinitePieceObjects(
 		infiniteGroup,
 		...transformPieceGroupAndObjects(
 			activePlaylist._id,
+			undefined,
 			infiniteGroup,
 			nowInParent,
 			pieceInstanceWithUpdatedEndCap,
 			pieceEnable,
-			0,
 			groupClasses,
 			{
 				isRehearsal: !!activePlaylist.rehearsal,


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

<!--
Tell us who / which organization you are representing, and how the Sofie team will be able to contact you.
Example: "This pull request is posted on behalf of the NRK."
-->

This pull request is posted on behalf of the NRK.

## Type of Contribution

This is a:

<!-- (pick one) -->

Bug fix

## Current Behavior

<!--
Please describe how things worked before this PR.
If it's a bug fixe: Describe the bug (what was happening?)
-->

When adLibbing Pieces on the same sourceLayer or a sourceLayer of the same exclusivity group, the Pieces being replaced by new Pieces end before the new Piece begins

This is caused by using the `resolvedEndCap` verbatim, without translating it into the Part timespace.

## New Behavior

<!--
What is the new behavior?
-->

The `resolvedEndCap` is correctly always translated into the Part timespace. Code documentation is expanded to explain the meaning and the timespace of the values.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [x] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

This PR affects the playout logic in general.

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

We intend to finish the development on this feature in two weeks time.

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [x] Relevant unit tests has been added / updated.
- [x] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
