### PR TITLE
fix: remove unused ui subscriptions

### DIFF
--- a/packages/webui/src/client/ui/ClockView/CameraScreen/index.tsx
+++ b/packages/webui/src/client/ui/ClockView/CameraScreen/index.tsx
@@ -108,7 +108,7 @@ export function CameraScreen({ playlist, studioId }: Readonly<IProps>): JSX.Elem
 	const studioReady = useSubscription(MeteorPubSub.uiStudio, studioId)
 	useSubscriptionIfEnabled(MeteorPubSub.uiPartInstances, !!playlist?.activationId, playlist?.activationId ?? null)
 
-	useSubscriptionIfEnabled(CorelibPubSub.parts, rundownIds.length > 0, rundownIds, null)
+	useSubscriptionIfEnabled(MeteorPubSub.uiParts, !!playlist, playlist?._id ?? null)
 
 	useSubscriptionIfEnabled(CorelibPubSub.pieceInstancesSimple, rundownIds.length > 0, rundownIds, null)
 

--- a/packages/webui/src/client/ui/ClockView/DirectorScreen/DirectorScreen.tsx
+++ b/packages/webui/src/client/ui/ClockView/DirectorScreen/DirectorScreen.tsx
@@ -373,7 +373,6 @@ function useDirectorScreenSubscriptions(props: DirectorScreenProps): void {
 	const { rundownIds, showStyleBaseIds, showStyleVariantIds } = useRundownAndShowStyleIdsForPlaylist(playlist?._id)
 
 	useSubscription(CorelibPubSub.segments, rundownIds, {})
-	useSubscription(CorelibPubSub.parts, rundownIds, null)
 	useSubscription(MeteorPubSub.uiParts, playlist?._id ?? null)
 	useSubscription(MeteorPubSub.uiPartInstances, playlist?.activationId ?? null)
 	useSubscriptions(

--- a/packages/webui/src/client/ui/ClockView/PresenterScreen.tsx
+++ b/packages/webui/src/client/ui/ClockView/PresenterScreen.tsx
@@ -424,7 +424,6 @@ export function usePresenterScreenSubscriptions(props: PresenterScreenProps): vo
 	const { rundownIds, showStyleBaseIds, showStyleVariantIds } = useRundownAndShowStyleIdsForPlaylist(playlist?._id)
 
 	useSubscriptionIfEnabled(CorelibPubSub.segments, rundownIds.length > 0, rundownIds, {})
-	useSubscriptionIfEnabled(CorelibPubSub.parts, rundownIds.length > 0, rundownIds, null)
 	useSubscriptionIfEnabled(MeteorPubSub.uiParts, !!playlist, playlist?._id ?? null)
 	useSubscriptionIfEnabled(MeteorPubSub.uiPartInstances, !!playlist?.activationId, playlist?.activationId ?? null)
 	useSubscriptionIfEnabled(CorelibPubSub.pieces, rundownIds.length > 0, rundownIds, null)


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of Superfly

## Type of Contribution

This is a: Bug fix 

## Current Behavior

The ui in some places is subscription to the `CorelibPubSub.parts` subscription. The ui has no knowledge of the parts collection, it is solely using the uiParts instead.  
That makes these subscriptions useless

## New Behavior

Remove the subscriptions. The one which didnt have a partner uiParts subscription has one added, in case the logic is expecting it to be running.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [ ] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
