### PR TITLE
fix: default root url value

### DIFF
--- a/packages/corelib/src/lib.ts
+++ b/packages/corelib/src/lib.ts
@@ -27,7 +27,7 @@ export type { Complete, ArrayElement, Subtract } from '@sofie-automation/shared-
 export { assertNever, literal } from '@sofie-automation/shared-lib/dist/lib/lib'
 
 export function getSofieHostUrl(): string {
-	const url = process.env.ROOT_URL
+	const url = process.env.ROOT_URL ?? 'http://localhost:3000'
 	if (url) return url
 
 	throw new Error('ROOT_URL must be defined to launch Sofie')


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of myself

## Type of Contribution

This is a: Bug fix

## Current Behavior

Previously when running Sofie, it was possible to upgrade the studio blueprints without the `ROOT_URL` environment variable set.

Since some recent changes, Sofie now throws an error and doesn't upgrade the Studio blueprints when the variable is not set.

## New Behavior

Added a fallback to `http://localhost:3000` to match the default behavior, like the rest of Sofie. 

## Testing

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [X] No unit test changes are needed for this PR

### Affected areas

This PR affects configurations.

## Time Frame

Not urgent

## Other Information

This might be a dirty fix, I didn't look too deep into it. To me it seemed reasonable to add a fallback. Feedback welcome.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [X] PR is ready to be reviewed.
- [X] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [X] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
