### PR TITLE
fix: collapse VirtualElement height when wrapped content disappears

### DIFF
--- a/packages/webui/src/client/lib/VirtualElement.tsx
+++ b/packages/webui/src/client/lib/VirtualElement.tsx
@@ -388,7 +388,17 @@ export function VirtualElement({
 }
 function measureElement(wrapperEl: HTMLDivElement, placeholderHeight?: number): IElementMeasurements | null {
 	if (!wrapperEl || !wrapperEl.firstElementChild) {
-		return null
+		// If the wrapped content has disappeared (eg item deleted), force collapse.
+		// This prevents stale measured heights from leaving empty gaps in the list.
+		return {
+			width: 'auto',
+			clientHeight: 0,
+			marginTop: undefined,
+			marginBottom: undefined,
+			marginLeft: undefined,
+			marginRight: undefined,
+			id: wrapperEl?.id,
+		}
 	}
 
 	const el = wrapperEl.firstElementChild as HTMLElement


### PR DESCRIPTION
## About the Contributor

This PR is posted on behalf of EVS Broadcast Equipment.

## Type of Contribution

This is a bug fix.

## Current Behavior

When content is deleted while virtualized, its previously measured height remains and leaves an empty gap in the list. This can be reproduced by simply hiding a segment while the Rundown View is open.

## New Behavior

`measureElement` now checks whether the wrapper still has content. If it's gone, it returns a height of 0 so the element collapses instead of keeping the stale height.

## Testing

<!--
When you add a feature, you should also provide relevant unit tests, in order to
* ensure that the feature works as expected
* ensure that the feature will continue to work in the future
-->

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [x] No unit test changes are needed for this PR

### Affected areas

This PR affects the Rundown view.

## Time Frame

Not urgent.

## Other Information

<!-- The more information you can provide, the easier the pull request will be to merge -->

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [x] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
