### PR TITLE
fix: crashing timeline datastore test tool - support basic rendering of object datastore values

### DIFF
--- a/packages/webui/src/client/ui/TestTools/TimelineDatastore.tsx
+++ b/packages/webui/src/client/ui/TestTools/TimelineDatastore.tsx
@@ -44,7 +44,7 @@ function ComponentDatastoreControls() {
 								<td>{entry.modified}</td>
 								<td>{entry.mode}</td>
 								<td>
-									<pre>{entry.value}</pre>
+									<pre>{JSON.stringify(entry.value)}</pre>
 								</td>
 							</tr>
 						))}


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://sofie-automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the CBC.

## Type of Contribution

This is a:

Bug fix

## Current Behavior

The TimelineDatastoreView crashes when a datastore entry contains an object.

<img width="767" height="479" alt="Screenshot 2026-09-03 at 10 01 22" src="https://github.com/user-attachments/assets/bd0f564a-1802-4544-99f1-6138a83f2a52" />

## New Behavior

The value is stringified, preventing the crash and allows the rendering of the object values.

<img width="1009" height="531" alt="Screenshot 2026-09-03 at 10 00 59" src="https://github.com/user-attachments/assets/c0b17725-2fb2-4d37-ab86-15c393b1064d" />

## Testing

- [ ] I have added one or more unit tests for this PR
- [ ] I have updated the relevant unit tests
- [X] No unit test changes are needed for this PR

### Affected areas

UI rendering in the Timeline Datastore test tool.

## Time Frame

Not urgent, but we would like to get this merged into the in-development release.

## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [X] PR is ready to be reviewed.
- [X] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
