### PR TITLE
fix: syncIngestUpdateToPartInstance recreating partInstance uses stale data

### DIFF
--- a/packages/job-worker/src/ingest/__tests__/syncChangesToPartInstance.test.ts
+++ b/packages/job-worker/src/ingest/__tests__/syncChangesToPartInstance.test.ts
@@ -20,7 +20,7 @@ import {
 	PlaylistTimingType,
 	ShowStyleBlueprintManifest,
 } from '@sofie-automation/blueprints-integration'
-import { RundownPlaylistId } from '@sofie-automation/corelib/dist/dataModel/Ids'
+import { RundownId, RundownPlaylistId } from '@sofie-automation/corelib/dist/dataModel/Ids'
 import {
 	DBRundownPlaylist,
 	SelectedPartInstance,
@@ -32,6 +32,8 @@ import { PlayoutSegmentModelImpl } from '../../playout/model/implementation/Play
 import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
 import { ProcessedShowStyleCompound } from '../../jobs/index.js'
 import { PartialDeep, ReadonlyDeep } from 'type-fest'
+import { Piece } from '@sofie-automation/corelib/dist/dataModel/Piece'
+import { defaultPiece } from '../../__mocks__/defaultCollectionObjects.js'
 
 jest.mock('../../playout/adlibTesting')
 import { validateAdlibTestingPartInstanceProperties } from '../../playout/adlibTesting.js'
@@ -410,10 +412,15 @@ describe('SyncChangesToPartInstancesWorker', () => {
 			return { playlistId, playoutModel, part0, nextPartInstance }
 		}
 
-		function createMockIngestModelReadonly(): IngestModelReadonly {
+		function createMockIngestModelReadonly(unsavedPieces?: {
+			rundownId: RundownId
+			pieces: ReadonlyDeep<Piece>[]
+		}): IngestModelReadonly {
 			return mock<IngestModelReadonly>(
 				{
 					findPart: jest.fn(() => undefined),
+					rundownId: unsavedPieces?.rundownId,
+					getAllPieces: jest.fn(() => unsavedPieces?.pieces ?? []),
 				},
 				mockOptions
 			)
@@ -528,6 +535,42 @@ describe('SyncChangesToPartInstancesWorker', () => {
 				consumesQueuedSegmentId: false,
 				manuallySelected: true,
 			} satisfies SelectedPartInstance)
+		})
+
+		test('replacement partInstance uses the unsaved Pieces from the IngestModel', async () => {
+			const context = setupDefaultJobEnvironment()
+			const showStyleCompound = await setupMockShowStyleCompound(context)
+			const blueprint = await context.getShowStyleBlueprint(showStyleCompound._id)
+
+			const { playoutModel, part0 } = await createSimplePlayoutModel(context, showStyleCompound)
+
+			// The database still holds the Piece as it was before the ingest operation
+			const savedPiece = defaultPiece(protectString('mockPieceId0'), part0.rundownId, part0.segmentId, part0._id)
+			await context.mockCollections.Pieces.insertOne(savedPiece)
+
+			// The IngestModel holds the updated Piece, which has not been written to the database yet
+			const unsavedPiece: Piece = { ...savedPiece, name: 'Updated Piece' }
+			const ingestModel = createMockIngestModelReadonly({
+				rundownId: part0.rundownId,
+				pieces: [unsavedPiece],
+			})
+
+			const worker = new SyncChangesToPartInstancesWorker(
+				context,
+				playoutModel,
+				ingestModel,
+				showStyleCompound,
+				blueprint
+			)
+
+			// Force the next part to be manually selected, so that it gets re-created
+			playoutModel.setPartInstanceAsNext(playoutModel.nextPartInstance, true, false)
+
+			await worker.recreateNextPartInstance(part0)
+
+			expect(playoutModel.nextPartInstance).toBeTruthy()
+			expect(playoutModel.nextPartInstance!.pieceInstances).toHaveLength(1)
+			expect(playoutModel.nextPartInstance!.pieceInstances[0].pieceInstance.piece.name).toBe('Updated Piece')
 		})
 	})
 })

