### PR TITLE
fix: device status notifications ignoring legacy messages

### DIFF
--- a/meteor/__mocks__/helpers/database.ts
+++ b/meteor/__mocks__/helpers/database.ts
@@ -393,6 +393,66 @@ export async function setupMockStudioBlueprint(showStyleBaseId: ShowStyleBaseId)
 		ignoreIdChange: true,
 	})
 }
+/** A Studio blueprint which customises device status messages. An entry of `''` suppresses that status code. */
+export async function setupMockStudioBlueprintWithDeviceStatusMessages(
+	showStyleBaseId: ShowStyleBaseId,
+	deviceStatusMessages: Record<string, string>
+): Promise<Blueprint> {
+	const { INTEGRATION_VERSION, TSR_VERSION } = getBlueprintDependencyVersions()
+
+	const BLUEPRINT_TYPE = BlueprintManifestType.STUDIO
+	const SHOW_STYLE_ID: string = unprotectString(showStyleBaseId)
+	// packageBlueprint can only substitute strings and numbers, and embeds them in a single-quoted
+	// literal via String.replace - so escape for both before handing it over:
+	const DEVICE_STATUS_MESSAGES_JSON: string = JSON.stringify(deviceStatusMessages)
+		.replace(/\\/g, '\\\\')
+		.replace(/'/g, "\\'")
+		.replace(/\$/g, '$$$$')
+
+	const code = packageBlueprint<StudioBlueprintManifest>(
+		{
+			BLUEPRINT_TYPE,
+			INTEGRATION_VERSION,
+			TSR_VERSION,
+			SHOW_STYLE_ID,
+			DEVICE_STATUS_MESSAGES_JSON,
+		},
+		function (): StudioBlueprintManifest {
+			return {
+				blueprintType: BLUEPRINT_TYPE,
+				blueprintVersion: '0.0.0',
+				integrationVersion: INTEGRATION_VERSION,
+				TSRVersion: TSR_VERSION,
+
+				configPresets: {
+					main: {
+						name: 'Main',
+						config: {},
+					},
+				},
+
+				studioConfigSchema: '{}' as any,
+				getBaseline: () => {
+					return {
+						timelineObjects: [],
+					}
+				},
+				getShowStyleId: (): string | null => {
+					return SHOW_STYLE_ID
+				},
+
+				deviceStatusMessages: JSON.parse(DEVICE_STATUS_MESSAGES_JSON),
+			}
+		}
+	)
+
+	const blueprintId: BlueprintId = protectString('mockDeviceStatusBlueprint' + dbI++)
+
+	return internalUploadBlueprint(blueprintId, code, {
+		blueprintName: 'mockDeviceStatusBlueprint',
+		ignoreIdChange: true,
+	})
+}
 export async function setupMockShowStyleBlueprint(showStyleVariantId: ShowStyleVariantId): Promise<Blueprint> {
 	const { INTEGRATION_VERSION, TSR_VERSION } = getBlueprintDependencyVersions()
 

--- a/meteor/server/api/__tests__/peripheralDevice.test.ts
+++ b/meteor/server/api/__tests__/peripheralDevice.test.ts
@@ -211,7 +211,25 @@ describe('test peripheralDevice general API methods', () => {
 		})
 		expect(((await PeripheralDevices.findOneAsync(device._id)) as PeripheralDevice).status).toMatchObject({
 			statusCode: StatusCode.WARNING_MINOR,
-			messages: ["Something's not right"],
+			statusDetails: [{ message: "Something's not right" }],
+		})
+	})
+
+	test('setStatus with legacy messages', async () => {
+		// Devices built against an older server-core-integration report `messages` and no `statusDetails`.
+		// `statusDetails` is typed as required to encourage devices to send it, so this shape has to be
+		// asserted, but Core still has to normalise it on ingest and store no `messages`:
+		const legacyStatus: any = {
+			statusCode: StatusCode.BAD,
+			messages: ['Not enough workers'],
+		}
+
+		await MeteorCall.peripheralDevice.setStatus(device._id, device.token, legacyStatus)
+
+		const status = ((await PeripheralDevices.findOneAsync(device._id)) as PeripheralDevice).status
+		expect(status).toEqual({
+			statusCode: StatusCode.BAD,
+			statusDetails: [{ message: 'Not enough workers' }],
 		})
 	})
 

--- a/meteor/server/api/__tests__/peripheralDeviceStatus.test.ts
+++ b/meteor/server/api/__tests__/peripheralDeviceStatus.test.ts
@@ -1,0 +1,233 @@
+import '../../../__mocks__/_extendJest'
+import { StatusCode } from '@sofie-automation/blueprints-integration'
+import { PeripheralDevice } from '@sofie-automation/corelib/dist/dataModel/PeripheralDevice'
+import { PeripheralDeviceStatusObject } from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
+import { PeripheralDeviceAPIMethods } from '@sofie-automation/shared-lib/dist/peripheralDevice/methodsAPI'
+import { makeMeteorCallForTest } from '../../../__mocks__/helpers/methods'
+import {
+	DefaultEnvironment,
+	setupDefaultStudioEnvironment,
+	setupMockStudioBlueprintWithDeviceStatusMessages,
+} from '../../../__mocks__/helpers/database'
+import { PeripheralDevices, Studios } from '../../collections'
+import { ServerPeripheralDeviceAPIClass } from '../peripheralDevice'
+
+const MeteorCall = makeMeteorCallForTest({
+	methods: PeripheralDeviceAPIMethods,
+	class: ServerPeripheralDeviceAPIClass,
+})
+
+const STATUS_CODE_OFFLINE = 'DEVICE_MOCK_OFFLINE'
+const STATUS_CODE_NOISY = 'DEVICE_MOCK_NOISY'
+
+/** A status as sent by a device built against an older server-core-integration */
+function legacyDeviceStatus(statusCode: StatusCode, messages: string[]): PeripheralDeviceStatusObject {
+	return { statusCode, messages } as unknown as PeripheralDeviceStatusObject
+}
+
+describe('peripheralDevice setStatus', () => {
+	let env: DefaultEnvironment
+	let device: PeripheralDevice
+
+	beforeEach(async () => {
+		env = await setupDefaultStudioEnvironment()
+		device = env.ingestDevice
+	})
+
+	async function setStatus(status: PeripheralDeviceStatusObject) {
+		await MeteorCall.peripheralDevice.setStatus(device._id, device.token, status)
+	}
+	async function getStoredStatus() {
+		return ((await PeripheralDevices.findOneAsync(device._id)) as PeripheralDevice).status
+	}
+	/** Point the studio at a blueprint which customises the given status codes */
+	async function useBlueprintWithDeviceStatusMessages(deviceStatusMessages: Record<string, string>) {
+		const blueprint = await setupMockStudioBlueprintWithDeviceStatusMessages(
+			env.showStyleBaseId,
+			deviceStatusMessages
+		)
+		await Studios.updateAsync(env.studio._id, { $set: { blueprintId: blueprint._id } })
+	}
+
+	describe('normalising what the device sent', () => {
+		test('stores statusDetails as sent', async () => {
+			await setStatus({
+				statusCode: StatusCode.WARNING_MINOR,
+				statusDetails: [{ message: 'Something is off' }, { message: 'And another thing' }],
+			})
+
+			expect(await getStoredStatus()).toEqual({
+				statusCode: StatusCode.WARNING_MINOR,
+				statusDetails: [{ message: 'Something is off' }, { message: 'And another thing' }],
+			})
+		})
+
+		test('converts a legacy messages array into statusDetails', async () => {
+			await setStatus(legacyDeviceStatus(StatusCode.BAD, ['Not enough workers', 'Expectation failed']))
+
+			expect(await getStoredStatus()).toEqual({
+				statusCode: StatusCode.BAD,
+				statusDetails: [{ message: 'Not enough workers' }, { message: 'Expectation failed' }],
+			})
+		})
+
+		test('converts a legacy messages array when statusDetails is empty', async () => {
+			await setStatus({
+				statusCode: StatusCode.BAD,
+				statusDetails: [],
+				messages: ['Not enough workers'],
+			} as unknown as PeripheralDeviceStatusObject)
+
+			expect(await getStoredStatus()).toEqual({
+				statusCode: StatusCode.BAD,
+				statusDetails: [{ message: 'Not enough workers' }],
+			})
+		})
+
+		test('never stores a messages property', async () => {
+			await setStatus(legacyDeviceStatus(StatusCode.BAD, ['Not enough workers']))
+
+			expect(await getStoredStatus()).not.toHaveProperty('messages')
+		})
+
+		test('stores an empty statusDetails when the device sends neither', async () => {
+			await setStatus({ statusCode: StatusCode.GOOD } as PeripheralDeviceStatusObject)
+
+			expect(await getStoredStatus()).toEqual({
+				statusCode: StatusCode.GOOD,
+				statusDetails: [],
+			})
+		})
+
+		test('rejects a statusDetails which is not an array of details', async () => {
+			// Without validation this is stored as-is, and every reader of statusDetails then throws:
+			await expect(
+				setStatus({
+					statusCode: StatusCode.BAD,
+					statusDetails: 'not an array',
+				} as unknown as PeripheralDeviceStatusObject)
+			).rejects.toThrow(/Match error/)
+
+			expect(await getStoredStatus()).toEqual({ statusCode: StatusCode.GOOD, statusDetails: [] })
+		})
+
+		test('rejects a legacy messages which is not an array of strings', async () => {
+			await expect(
+				setStatus(legacyDeviceStatus(StatusCode.BAD, 'not an array' as unknown as string[]))
+			).rejects.toThrow(/Match error/)
+		})
+
+		test('does not write when an unchanged status is reported again', async () => {
+			await setStatus(legacyDeviceStatus(StatusCode.BAD, ['Not enough workers']))
+
+			const updateSpy = jest.spyOn(PeripheralDevices, 'updateAsync')
+			try {
+				await setStatus(legacyDeviceStatus(StatusCode.BAD, ['Not enough workers']))
+
+				// Already connected with this exact status, so there is nothing to write:
+				expect(updateSpy).not.toHaveBeenCalled()
+			} finally {
+				updateSpy.mockRestore()
+			}
+		})
+	})
+
+	describe('blueprint resolution', () => {
+		test('rewrites the message of a detail the blueprint recognises', async () => {
+			await useBlueprintWithDeviceStatusMessages({
+				[STATUS_CODE_OFFLINE]: '{{deviceName}} cannot be reached on {{host}}',
+			})
+
+			await setStatus({
+				statusCode: StatusCode.BAD,
+				statusDetails: [
+					{ code: STATUS_CODE_OFFLINE, context: { host: '10.0.0.1' }, message: 'Mock device disconnected' },
+				],
+			})
+
+			const status = await getStoredStatus()
+			expect(status.statusDetails).toHaveLength(1)
+			expect(status.statusDetails[0].message).toBe(`${device.name} cannot be reached on 10.0.0.1`)
+			// The code and context are kept, so consumers can re-render it:
+			expect(status.statusDetails[0].code).toBe(STATUS_CODE_OFFLINE)
+			expect(status.statusDetails[0].context).toMatchObject({ host: '10.0.0.1' })
+		})
+
+		test('survives a blueprint message containing quote, backslash and dollar', async () => {
+			// The mock helper embeds these templates in generated source, so they must survive that round trip:
+			const awkward = "it's a \\ backslash and a $dollar"
+			await useBlueprintWithDeviceStatusMessages({ [STATUS_CODE_OFFLINE]: awkward })
+
+			await setStatus({
+				statusCode: StatusCode.BAD,
+				statusDetails: [{ code: STATUS_CODE_OFFLINE, context: {}, message: 'Mock device disconnected' }],
+			})
+
+			expect((await getStoredStatus()).statusDetails[0].message).toBe(awkward)
+		})
+
+		test('drops a detail whose message the blueprint suppresses', async () => {
+			// An empty template suppresses that status code:
+			await useBlueprintWithDeviceStatusMessages({
+				[STATUS_CODE_NOISY]: '',
+				[STATUS_CODE_OFFLINE]: '{{deviceName}} cannot be reached',
+			})
+
+			await setStatus({
+				statusCode: StatusCode.BAD,
+				statusDetails: [
+					{ code: STATUS_CODE_NOISY, context: {}, message: 'Noisy thing happened' },
+					{ code: STATUS_CODE_OFFLINE, context: {}, message: 'Mock device disconnected' },
+				],
+			})
+
+			expect((await getStoredStatus()).statusDetails).toEqual([
+				expect.objectContaining({ code: STATUS_CODE_OFFLINE, message: `${device.name} cannot be reached` }),
+			])
+		})
+
+		test('leaves a detail without a code alone', async () => {
+			await useBlueprintWithDeviceStatusMessages({
+				[STATUS_CODE_OFFLINE]: '{{deviceName}} cannot be reached',
+			})
+
+			await setStatus({
+				statusCode: StatusCode.BAD,
+				statusDetails: [{ message: 'Something the blueprint knows nothing about' }],
+			})
+
+			expect((await getStoredStatus()).statusDetails).toEqual([
+				{ message: 'Something the blueprint knows nothing about' },
+			])
+		})
+
+		test('leaves a detail whose code the blueprint does not customise alone', async () => {
+			await useBlueprintWithDeviceStatusMessages({
+				[STATUS_CODE_OFFLINE]: '{{deviceName}} cannot be reached',
+			})
+
+			await setStatus({
+				statusCode: StatusCode.BAD,
+				statusDetails: [{ code: 'DEVICE_MOCK_SOMETHING_ELSE', context: {}, message: 'Pre-rendered message' }],
+			})
+
+			expect((await getStoredStatus()).statusDetails[0].message).toBe('Pre-rendered message')
+		})
+
+		test('keeps the pre-rendered message when the device has no studio', async () => {
+			await useBlueprintWithDeviceStatusMessages({
+				[STATUS_CODE_OFFLINE]: '{{deviceName}} cannot be reached',
+			})
+			await PeripheralDevices.mutableCollection.updateAsync(device._id, {
+				$unset: { studioAndConfigId: 1 },
+			})
+
+			await setStatus({
+				statusCode: StatusCode.BAD,
+				statusDetails: [{ code: STATUS_CODE_OFFLINE, context: {}, message: 'Mock device disconnected' }],
+			})
+
+			expect((await getStoredStatus()).statusDetails[0].message).toBe('Mock device disconnected')
+		})
+	})
+})