--- a/packages/job-worker/src/ingest/syncChangesToPartInstance.ts
+++ b/packages/job-worker/src/ingest/syncChangesToPartInstance.ts
@@ -261,7 +261,7 @@ export class SyncChangesToPartInstancesWorker {
 		const originalNextPartInfo = this.#playoutModel.playlist.nextPartInfo
 
 		// Clear the next part
-		await setNextPart(this.#context, this.#playoutModel, null, false, 0)
+		await setNextPart(this.#context, this.#playoutModel, null, false, 0, this.#ingestModel)
 
 		if (originalNextPartInfo?.manuallySelected && newPart) {
 			// If the next part was manually selected, we need to force it to be re-created
@@ -273,7 +273,8 @@ export class SyncChangesToPartInstancesWorker {
 					consumesQueuedSegmentId: originalNextPartInfo.consumesQueuedSegmentId,
 				},
 				true,
-				this.#playoutModel.playlist.nextTimeOffset || 0
+				this.#playoutModel.playlist.nextTimeOffset || 0,
+				this.#ingestModel
 			)
 		} else {
 			// A new next part will be selected automatically during the commit

--- a/packages/job-worker/src/playout/setNext.ts
+++ b/packages/job-worker/src/playout/setNext.ts
@@ -36,6 +36,7 @@ import { PersistentPlayoutStateStore } from '../blueprints/context/services/Pers
 import { DBPartInstance } from '@sofie-automation/corelib/dist/dataModel/PartInstance'
 import { PlayoutPartInstanceModelImpl } from './model/implementation/PlayoutPartInstanceModelImpl.js'
 import { QuickLoopService } from './model/services/QuickLoopService.js'
+import type { IngestModelReadonly } from '../ingest/model/IngestModel.js'
 import { recalculateTTimerProjections } from './tTimers.js'
 
 /**
@@ -45,13 +46,15 @@ import { recalculateTTimerProjections } from './tTimers.js'
  * @param rawNextPart The Part to set as next
  * @param setManually Whether this was manually chosen by the user
  * @param nextTimeOffset The offset into the Part to start playback
+ * @param unsavedIngestModel If an ingest operation is still being written, the unsaved Ingest model. Without this, the new PartInstance would be built from the pre-ingest Pieces
  */
 export async function setNextPart(
 	context: JobContext,
 	playoutModel: PlayoutModel,
 	rawNextPart: ReadonlyDeep<Omit<SelectNextPartResult, 'index'>> | PlayoutPartInstanceModel | null,
 	setManually: boolean,
-	nextTimeOffset?: number
+	nextTimeOffset?: number,
+	unsavedIngestModel?: IngestModelReadonly
 ): Promise<void> {
 	const span = context.startSpan('setNextPart')
 
@@ -63,7 +66,8 @@ export async function setNextPart(
 		playoutModel,
 		rawNextPart,
 		setManually,
-		nextTimeOffset
+		nextTimeOffset,
+		unsavedIngestModel
 	)
 	while (moveNextToPart) {
 		// Ensure that we aren't stuck in an infinite loop. If this while loop is being run for a part twice, then the blueprints are behaving oddly and will likely get stuck
@@ -88,7 +92,9 @@ export async function setNextPart(
 						consumesQueuedSegmentId: false,
 					}
 				: null,
-			true
+			true,
+			undefined,
+			unsavedIngestModel
 		)
 	}
 
@@ -111,7 +117,8 @@ async function setNextPartAndCheckForPendingMoveNextPart(
 	playoutModel: PlayoutModel,
 	rawNextPart: ReadonlyDeep<Omit<SelectNextPartResult, 'index'>> | PlayoutPartInstanceModel | null,
 	setManually: boolean,
-	nextTimeOffset?: number
+	nextTimeOffset: number | undefined,
+	unsavedIngestModel: IngestModelReadonly | undefined
 ): Promise<{ selectedPart: ReadonlyDeep<DBPart> | null } | undefined> {
 	if (rawNextPart) {
 		if (!playoutModel.playlist.activationId)
@@ -133,7 +140,12 @@ async function setNextPartAndCheckForPendingMoveNextPart(
 			}
 
 			consumesQueuedSegmentId = false
-			newPartInstance = await prepareExistingPartInstanceForBeingNexted(context, playoutModel, inputPartInstance)
+			newPartInstance = await prepareExistingPartInstanceForBeingNexted(
+				context,
+				playoutModel,
+				inputPartInstance,
+				unsavedIngestModel
+			)
 		} else {
 			const selectedPart: ReadonlyDeep<Omit<SelectNextPartResult, 'index'>> = rawNextPart
 			if (selectedPart.part.invalid) {
@@ -157,7 +169,8 @@ async function setNextPartAndCheckForPendingMoveNextPart(
 				newPartInstance = await prepareExistingPartInstanceForBeingNexted(
 					context,
 					playoutModel,
-					nextPartInstance
+					nextPartInstance,
+					unsavedIngestModel
 				)
 			} else {
 				// Create new instance
@@ -165,7 +178,8 @@ async function setNextPartAndCheckForPendingMoveNextPart(
 					context,
 					playoutModel,
 					currentPartInstance,
-					selectedPart.part
+					selectedPart.part,
+					unsavedIngestModel
 				)
 			}
 		}
@@ -290,12 +304,13 @@ async function applyOnSetAsNextSideEffects(
 async function prepareExistingPartInstanceForBeingNexted(
 	context: JobContext,
 	playoutModel: PlayoutModel,
-	instance: PlayoutPartInstanceModel
+	instance: PlayoutPartInstanceModel,
+	unsavedIngestModel: IngestModelReadonly | undefined
 ): Promise<PlayoutPartInstanceModel> {
 	await syncPlayheadInfinitesForNextPartInstance(
 		context,
 		playoutModel,
-		undefined, // Any ingest model must have been fully written before we get here
+		unsavedIngestModel,
 		playoutModel.currentPartInstance,
 		instance
 	)
@@ -307,14 +322,15 @@ async function preparePartInstanceForPartBeingNexted(
 	context: JobContext,
 	playoutModel: PlayoutModel,
 	currentPartInstance: PlayoutPartInstanceModel | null,
-	nextPart: ReadonlyDeep<DBPart>
+	nextPart: ReadonlyDeep<DBPart>,
+	unsavedIngestModel: IngestModelReadonly | undefined
 ): Promise<PlayoutPartInstanceModel> {
 	const rundown = playoutModel.getRundown(nextPart.rundownId)
 	if (!rundown) throw new Error(`Could not find rundown ${nextPart.rundownId}`)
 
 	const partInstanceId = protectString('') // Replaced inside playoutModel.createInstanceForPart
 
-	const possiblePieces = await fetchPiecesThatMayBeActiveForPart(context, playoutModel, undefined, nextPart)
+	const possiblePieces = await fetchPiecesThatMayBeActiveForPart(context, playoutModel, unsavedIngestModel, nextPart)
 	const newPieceInstances = getPieceInstancesForPart(
 		context,
 		playoutModel,
@@ -330,7 +346,7 @@ async function preparePartInstanceForPartBeingNexted(
 		const baselineInfinites = await getBaselineInfinitesForPart(
 			context,
 			playoutModel,
-			undefined, // Any ingest model must have been fully written before we get here
+			unsavedIngestModel,
 			nextPart,
 			partInstanceId
 		)


### PR DESCRIPTION

## About the Contributor

This pull request is posted on behalf of the BBC

## Type of Contribution

This is a: Bug fix

## Current Behavior

Performing a user operation on a piece instance doesn’t save as expected.

Calling `removePartInstance` inside of `syncIngestUpdateToPartInstance` after performing an operation causes the part instance to revert back to the original ingest data instead of the overridden data.


## New Behavior

This was happening because at the time of the `setNextPart` being performed, the ingest changes were not yet fully written to mongodb. The unsaved ingest model has been bubbled through `setNextPart` so that this gap is closed.


## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [x] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [ ] No unit test changes are needed for this PR

### Affected areas

<!--
Please provide some details on what areas of the system that are affected by this PR.
This is useful for testers to know where to focus their testing efforts.
Examples:
* This PR affects the playout logic in general.
* This PR affects the timing calculation in the Rundown during playout.
* This PR affects the NRC/MOS integration
*
-->

## Time Frame

<!--
Please provide a note about the urgency or development plan for this PR.
Example:
* This Bug Fix is critical for us, please review and merge it as soon as possible.
* We intend to finish the development on this feature in two weeks time.
* Not urgent, but we would like to get this merged into the in-development release.
-->

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