--- a/meteor/server/api/peripheralDevice.ts
+++ b/meteor/server/api/peripheralDevice.ts
@@ -90,6 +90,14 @@ type StudioBlueprintLookup = {
 	manifest: StudioBlueprintManifest
 }
 
+/** Devices built against an older server-core-integration send `messages` instead of `statusDetails` */
+function statusDetailsFromDevice(status: PeripheralDeviceStatusObject): DeviceStatusDetail[] {
+	if (status.statusDetails?.length) return status.statusDetails
+
+	const legacyMessages = (status as { messages?: Array<string> }).messages ?? []
+	return legacyMessages.map((message) => ({ message }))
+}
+
 /**
  * Load and evaluate the Studio blueprint manifest for a studio.
  * Returns undefined when the studio has no blueprint or lookup fails.
@@ -115,24 +123,24 @@ async function getStudioBlueprintManifest(studioId: StudioId): Promise<StudioBlu
  * Resolve device status details using the Studio blueprint's deviceStatusMessages.
  * This allows blueprints to customize status messages shown to operators.
  *
+ * Messages are rewritten in place; a message the blueprint suppresses is left empty for the caller to drop.
+ *
  * @param studioId - The studio ID to look up the blueprint
  * @param deviceName - The peripheral device name (shorter than TSR's internal name)
  * @param deviceId - The peripheral device ID
- * @param statusDetails - Structured status details from TSR
- * @param defaultMessages - The original messages from TSR (used as fallback)
+ * @param statusDetails - Structured status details from the device, mutated in place
  */
 async function resolveDeviceStatusDetails(
 	studioId: StudioId,
 	deviceName: string,
 	deviceId: PeripheralDeviceId,
-	statusDetails: DeviceStatusDetail[],
-	defaultMessages: string[]
-): Promise<string[]> {
+	statusDetails: DeviceStatusDetail[]
+): Promise<void> {
 	try {
 		const studioBlueprint = await getStudioBlueprintManifest(studioId)
 		if (!studioBlueprint) {
-			// No blueprint, return empty (caller will use original messages)
-			return []
+			// No blueprint, leave the messages as the device rendered them
+			return
 		}
 
 		const { blueprint, manifest: blueprintManifest } = studioBlueprint
@@ -144,7 +152,7 @@ async function resolveDeviceStatusDetails(
 		if (!blueprintManifest.deviceStatusMessages) {
 			// Blueprint doesn't define any custom status messages
 			logger.debug(`Blueprint ${blueprint._id} has no deviceStatusMessages`)
-			return []
+			return
 		}
 
 		// Create resolver with the blueprint's status messages
@@ -155,15 +163,11 @@ async function resolveDeviceStatusDetails(
 		)
 
 		// Resolve each status detail
-		const resolvedMessages: string[] = []
-		for (let i = 0; i < statusDetails.length; i++) {
-			const statusDetail = statusDetails[i]
-			// statusDetail.message is always pre-rendered by TSR; use it as fallback if no defaultMessages entry
-			const defaultMessage = defaultMessages[i] ?? statusDetail.message
+		for (const statusDetail of statusDetails) {
+			const defaultMessage = statusDetail.message
 
 			if (!statusDetail.code) {
-				// No structured code - use the pre-rendered TSR message directly
-				resolvedMessages.push(defaultMessage)
+				// No structured code - keep the pre-rendered message
 				continue
 			}
 
@@ -185,21 +189,16 @@ async function resolveDeviceStatusDetails(
 				// Interpolate the message template with context values
 				const interpolated = interpollateTranslation(message.key, message.args)
 				logger.debug(`Resolved message for ${statusDetail.code}: ${interpolated}`)
-				resolvedMessages.push(interpolated)
-				// Also mutate statusDetail.message so the UI can read from statusDetails[].message directly
 				statusDetail.message = interpolated
 			} else {
-				// Message suppressed by blueprint - clear the message so the UI doesn't show the raw TSR message
+				// Suppressed by blueprint - the caller drops details with no message
 				statusDetail.message = ''
 				logger.debug(`Message suppressed for ${statusDetail.code}`)
 			}
 		}
-
-		return resolvedMessages
 	} catch (e) {
-		// Log error but don't fail - fall back to original messages
+		// Log error but don't fail - leave the messages as the device rendered them
 		logger.error(`Error resolving device status messages: ${e}`)
-		return []
 	}
 }
 
@@ -410,16 +409,23 @@ export namespace ServerPeripheralDeviceAPI {
 		context: MethodContext,
 		deviceId: PeripheralDeviceId,
 		token: string,
-		status: PeripheralDeviceStatusObject
+		statusFromDevice: PeripheralDeviceStatusObject
 	): Promise<PeripheralDeviceStatusObject> {
 		const peripheralDevice = await checkAccessAndGetPeripheralDevice(deviceId, token, context)
 
 		check(deviceId, z.string())
 		check(token, z.string())
-		check(status, zPlainObject)
-		check(status.statusCode, z.number())
-		if (status.statusCode < StatusCode.UNKNOWN || status.statusCode > StatusCode.FATAL) {
+		check(statusFromDevice, zPlainObject)
+		check(statusFromDevice.statusCode, z.number())
+		check(statusFromDevice.statusDetails, z.array(z.looseObject({ message: z.string() })).optional())
+		check((statusFromDevice as { messages?: unknown }).messages, z.array(z.string()).optional())
+		if (statusFromDevice.statusCode < StatusCode.UNKNOWN || statusFromDevice.statusCode > StatusCode.FATAL) {
 			throw new SofieError(400, 'device status code is not known')
+		}
+
+		const status: PeripheralDeviceStatusObject = {
+			statusCode: statusFromDevice.statusCode,
+			statusDetails: statusDetailsFromDevice(statusFromDevice),
 		}
 
 		// Resolve status messages using Studio blueprint if structured status details are present
@@ -432,25 +438,19 @@ export namespace ServerPeripheralDeviceAPI {
 			studioId = parentDevice?.studioAndConfigId?.studioId
 		}
 
-		logger.info(
-			`Device ${deviceId} setStatus: statusDetails=${status.statusDetails?.length ?? 'undefined'}, messages=${status.messages?.length ?? 'undefined'}, studioId=${studioId ?? 'none'}`
+		logger.silly(
+			`Device ${deviceId} setStatus: statusCode=${status.statusCode}, statusDetails=${status.statusDetails.length}, studioId=${studioId ?? 'none'}`
 		)
-		if (status.statusDetails && status.statusDetails.length > 0) {
-			if (studioId) {
-				const resolvedMessages = await resolveDeviceStatusDetails(
-					studioId,
-					peripheralDevice.name,
-					peripheralDevice._id,
-					status.statusDetails,
-					status.messages ?? []
-				)
-				// Use blueprint-resolved messages if available, otherwise fall back to statusDetails messages
-				status.messages =
-					resolvedMessages.length > 0 ? resolvedMessages : status.statusDetails.map((d) => d.message)
-			} else {
-				// No studio context, derive messages directly from statusDetails
-				status.messages = status.statusDetails.map((d) => d.message)
-			}
+		if (status.statusDetails.length > 0 && studioId) {
+			await resolveDeviceStatusDetails(
+				studioId,
+				peripheralDevice.name,
+				peripheralDevice._id,
+				status.statusDetails
+			)
+
+			// Drop what the blueprint suppressed:
+			status.statusDetails = status.statusDetails.filter((d) => d.message !== '')
 		}
 
 		// check if we have to update something:

--- a/meteor/server/api/rest/v1/__tests__/typeConversions.spec.ts
+++ b/meteor/server/api/rest/v1/__tests__/typeConversions.spec.ts
@@ -1,10 +1,16 @@
 import { protectString } from '@sofie-automation/corelib/dist/protectedString'
-import { buildStudioFromResolved } from '../typeConversion'
+import { APIPeripheralDeviceFrom, buildStudioFromResolved } from '../typeConversion'
 import { wrapDefaultObject } from '@sofie-automation/corelib/dist/settings/objectWithOverrides'
 import { DBStudio, IStudioSettings } from '@sofie-automation/corelib/dist/dataModel/Studio'
 import { StudioId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import { IBlueprintConfig, StudioBlueprintManifest } from '@sofie-automation/blueprints-integration'
 import { APIStudio } from '../../../../lib/rest/v1'
+import { PeripheralDevice } from '@sofie-automation/corelib/dist/dataModel/PeripheralDevice'
+import { StatusCode } from '@sofie-automation/blueprints-integration'
+import {
+	PeripheralDeviceCategory,
+	PeripheralDeviceType,
+} from '@sofie-automation/shared-lib/dist/peripheralDevice/peripheralDeviceAPI'
 
 describe('buildStudioFromResolved', () => {
 	test('preserves existing fields and overrides API ones', async () => {
@@ -79,5 +85,51 @@ describe('buildStudioFromResolved', () => {
 			path: 'fromBlueprints',
 			value: true,
 		})
+	})
+})
+
+describe('APIPeripheralDeviceFrom', () => {
+	function makeDevice(status: PeripheralDevice['status']): PeripheralDevice {
+		return {
+			_id: protectString('device0'),
+			name: 'Mock device',
+			connected: true,
+			category: PeripheralDeviceCategory.PLAYOUT,
+			type: PeripheralDeviceType.PLAYOUT,
+			status,
+		} as PeripheralDevice
+	}
+
+	test('derives the messages of the API device from statusDetails', () => {
+		// `messages` is no longer stored on the device, but the REST API still exposes the human
+		// readable half of each status detail under that name:
+		const apiDevice = APIPeripheralDeviceFrom(
+			makeDevice({
+				statusCode: StatusCode.BAD,
+				statusDetails: [
+					{ code: 'DEVICE_MOCK_OFFLINE', context: { host: '10.0.0.1' }, message: 'Mock device is offline' },
+					{ message: 'And another thing' },
+				],
+			})
+		)
+
+		expect(apiDevice.messages).toEqual(['Mock device is offline', 'And another thing'])
+		expect(apiDevice.status).toBe('bad')
+	})
+
+	test('returns no messages when there are no statusDetails', () => {
+		const apiDevice = APIPeripheralDeviceFrom(makeDevice({ statusCode: StatusCode.GOOD, statusDetails: [] }))
+
+		expect(apiDevice.messages).toEqual([])
+		expect(apiDevice.status).toBe('good')
+	})
+
+	test('returns no messages for a device stored before statusDetails existed', () => {
+		// Devices which never reconnected after the upgrade have neither field resolved:
+		const apiDevice = APIPeripheralDeviceFrom(
+			makeDevice({ statusCode: StatusCode.GOOD } as PeripheralDevice['status'])
+		)
+
+		expect(apiDevice.messages).toEqual([])
 	})
 })

--- a/meteor/server/api/rest/v1/typeConversion.ts
+++ b/meteor/server/api/rest/v1/typeConversion.ts
@@ -587,7 +587,7 @@ export function APIPeripheralDeviceFrom(device: PeripheralDevice): APIPeripheral
 		id: unprotectString(device._id),
 		name: device.name,
 		status,
-		messages: device.status.messages ?? [],
+		messages: device.status.statusDetails?.map((d) => d.message) ?? [],
 		deviceType,
 		connected: device.connected,
 	}

--- a/meteor/server/systemStatus/__tests__/systemStatus.test.ts
+++ b/meteor/server/systemStatus/__tests__/systemStatus.test.ts
@@ -95,7 +95,6 @@ describe('systemStatus', () => {
 				status: literal<PeripheralDeviceStatusObject>({
 					statusCode: StatusCode.WARNING_MAJOR,
 					statusDetails: [],
-					messages: [],
 				}),
 			},
 		})
@@ -122,7 +121,6 @@ describe('systemStatus', () => {
 				status: literal<PeripheralDeviceStatusObject>({
 					statusCode: StatusCode.GOOD,
 					statusDetails: [],
-					messages: [],
 				}),
 			},
 		})

--- a/meteor/server/systemStatus/systemStatus.ts
+++ b/meteor/server/systemStatus/systemStatus.ts
@@ -61,7 +61,7 @@ export interface StatusObjectInternal {
 
 function getSystemStatusForDevice(device: PeripheralDevice): StatusResponse {
 	const deviceStatus: StatusCode = device.status.statusCode
-	const deviceStatusMessages: Array<string> = device.status.messages || []
+	const deviceStatusMessages: Array<string> = device.status.statusDetails?.map((d) => d.message) ?? []
 
 	const checks: Array<CheckObj> = []
 	const pushStatusAsCheck = (name: string, statusCode: StatusCode, messages: string[]) => {

--- a/packages/job-worker/src/playout/model/implementation/__tests__/PlayoutModelImpl.spec.ts
+++ b/packages/job-worker/src/playout/model/implementation/__tests__/PlayoutModelImpl.spec.ts
@@ -757,7 +757,6 @@ function setupMockPlayoutGateway(id: PeripheralDeviceId): PeripheralDevice {
 		name: `Dummy ${id}`,
 		status: {
 			statusCode: StatusCode.GOOD,
-			messages: [],
 			statusDetails: [],
 		},
 		token: '',

--- a/packages/shared-lib/src/peripheralDevice/peripheralDeviceAPI.ts
+++ b/packages/shared-lib/src/peripheralDevice/peripheralDeviceAPI.ts
@@ -79,7 +79,6 @@ export type PlayoutChangedResult = {
 
 export interface PeripheralDeviceStatusObject {
 	statusCode: StatusCode
-	messages?: Array<string>
 	/**
 	 * Structured status details for blueprint customization and UI display.
 	 * Blueprints can provide custom translations for status codes when present.

--- a/packages/webui/src/client/ui/RundownView/RundownNotifier.tsx
+++ b/packages/webui/src/client/ui/RundownView/RundownNotifier.tsx
@@ -45,6 +45,7 @@ import { RundownPlaylistCollectionUtil } from '../../collections/rundownPlaylist
 import { logger } from '../../lib/logging.js'
 import { CorelibPubSub } from '@sofie-automation/corelib/dist/pubsub'
 import { UserPermissionsContext, type UserPermissions } from '../UserPermissions.js'
+import { statusCodeToString } from '../Status/StatusCodePill.js'
 import { assertNever } from '@sofie-automation/corelib/dist/lib'
 import { DBNotificationTargetType } from '@sofie-automation/corelib/dist/dataModel/Notifications'
 import type { UIPieceContentStatus } from '@sofie-automation/corelib/dist/dataModel/PieceContentStatus'
@@ -810,7 +811,10 @@ class RundownViewNotifier extends WithManagedTracker {
 		if (!device.connected) {
 			return t('Device {{deviceName}} is disconnected', { deviceName: device.name })
 		}
-		return `${device.name}: ` + (device.status.statusDetails?.map((d) => d.message) || ['']).join(', ')
+		const messages = device.status.statusDetails?.map((d) => d.message) ?? []
+		// A device can report a bad status with no messages, so don't render an empty notification:
+		if (messages.length === 0) return `${device.name}: ${statusCodeToString(t, device.status.statusCode)}`
+		return `${device.name}: ${messages.join(', ')}`
 	}
 }
 


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the BBC

## Type of Contribution

This is a: Bug fix 

## Current Behavior

#1604 added `statusDetails` as a replacement for `messages` in the device status, to allow the devices to provide more detailed messages.

However, if a device provided the old `messages` the messages would be ignored. This would result in an empty notification.

## New Behavior

The old messages key is removed from the types, to clarify there is one flow and that devices should be updated to the new flow.

The fixup of statuses from old devices is now working. So a device sending just `messages` and not `statusDetails` will be correctly translated.

The ui is also fixed up so that if there is a bad state with no messages, a placeholder message is put in the notification instead of leaving the content empty.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
